### PR TITLE
test_netboot_pxe: headless verification of iPXE -> netbootxyz dispatch

### DIFF
--- a/docs/superpowers/plans/2026-05-08-netboot-asset-management.md
+++ b/docs/superpowers/plans/2026-05-08-netboot-asset-management.md
@@ -1,0 +1,1593 @@
+# netboot.xyz Asset Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `playbooks/truenas/configure_netbootxyz.yml` and `playbooks/truenas/sync_boot_files.yml` with a single declarative-plus-fragments playbook tree under `playbooks/netboot/`. Eliminate the hardcoded `/home/igou/igou-node-bootstrap/netbootxyz-menus` reference, drive the menu from a `netboot_entries` inventory list, and add per-host pins by MAC/hostname auto-served via a header in the generated `menu.ipxe`.
+
+**Architecture:** One orchestrator `playbooks/netboot/deploy_assets.yml` with six tagged stages (`preflight`, `render`, `push`, `fetch`, `local`, `verify`) backed by per-stage task files. `render` runs `delegate_to: localhost` and writes to `.cache/netboot-menus/`. `push`/`fetch`/`local` run against `truenas`. `verify` runs `delegate_to: localhost` and probes the netbootxyz HTTP endpoint. Idempotency via content-hash checks before every write. Inventory variables in a new `igou-inventory/group_vars/all/netboot.yml` (split-dir style).
+
+**Tech Stack:** Ansible (`ansible.builtin.template`, `ansible.builtin.copy`, `ansible.builtin.synchronize`, `ansible.builtin.file`, `ansible.builtin.stat`, `ansible.builtin.get_url`, `ansible.builtin.uri`, `ansible.builtin.assert`), Jinja2 templates, the existing TrueNAS connection (already configured in inventory).
+
+---
+
+## Reference material
+
+- Spec: `docs/superpowers/specs/2026-05-08-netboot-asset-management-design.md`. Re-read end to end. The decisions log at the bottom is the source of truth for ambiguity.
+- Prior art (style template): `playbooks/truenas/configure_netbootxyz.yml`, `playbooks/truenas/sync_boot_files.yml`, `playbooks/truenas/configure_docker_containers.yml`. Match the comment-header convention and the 1000:1000 owner/group default.
+- The recent stagewise pattern: `playbooks/routeros/deploy_netboot_binaries.yml` and the `playbooks/routeros/tasks/netboot_*.yml` files. Same `import_tasks` + tag-per-stage shape.
+- Repo conventions: `CLAUDE.md` at the repo root. YAML must start with `---`, two-space indent, YAML 1.2 booleans (`true`/`false`), ansible-lint production profile.
+- Live netbootxyz container config: `igou-inventory/group_vars/truenas.yml` `truenas_docker_containers[name=netbootxyz]`. The `assets:/assets` and `config:/config` named volumes resolve to `/mnt/ssd/containers/netbootxyz/{assets,config}`.
+- The existing per-host workaround: `playbooks/truenas/configure_netbootxyz.yml` mirrors content into `config/menus/local/`. We replicate that.
+
+## Files Created/Modified/Deleted
+
+```
+.gitignore                                              MODIFY  (add .cache/netboot-menus/)
+igou-inventory/group_vars/all.yml                       SPLIT   (becomes all/main.yml)
+igou-inventory/group_vars/all/main.yml                  CREATE  (renamed from all.yml)
+igou-inventory/group_vars/all/netboot.yml               CREATE  (new vars)
+igou-inventory/group_vars/truenas.yml                   MODIFY  (drop truenas_boot_files_* block)
+
+playbooks/netboot/deploy_assets.yml                     CREATE  (orchestrator)
+playbooks/netboot/tasks/preflight.yml                   CREATE  (schema validation)
+playbooks/netboot/tasks/render_menu.yml                 CREATE  (render to .cache/)
+playbooks/netboot/tasks/push_text.yml                   CREATE  (sync to TrueNAS)
+playbooks/netboot/tasks/fetch_binaries.yml              CREATE  (download ISOs)
+playbooks/netboot/tasks/push_local_artifacts.yml        CREATE  (copy local builds)
+playbooks/netboot/tasks/verify.yml                      CREATE  (HTTP probes)
+playbooks/netboot/templates/menu.ipxe.j2                CREATE  (top-level menu)
+playbooks/netboot/templates/entry-kernel.ipxe.j2        CREATE  (kernel/initrd entry)
+playbooks/netboot/templates/entry-iso.ipxe.j2           CREATE  (sanboot iso entry)
+playbooks/netboot/templates/entry-chainload.ipxe.j2     CREATE  (chain to URL)
+playbooks/netboot/templates/host-mac.ipxe.j2            CREATE  (per-host recipe)
+playbooks/netboot/files/fragments/.gitkeep              CREATE
+playbooks/netboot/files/kickstart/.gitkeep              CREATE
+playbooks/netboot/files/cloud-init/.gitkeep             CREATE
+
+playbooks/truenas/configure_netbootxyz.yml              DELETE
+playbooks/truenas/sync_boot_files.yml                   DELETE
+```
+
+## Pre-flight assumptions (verify before Task 1)
+
+These are *assumptions baked into this plan*. If any is wrong, stop and clarify with the user before proceeding.
+
+1. **TrueNAS connection works.** `ansible -i igou-inventory/inventory.yaml truenas -m ping` returns `pong`. The container is running and reachable on `10.10.45.242`.
+2. **The netbootxyz container is at `1000:1000`.** Verified by `igou-inventory/group_vars/truenas.yml`. New files default to that owner.
+3. **`assets:/assets` and `config:/config` are named volumes resolving to `/mnt/ssd/containers/netbootxyz/{assets,config}`.** This is the TrueNAS Docker convention for named volumes inside an app's dataset. Verify by SSH-ing to TrueNAS and `ls /mnt/ssd/containers/netbootxyz/`.
+4. **No-one has manually written into `/mnt/ssd/containers/netbootxyz/config/menus/local/` outside the existing playbook.** The new playbook treats the `local/` mirror as managed.
+5. **`igou-inventory` is a sibling repo, symlinked at `igou-inventory/` under the workspace.** Inventory edits are committed to that repo, *not* `igou-ansible`.
+6. **Existing `~/igou-node-bootstrap/netbootxyz-menus/` content is reachable from the operator's environment for one-time translation.** Per the spec, the playbook does not auto-import; the operator translates by hand into `netboot_entries` / `fragments/` during Task 8.
+
+---
+
+## Task 1: Inventory split-dir + new netboot variables + .gitignore
+
+**Files:**
+- Move: `igou-inventory/group_vars/all.yml` → `igou-inventory/group_vars/all/main.yml`
+- Create: `igou-inventory/group_vars/all/netboot.yml`
+- Modify: `.gitignore` (add `.cache/netboot-menus/`)
+
+This task locks in the variable surface every later task uses. We do this first so the orchestrator and stage tasks can `Read` real values via inventory.
+
+- [ ] **Step 1: Convert `all.yml` to `all/` split-dir**
+
+  Ansible accepts either `group_vars/all.yml` (single file) or `group_vars/all/*.yml` (directory). We need the directory form so we can drop in a per-feature file.
+
+  ```bash
+  cd igou-inventory/group_vars
+  mkdir all
+  git mv all.yml all/main.yml
+  ```
+
+  Verify the move:
+
+  ```bash
+  ls -la all/
+  ```
+
+  Expected: `main.yml` exists; `all.yml` is gone.
+
+- [ ] **Step 2: Create `igou-inventory/group_vars/all/netboot.yml`**
+
+  Full content:
+
+  ```yaml
+  ---
+  # Variables consumed by playbooks/netboot/deploy_assets.yml.
+  #
+  # netbootxyz_host         — Ansible inventory hostname that runs the netbootxyz container.
+  # netbootxyz_root         — TrueNAS-side filesystem path that maps to the container's
+  #                            /config and /assets mounts (i.e. parent of "config" and "assets").
+  # netbootxyz_self_url     — Externally-reachable HTTP URL the rendered menu uses for
+  #                            chain calls back to itself (per-host hooks, kickstart refs).
+  # netboot_entries         — declarative menu items. See the spec for the schema.
+  # netboot_host_pins       — MAC/hostname pins. See the spec for the three forms.
+
+  netbootxyz_host: truenas
+  netbootxyz_root: /mnt/ssd/containers/netbootxyz
+  netbootxyz_self_url: http://10.10.45.242
+
+  netboot_entries: []
+  netboot_host_pins: []
+  ```
+
+  Both lists start empty; Task 8 populates them as part of the cutover.
+
+- [ ] **Step 3: Add `.cache/netboot-menus/` to `.gitignore`**
+
+  Open `.gitignore` (in the `igou-ansible` repo). Append:
+
+  ```
+  # Local render cache for playbooks/netboot/deploy_assets.yml
+  .cache/netboot-menus/
+  ```
+
+  If `.cache/` is already gitignored as a wildcard (it is — see commit `5025a6c yamllint: ignore .cache/`), add the entry anyway as documentation. The entry is harmless even if redundant.
+
+- [ ] **Step 4: Verify Ansible still resolves the inventory**
+
+  ```bash
+  ansible-inventory -i igou-inventory/inventory.yaml --list --yaml | grep -A 5 netbootxyz_host
+  ```
+
+  Expected: a line `netbootxyz_host: truenas` appears at least once. If it doesn't, the split-dir conversion broke something — investigate before continuing.
+
+- [ ] **Step 5: Commit (two repos)**
+
+  In `igou-inventory`:
+
+  ```bash
+  cd igou-inventory
+  git add -A group_vars/all group_vars/all.yml
+  git commit -m "Split group_vars/all into directory + add netboot vars"
+  cd -
+  ```
+
+  In `igou-ansible`:
+
+  ```bash
+  git add .gitignore
+  git commit -m "Ignore .cache/netboot-menus/ render output"
+  ```
+
+---
+
+## Task 2: Orchestrator playbook + preflight stage
+
+**Files:**
+- Create: `playbooks/netboot/deploy_assets.yml`
+- Create: `playbooks/netboot/tasks/preflight.yml`
+- Create: `playbooks/netboot/files/{fragments,kickstart,cloud-init}/.gitkeep` (so empty dirs commit)
+
+This task gives every later task a runnable orchestrator. After this task you can run `--tags preflight` and validate inventory without touching TrueNAS.
+
+- [ ] **Step 1: Create `playbooks/netboot/deploy_assets.yml`**
+
+  Full content:
+
+  ```yaml
+  ---
+  # Manage netboot.xyz menu, kickstart/cloud-init seeds, and per-host PXE
+  # pins on the TrueNAS-hosted netbootxyz container.
+  #
+  # Stages (each tag-gated):
+  #   preflight  — schema validation, always runs.
+  #   render     — Jinja-render menu.ipxe + entries/ + host/ to .cache/.
+  #   push       — sync rendered + static text content to TrueNAS.
+  #   fetch      — idempotent download of upstream URLs into /assets.
+  #   local      — copy locally-built kernels/initrds into /assets.
+  #   verify     — HTTP probes for menu.ipxe, host files, and ISOs.
+  #
+  # Inventory schema:
+  #   See igou-inventory/group_vars/all/netboot.yml and the design spec
+  #   docs/superpowers/specs/2026-05-08-netboot-asset-management-design.md.
+  #
+  # Common invocations:
+  #   ansible-navigator run playbooks/netboot/deploy_assets.yml \
+  #     -i igou-inventory/inventory.yaml
+  #   # local-only render, no TrueNAS contact:
+  #   ansible-navigator run playbooks/netboot/deploy_assets.yml \
+  #     -i igou-inventory/inventory.yaml \
+  #     --tags render -e netbootxyz_host=localhost --check
+  #   # menu touch-up, skip the slow stages:
+  #   ansible-navigator run playbooks/netboot/deploy_assets.yml \
+  #     -i igou-inventory/inventory.yaml \
+  #     --tags render,push,verify
+  #
+  # Add an entry: edit netboot_entries in
+  #   igou-inventory/group_vars/all/netboot.yml.
+  # Add a per-host pin: edit netboot_host_pins in the same file.
+  # Add a hand-written .ipxe fragment: drop it in
+  #   playbooks/netboot/files/fragments/. Auto-included on next render.
+
+  - name: Deploy netboot.xyz custom menu and assets
+    hosts: "{{ netbootxyz_host | default('truenas') }}"
+    gather_facts: false
+    become: true
+    tasks:
+      - import_tasks: tasks/preflight.yml
+        tags: [preflight, render, push, fetch, local, verify, always]
+      - import_tasks: tasks/render_menu.yml
+        tags: [render]
+      - import_tasks: tasks/push_text.yml
+        tags: [push]
+      - import_tasks: tasks/fetch_binaries.yml
+        tags: [fetch]
+      - import_tasks: tasks/push_local_artifacts.yml
+        tags: [local]
+      - import_tasks: tasks/verify.yml
+        tags: [verify]
+  ```
+
+- [ ] **Step 2: Create `playbooks/netboot/tasks/preflight.yml`**
+
+  Full content:
+
+  ```yaml
+  ---
+  # Schema validation. delegate_to: localhost — pure data work, no remote contact.
+  # Runs under every stage tag so every other task can rely on validated input.
+
+  - name: Preflight — validate netboot_entries shape
+    ansible.builtin.assert:
+      that:
+        - netboot_entries is iterable
+        - netboot_entries is not string
+      fail_msg: "netboot_entries must be a list (got {{ netboot_entries | type_debug }})."
+    delegate_to: localhost
+    run_once: true
+
+  - name: Preflight — validate each entry
+    ansible.builtin.assert:
+      that:
+        - item.id is defined
+        - item.id is match('^[a-z0-9][a-z0-9._-]*$')
+        - item.name is defined
+        - item.kind is defined
+        - item.kind in ['kernel', 'iso', 'chainload', 'local']
+        - (item.kind != 'kernel') or (item.kernel is defined and item.initrd is defined)
+        - (item.kind != 'iso') or (item.url is defined and item.sha256 is defined)
+        - (item.kind != 'chainload') or (item.url is defined)
+        - (item.kind != 'local') or (item.kernel_src is defined and item.initrd_src is defined)
+      fail_msg: |
+        Invalid netboot_entries item: {{ item | to_nice_yaml }}
+        Slug must match ^[a-z0-9][a-z0-9._-]*$. Required fields per kind:
+          kernel:    kernel, initrd
+          iso:       url, sha256
+          chainload: url
+          local:     kernel_src, initrd_src
+    loop: "{{ netboot_entries }}"
+    loop_control:
+      label: "{{ item.id | default('<missing-id>') }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Preflight — collect entry ids for cross-reference
+    ansible.builtin.set_fact:
+      _netboot_entry_ids: "{{ netboot_entries | map(attribute='id') | list }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Preflight — validate each host pin
+    ansible.builtin.assert:
+      that:
+        - item.mac is defined
+        - item.mac is match('^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$')
+        - >-
+          ((item.entry is defined) | int)
+          + ((item.kernel is defined and item.initrd is defined) | int)
+          + ((item.fragment is defined) | int)
+          == 1
+        - (item.entry is not defined) or (item.entry in _netboot_entry_ids)
+      fail_msg: |
+        Invalid netboot_host_pins item: {{ item | to_nice_yaml }}
+        Each pin must:
+          - have a MAC matching aa:bb:cc:dd:ee:ff
+          - specify exactly one of: entry, kernel+initrd, fragment
+          - if entry is set, reference an id present in netboot_entries
+    loop: "{{ netboot_host_pins }}"
+    loop_control:
+      label: "{{ item.mac | default('<missing-mac>') }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Preflight — verify referenced kickstart files exist locally
+    ansible.builtin.stat:
+      path: "{{ playbook_dir }}/files/kickstart/{{ item.kickstart }}"
+    register: _ks_check
+    loop: "{{ netboot_entries | selectattr('kickstart', 'defined') | list }}"
+    loop_control:
+      label: "{{ item.id }} -> {{ item.kickstart }}"
+    delegate_to: localhost
+    run_once: true
+    failed_when:
+      - _ks_check.stat is defined
+      - not _ks_check.stat.exists
+
+  - name: Preflight — discover fragment files
+    ansible.builtin.find:
+      paths: "{{ playbook_dir }}/files/fragments"
+      patterns: "*.ipxe"
+      file_type: file
+    register: _fragments_find
+    delegate_to: localhost
+    run_once: true
+
+  - name: Preflight — register fragment filename list
+    ansible.builtin.set_fact:
+      _netboot_fragments: "{{ _fragments_find.files | map(attribute='path') | map('basename') | sort | list }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Preflight — summary
+    ansible.builtin.debug:
+      msg:
+        - "entries:    {{ netboot_entries | length }}"
+        - "host pins:  {{ netboot_host_pins | length }}"
+        - "fragments:  {{ _netboot_fragments | length }} ({{ _netboot_fragments | join(', ') }})"
+    delegate_to: localhost
+    run_once: true
+  ```
+
+- [ ] **Step 3: Create empty content directories**
+
+  ```bash
+  mkdir -p playbooks/netboot/files/fragments \
+           playbooks/netboot/files/kickstart \
+           playbooks/netboot/files/cloud-init \
+           playbooks/netboot/templates \
+           playbooks/netboot/tasks
+  touch playbooks/netboot/files/fragments/.gitkeep \
+        playbooks/netboot/files/kickstart/.gitkeep \
+        playbooks/netboot/files/cloud-init/.gitkeep
+  ```
+
+- [ ] **Step 4: Run preflight against the empty inventory (the failing-test step)**
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --tags preflight -e netbootxyz_host=localhost \
+    --mode stdout
+  ```
+
+  Expected output (paraphrased): every assert PASSES (no entries to validate), the `summary` debug shows `entries: 0`, `host pins: 0`, `fragments: 0`. Empty lists are valid input.
+
+- [ ] **Step 5: Run preflight with a deliberately-bad sample (verify it fails loudly)**
+
+  Create a temp test file `/tmp/netboot-test-vars.yml`:
+
+  ```yaml
+  ---
+  netboot_entries:
+    - id: BAD CAPS
+      name: "Bad slug"
+      kind: kernel
+  netboot_host_pins: []
+  ```
+
+  Run:
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --tags preflight -e netbootxyz_host=localhost \
+    -e @/tmp/netboot-test-vars.yml \
+    --mode stdout
+  ```
+
+  Expected: assertion failure naming `BAD CAPS`, complaining about the slug regex AND missing `kernel:`/`initrd:`. Delete `/tmp/netboot-test-vars.yml` after.
+
+- [ ] **Step 6: Lint**
+
+  ```bash
+  ansible-lint --profile=production playbooks/netboot/
+  yamllint playbooks/netboot/
+  ```
+
+  Both should report 0 issues.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add playbooks/netboot/
+  git commit -m "Add netboot deploy_assets orchestrator and preflight stage"
+  ```
+
+---
+
+## Task 3: Render templates + render_menu stage
+
+**Files:**
+- Create: `playbooks/netboot/templates/menu.ipxe.j2`
+- Create: `playbooks/netboot/templates/entry-kernel.ipxe.j2`
+- Create: `playbooks/netboot/templates/entry-iso.ipxe.j2`
+- Create: `playbooks/netboot/templates/entry-chainload.ipxe.j2`
+- Create: `playbooks/netboot/templates/host-mac.ipxe.j2`
+- Create: `playbooks/netboot/tasks/render_menu.yml`
+
+This task makes `--tags render` produce a complete `.cache/netboot-menus/` tree from inventory. No remote writes yet.
+
+> **Note on chainload entries:** the spec said `chainload` entries embed inline in `menu.ipxe`. We instead give every entry a uniform `entries/<id>.ipxe` file (chainload's is a one-line `chain ${url}`). This is a strict superset — same client behavior, simpler menu template. Spec section "Open items resolved during brainstorming" explicitly listed implementation choices as fair game; this is the only one we deviate on.
+
+- [ ] **Step 1: Create `playbooks/netboot/templates/menu.ipxe.j2`**
+
+  Full content:
+
+  ```jinja
+  #!ipxe
+  ### Managed by playbooks/netboot/deploy_assets.yml — do not edit manually.
+
+  :per_host
+  isset ${hostname} && chain {{ netbootxyz_self_url }}/menus/host/HOSTNAME-${hostname}.ipxe || goto check_mac
+  :check_mac
+  isset ${mac} && chain {{ netbootxyz_self_url }}/menus/host/MAC-${mac:hexraw}.ipxe || goto main_menu
+
+  :main_menu
+  clear menu_choice
+  menu netboot.xyz custom menu
+  {% for entry in netboot_entries %}
+  item {{ entry.id }} ${space} {{ entry.name }}
+  {% endfor %}
+  {% if _netboot_fragments | length > 0 %}
+  item --gap -- Custom fragments
+  {% for f in _netboot_fragments %}
+  item fragment_{{ loop.index0 }} ${space} {{ f }}
+  {% endfor %}
+  {% endif %}
+  item --gap
+  item exit ${space} Exit
+
+  choose menu_choice || goto menu_exit
+  echo ${cls}
+  goto ${menu_choice}
+
+  {% for entry in netboot_entries %}
+  :{{ entry.id }}
+  chain entries/{{ entry.id }}.ipxe
+  goto menu_exit
+
+  {% endfor %}
+  {% for f in _netboot_fragments %}
+  :fragment_{{ loop.index0 }}
+  chain fragments/{{ f }}
+  goto menu_exit
+
+  {% endfor %}
+  :menu_exit
+  exit
+  ```
+
+- [ ] **Step 2: Create `playbooks/netboot/templates/entry-kernel.ipxe.j2`**
+
+  Full content:
+
+  ```jinja
+  #!ipxe
+  ### Managed by playbooks/netboot/deploy_assets.yml — do not edit manually.
+  ### Entry: {{ entry.name }} ({{ entry.id }})
+
+  {% if entry.kind == 'local' %}
+  set base /assets/local/{{ entry.id }}
+  kernel {{ netbootxyz_self_url }}${base}/vmlinuz {{ entry.cmdline | default('') }}
+  initrd {{ netbootxyz_self_url }}${base}/initrd
+  {% elif entry.cache | default(false) %}
+  set base /assets/cache/{{ entry.id }}
+  kernel {{ netbootxyz_self_url }}${base}/vmlinuz {{ entry.cmdline | default('') }}
+  initrd {{ netbootxyz_self_url }}${base}/initrd
+  {% else %}
+  kernel {{ entry.kernel | replace('${netboot_self}', netbootxyz_self_url) }} {{ entry.cmdline | default('') | replace('${netboot_self}', netbootxyz_self_url) }}
+  initrd {{ entry.initrd | replace('${netboot_self}', netbootxyz_self_url) }}
+  {% endif %}
+  boot || goto failed
+
+  :failed
+  echo Boot failed for {{ entry.id }}; press any key to return to menu.
+  prompt
+  exit
+  ```
+
+- [ ] **Step 3: Create `playbooks/netboot/templates/entry-iso.ipxe.j2`**
+
+  Full content:
+
+  ```jinja
+  #!ipxe
+  ### Managed by playbooks/netboot/deploy_assets.yml — do not edit manually.
+  ### Entry: {{ entry.name }} ({{ entry.id }})
+
+  ### memdisk is hosted by the netbootxyz container at /memdisk on its HTTP root.
+  kernel {{ netbootxyz_self_url }}/memdisk iso raw
+  initrd {{ netbootxyz_self_url }}/assets/iso/{{ entry.id }}.iso
+  boot || goto failed
+
+  :failed
+  echo Boot failed for {{ entry.id }}; press any key to return to menu.
+  prompt
+  exit
+  ```
+
+- [ ] **Step 4: Create `playbooks/netboot/templates/entry-chainload.ipxe.j2`**
+
+  Full content:
+
+  ```jinja
+  #!ipxe
+  ### Managed by playbooks/netboot/deploy_assets.yml — do not edit manually.
+  ### Entry: {{ entry.name }} ({{ entry.id }})
+
+  chain {{ entry.url | replace('${netboot_self}', netbootxyz_self_url) }}
+  ```
+
+- [ ] **Step 5: Create `playbooks/netboot/templates/host-mac.ipxe.j2`**
+
+  Full content:
+
+  ```jinja
+  #!ipxe
+  ### Managed by playbooks/netboot/deploy_assets.yml — do not edit manually.
+  ### Host pin: mac={{ pin.mac }}{% if pin.hostname is defined %} hostname={{ pin.hostname }}{% endif %}
+
+  {% if pin.entry is defined %}
+  chain entries/{{ pin.entry }}.ipxe
+  {% elif pin.fragment is defined %}
+  {{ pin.fragment }}
+  {% else %}
+  kernel {{ pin.kernel | replace('${netboot_self}', netbootxyz_self_url) }} {{ pin.cmdline | default('') | replace('${netboot_self}', netbootxyz_self_url) }}
+  initrd {{ pin.initrd | replace('${netboot_self}', netbootxyz_self_url) }}
+  boot
+  {% endif %}
+  ```
+
+- [ ] **Step 6: Create `playbooks/netboot/tasks/render_menu.yml`**
+
+  Full content:
+
+  ```yaml
+  ---
+  # Render menu.ipxe + entries/<id>.ipxe + host/MAC-*.ipxe + host/HOSTNAME-*.ipxe
+  # into the local cache at .cache/netboot-menus/. Push stage handles the upload.
+
+  - name: Render — define cache root
+    ansible.builtin.set_fact:
+      _netboot_cache_dir: "{{ playbook_dir }}/../../.cache/netboot-menus"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Render — wipe cache to avoid stale outputs
+    ansible.builtin.file:
+      path: "{{ _netboot_cache_dir }}"
+      state: absent
+    delegate_to: localhost
+    run_once: true
+
+  - name: Render — recreate cache subdirs
+    ansible.builtin.file:
+      path: "{{ _netboot_cache_dir }}/{{ item }}"
+      state: directory
+      mode: "0755"
+    loop:
+      - ""
+      - entries
+      - host
+    delegate_to: localhost
+    run_once: true
+
+  - name: Render — top-level menu.ipxe
+    ansible.builtin.template:
+      src: menu.ipxe.j2
+      dest: "{{ _netboot_cache_dir }}/menu.ipxe"
+      mode: "0644"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Render — entries (kernel/local)
+    ansible.builtin.template:
+      src: entry-kernel.ipxe.j2
+      dest: "{{ _netboot_cache_dir }}/entries/{{ item.id }}.ipxe"
+      mode: "0644"
+    vars:
+      entry: "{{ item }}"
+    loop: "{{ netboot_entries | selectattr('kind', 'in', ['kernel', 'local']) | list }}"
+    loop_control:
+      label: "{{ item.id }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Render — entries (iso)
+    ansible.builtin.template:
+      src: entry-iso.ipxe.j2
+      dest: "{{ _netboot_cache_dir }}/entries/{{ item.id }}.ipxe"
+      mode: "0644"
+    vars:
+      entry: "{{ item }}"
+    loop: "{{ netboot_entries | selectattr('kind', 'equalto', 'iso') | list }}"
+    loop_control:
+      label: "{{ item.id }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Render — entries (chainload)
+    ansible.builtin.template:
+      src: entry-chainload.ipxe.j2
+      dest: "{{ _netboot_cache_dir }}/entries/{{ item.id }}.ipxe"
+      mode: "0644"
+    vars:
+      entry: "{{ item }}"
+    loop: "{{ netboot_entries | selectattr('kind', 'equalto', 'chainload') | list }}"
+    loop_control:
+      label: "{{ item.id }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Render — host pins (MAC file)
+    ansible.builtin.template:
+      src: host-mac.ipxe.j2
+      dest: "{{ _netboot_cache_dir }}/host/MAC-{{ item.mac | lower | replace(':', '') }}.ipxe"
+      mode: "0644"
+    vars:
+      pin: "{{ item }}"
+    loop: "{{ netboot_host_pins }}"
+    loop_control:
+      label: "{{ item.mac }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Render — host pins (HOSTNAME alias chains to MAC file)
+    ansible.builtin.copy:
+      dest: "{{ _netboot_cache_dir }}/host/HOSTNAME-{{ item.hostname }}.ipxe"
+      content: |
+        #!ipxe
+        ### Managed by playbooks/netboot/deploy_assets.yml — do not edit manually.
+        chain MAC-{{ item.mac | lower | replace(':', '') }}.ipxe
+      mode: "0644"
+    loop: "{{ netboot_host_pins | selectattr('hostname', 'defined') | list }}"
+    loop_control:
+      label: "{{ item.hostname }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Render — summary
+    ansible.builtin.find:
+      paths: "{{ _netboot_cache_dir }}"
+      file_type: file
+      recurse: true
+    register: _render_summary
+    delegate_to: localhost
+    run_once: true
+
+  - name: Render — list rendered files
+    ansible.builtin.debug:
+      msg: "{{ _render_summary.files | map(attribute='path') | map('regex_replace', _netboot_cache_dir + '/', '') | sort | list }}"
+    delegate_to: localhost
+    run_once: true
+  ```
+
+- [ ] **Step 7: Run render with sample inventory (the test step)**
+
+  Create a temporary test inventory `/tmp/netboot-render-test.yml`:
+
+  ```yaml
+  ---
+  netboot_entries:
+    - id: debian-12-preseed
+      name: "Debian 12 (preseed)"
+      kind: kernel
+      kernel: https://example.org/linux
+      initrd: https://example.org/initrd.gz
+      cmdline: "auto=true"
+    - id: talos-1.9
+      name: "Talos 1.9"
+      kind: iso
+      url: https://example.org/talos.iso
+      sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    - id: rocky-9-ks
+      name: "Rocky 9 (kickstart)"
+      kind: chainload
+      url: ${netboot_self}/assets/kickstart/rocky9.ipxe
+
+  netboot_host_pins:
+    - mac: aa:bb:cc:dd:ee:ff
+      hostname: worker-01.test
+      entry: talos-1.9
+  ```
+
+  Run:
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --tags render -e netbootxyz_host=localhost \
+    -e @/tmp/netboot-render-test.yml \
+    --mode stdout
+  ```
+
+  Expected: completes successfully, the final debug shows files including `menu.ipxe`, `entries/debian-12-preseed.ipxe`, `entries/talos-1.9.ipxe`, `entries/rocky-9-ks.ipxe`, `host/MAC-aabbccddeeff.ipxe`, `host/HOSTNAME-worker-01.test.ipxe`.
+
+- [ ] **Step 8: Eyeball the rendered output**
+
+  ```bash
+  cat .cache/netboot-menus/menu.ipxe
+  cat .cache/netboot-menus/entries/rocky-9-ks.ipxe
+  cat .cache/netboot-menus/host/MAC-aabbccddeeff.ipxe
+  ```
+
+  Expected:
+  - `menu.ipxe` starts with `#!ipxe`, includes the `:per_host`/`:check_mac`/`:main_menu` block, lists all three entries, and has a `goto` per entry.
+  - `entries/rocky-9-ks.ipxe` has `chain http://10.10.45.242/assets/kickstart/rocky9.ipxe` (the `${netboot_self}` substitution worked).
+  - `host/MAC-aabbccddeeff.ipxe` chains to `entries/talos-1.9.ipxe`.
+
+  Delete `/tmp/netboot-render-test.yml` after.
+
+- [ ] **Step 9: Lint**
+
+  ```bash
+  ansible-lint --profile=production playbooks/netboot/
+  yamllint playbooks/netboot/
+  ```
+
+- [ ] **Step 10: Commit**
+
+  ```bash
+  git add playbooks/netboot/templates playbooks/netboot/tasks/render_menu.yml
+  git commit -m "Add render stage with menu, entry, and host-pin templates"
+  ```
+
+---
+
+## Task 4: push_text stage
+
+**Files:**
+- Create: `playbooks/netboot/tasks/push_text.yml`
+
+This task syncs the rendered cache + the static `files/{kickstart,cloud-init}/` content to the TrueNAS netbootxyz container. Two destinations for the menus: `/config/menus/` (canonical) and `/config/menus/local/` (netbootxyz overwrite workaround).
+
+- [ ] **Step 1: Create `playbooks/netboot/tasks/push_text.yml`**
+
+  Full content:
+
+  ```yaml
+  ---
+  # Sync rendered menus + static assets text to TrueNAS. Scoped synchronize
+  # with delete=true is bounded to subdirs we own: menus/entries/, menus/host/,
+  # menus/fragments/. Flat menus/ is left alone so the OpenShift add-node files
+  # survive.
+
+  - name: Push — define paths
+    ansible.builtin.set_fact:
+      _netboot_menus_dst: "{{ netbootxyz_root }}/config/menus"
+      _netboot_assets_dst: "{{ netbootxyz_root }}/assets"
+      _netboot_cache_dir: "{{ playbook_dir }}/../../.cache/netboot-menus"
+      _netboot_fragments_src: "{{ playbook_dir }}/files/fragments"
+      _netboot_kickstart_src: "{{ playbook_dir }}/files/kickstart"
+      _netboot_cloudinit_src: "{{ playbook_dir }}/files/cloud-init"
+
+  - name: Push — ensure destination subdirs exist
+    ansible.builtin.file:
+      path: "{{ item }}"
+      state: directory
+      owner: "1000"
+      group: "1000"
+      mode: "0755"
+    loop:
+      - "{{ _netboot_menus_dst }}"
+      - "{{ _netboot_menus_dst }}/entries"
+      - "{{ _netboot_menus_dst }}/host"
+      - "{{ _netboot_menus_dst }}/fragments"
+      - "{{ _netboot_menus_dst }}/local"
+      - "{{ _netboot_menus_dst }}/local/entries"
+      - "{{ _netboot_menus_dst }}/local/host"
+      - "{{ _netboot_menus_dst }}/local/fragments"
+      - "{{ _netboot_assets_dst }}/kickstart"
+      - "{{ _netboot_assets_dst }}/cloud-init"
+
+  - name: Push — top-level menu.ipxe
+    ansible.builtin.copy:
+      src: "{{ _netboot_cache_dir }}/menu.ipxe"
+      dest: "{{ item }}/menu.ipxe"
+      owner: "1000"
+      group: "1000"
+      mode: "0644"
+    loop:
+      - "{{ _netboot_menus_dst }}"
+      - "{{ _netboot_menus_dst }}/local"
+
+  - name: Push — entries/ (with delete-extras)
+    ansible.posix.synchronize:
+      src: "{{ _netboot_cache_dir }}/entries/"
+      dest: "{{ item }}/entries/"
+      delete: true
+      recursive: true
+      use_ssh_args: true
+      rsync_opts:
+        - "--chown=1000:1000"
+        - "--chmod=F0644,D0755"
+    loop:
+      - "{{ _netboot_menus_dst }}"
+      - "{{ _netboot_menus_dst }}/local"
+
+  - name: Push — host/ (with delete-extras)
+    ansible.posix.synchronize:
+      src: "{{ _netboot_cache_dir }}/host/"
+      dest: "{{ item }}/host/"
+      delete: true
+      recursive: true
+      use_ssh_args: true
+      rsync_opts:
+        - "--chown=1000:1000"
+        - "--chmod=F0644,D0755"
+    loop:
+      - "{{ _netboot_menus_dst }}"
+      - "{{ _netboot_menus_dst }}/local"
+
+  - name: Push — fragments/ (with delete-extras)
+    ansible.posix.synchronize:
+      src: "{{ _netboot_fragments_src }}/"
+      dest: "{{ item }}/fragments/"
+      delete: true
+      recursive: true
+      use_ssh_args: true
+      rsync_opts:
+        - "--chown=1000:1000"
+        - "--chmod=F0644,D0755"
+        - "--exclude=.gitkeep"
+    loop:
+      - "{{ _netboot_menus_dst }}"
+      - "{{ _netboot_menus_dst }}/local"
+
+  - name: Push — kickstart/
+    ansible.posix.synchronize:
+      src: "{{ _netboot_kickstart_src }}/"
+      dest: "{{ _netboot_assets_dst }}/kickstart/"
+      delete: false
+      recursive: true
+      use_ssh_args: true
+      rsync_opts:
+        - "--chown=1000:1000"
+        - "--chmod=F0644,D0755"
+        - "--exclude=.gitkeep"
+
+  - name: Push — cloud-init/
+    ansible.posix.synchronize:
+      src: "{{ _netboot_cloudinit_src }}/"
+      dest: "{{ _netboot_assets_dst }}/cloud-init/"
+      delete: false
+      recursive: true
+      use_ssh_args: true
+      rsync_opts:
+        - "--chown=1000:1000"
+        - "--chmod=F0644,D0755"
+        - "--exclude=.gitkeep"
+  ```
+
+  > **Why `synchronize` not `copy`:** synchronize handles the delete-extras semantics natively. It requires rsync at both ends (TrueNAS has rsync available in the standard image). If the EE doesn't ship `ansible.posix`, install via `requirements.yml` — check first.
+
+- [ ] **Step 2: Verify `ansible.posix.synchronize` is available in the EE**
+
+  ```bash
+  grep -A 5 'collections:' requirements.yml | head -20
+  ```
+
+  Expected: `ansible.posix` listed. If not, append:
+
+  ```yaml
+  collections:
+    - name: ansible.posix
+      version: ">=1.5.0"
+  ```
+
+  And bump the EE rebuild before running. Note that as a pure-rsync-wrapper, `ansible.posix.synchronize` may already be available transitively. If unsure, run `ansible-doc ansible.posix.synchronize` to confirm.
+
+- [ ] **Step 3: Dry-run against the live TrueNAS (the test step)**
+
+  Use the same render-test inventory from Task 3 (recreate `/tmp/netboot-render-test.yml`).
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --tags render,push \
+    -e @/tmp/netboot-render-test.yml \
+    --check --diff \
+    --mode stdout
+  ```
+
+  Expected: render runs as before; push reports each `synchronize` task as `changed=true` listing `menu.ipxe`, `entries/*.ipxe`, `host/*.ipxe`. No file is shown being deleted (the live `menus/` should not have `entries/` / `host/` subdirs yet — we're creating them). If you see deletions of unrelated files, STOP — the scope is wrong.
+
+- [ ] **Step 4: Real-run with the empty inventory (no entries)**
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --tags render,push \
+    --mode stdout
+  ```
+
+  Expected: empty `entries/` and `host/` directories are created (and `local/` mirrors), `menu.ipxe` is written with no entries. Re-run → `changed=0`.
+
+- [ ] **Step 5: Verify on TrueNAS**
+
+  SSH (or via `ansible -m shell`):
+
+  ```bash
+  ansible -i igou-inventory/inventory.yaml truenas -m ansible.builtin.command \
+    -a 'ls -la /mnt/ssd/containers/netbootxyz/config/menus/'
+  ```
+
+  Expected: `entries/`, `host/`, `fragments/`, `local/`, and `menu.ipxe` exist. `local/` contains a parallel structure.
+
+- [ ] **Step 6: Lint and commit**
+
+  ```bash
+  ansible-lint --profile=production playbooks/netboot/
+  yamllint playbooks/netboot/
+  git add playbooks/netboot/tasks/push_text.yml requirements.yml
+  git commit -m "Add push_text stage with scoped synchronize to /config/menus and /assets"
+  ```
+
+  (Skip `requirements.yml` from the add if you didn't have to modify it.)
+
+---
+
+## Task 5: fetch_binaries stage
+
+**Files:**
+- Create: `playbooks/netboot/tasks/fetch_binaries.yml`
+
+This task downloads `kind: iso` URLs (and optionally `kind: kernel` with `cache: true`) into `/assets/iso/<id>.iso` (and `/assets/cache/<id>/{vmlinuz,initrd}`) on the TrueNAS host. Idempotent via sha256.
+
+- [ ] **Step 1: Create `playbooks/netboot/tasks/fetch_binaries.yml`**
+
+  Full content:
+
+  ```yaml
+  ---
+  # Idempotent download of upstream URLs into the netbootxyz container's
+  # /assets directory. Runs against netbootxyz_host so the bytes never round-
+  # trip through the control node.
+
+  - name: Fetch — ensure iso/ directory exists
+    ansible.builtin.file:
+      path: "{{ netbootxyz_root }}/assets/iso"
+      state: directory
+      owner: "1000"
+      group: "1000"
+      mode: "0755"
+
+  - name: Fetch — download kind=iso (sha256-checked)
+    ansible.builtin.get_url:
+      url: "{{ item.url }}"
+      dest: "{{ netbootxyz_root }}/assets/iso/{{ item.id }}.iso"
+      checksum: "sha256:{{ item.sha256 }}"
+      owner: "1000"
+      group: "1000"
+      mode: "0644"
+      force: false
+    loop: "{{ netboot_entries | selectattr('kind', 'equalto', 'iso') | list }}"
+    loop_control:
+      label: "{{ item.id }}"
+
+  - name: Fetch — ensure cache/ directory exists for kind=kernel cache=true
+    ansible.builtin.file:
+      path: "{{ netbootxyz_root }}/assets/cache/{{ item.id }}"
+      state: directory
+      owner: "1000"
+      group: "1000"
+      mode: "0755"
+    loop: >-
+      {{ netboot_entries
+         | selectattr('kind', 'equalto', 'kernel')
+         | selectattr('cache', 'defined')
+         | selectattr('cache', 'equalto', true)
+         | list }}
+    loop_control:
+      label: "{{ item.id }}"
+
+  - name: Fetch — download kind=kernel cache=true vmlinuz
+    ansible.builtin.get_url:
+      url: "{{ item.kernel }}"
+      dest: "{{ netbootxyz_root }}/assets/cache/{{ item.id }}/vmlinuz"
+      checksum: "{{ ('sha256:' + item.kernel_sha256) if item.kernel_sha256 is defined else omit }}"
+      owner: "1000"
+      group: "1000"
+      mode: "0644"
+      force: false
+    loop: >-
+      {{ netboot_entries
+         | selectattr('kind', 'equalto', 'kernel')
+         | selectattr('cache', 'defined')
+         | selectattr('cache', 'equalto', true)
+         | list }}
+    loop_control:
+      label: "{{ item.id }} vmlinuz"
+
+  - name: Fetch — download kind=kernel cache=true initrd
+    ansible.builtin.get_url:
+      url: "{{ item.initrd }}"
+      dest: "{{ netbootxyz_root }}/assets/cache/{{ item.id }}/initrd"
+      checksum: "{{ ('sha256:' + item.initrd_sha256) if item.initrd_sha256 is defined else omit }}"
+      owner: "1000"
+      group: "1000"
+      mode: "0644"
+      force: false
+    loop: >-
+      {{ netboot_entries
+         | selectattr('kind', 'equalto', 'kernel')
+         | selectattr('cache', 'defined')
+         | selectattr('cache', 'equalto', true)
+         | list }}
+    loop_control:
+      label: "{{ item.id }} initrd"
+  ```
+
+- [ ] **Step 2: Test fetch with a small known-good ISO (the test step)**
+
+  Pick a *small* test artifact — any tiny ISO with a known sha256. For this test, use Alpine standard mini-ISO (~5 MB).
+
+  Create `/tmp/netboot-fetch-test.yml`:
+
+  ```yaml
+  ---
+  netboot_entries:
+    - id: alpine-test
+      name: "Alpine test"
+      kind: iso
+      url: https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/x86_64/alpine-standard-3.19.0-x86_64.iso
+      sha256: 0c2e69e6d1d68ba3f5bf26a8baddc44dbf2fffb31c8b03f4d2a23c1cdca78a2c
+  netboot_host_pins: []
+  ```
+
+  > **Note:** verify the sha256 against the upstream `.sha256` file at run time — Alpine rotates artifacts. If the checksum no longer matches, get_url will fail loud, which is exactly the behavior we're testing.
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --tags fetch \
+    -e @/tmp/netboot-fetch-test.yml \
+    --mode stdout
+  ```
+
+  Expected: download completes, stat on TrueNAS shows `/mnt/ssd/containers/netbootxyz/assets/iso/alpine-test.iso` exists with the right size.
+
+- [ ] **Step 3: Verify idempotency**
+
+  Run the same command again. Expected: `changed=0`. The file is already there with the matching checksum, so `get_url force: false` is a no-op.
+
+- [ ] **Step 4: Verify checksum mismatch path**
+
+  Edit `/tmp/netboot-fetch-test.yml` to corrupt one hex char in the sha256. Re-run:
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --tags fetch \
+    -e @/tmp/netboot-fetch-test.yml \
+    --mode stdout
+  ```
+
+  Expected: failure with "checksum did not match". This is `get_url`'s built-in behavior; we just need to verify it does fire. Restore the correct sha256 after.
+
+- [ ] **Step 5: Cleanup test fixture**
+
+  ```bash
+  ansible -i igou-inventory/inventory.yaml truenas -m ansible.builtin.file \
+    -a 'path=/mnt/ssd/containers/netbootxyz/assets/iso/alpine-test.iso state=absent' \
+    -b
+  rm /tmp/netboot-fetch-test.yml
+  ```
+
+- [ ] **Step 6: Lint and commit**
+
+  ```bash
+  ansible-lint --profile=production playbooks/netboot/
+  yamllint playbooks/netboot/
+  git add playbooks/netboot/tasks/fetch_binaries.yml
+  git commit -m "Add fetch_binaries stage with sha256-checked get_url"
+  ```
+
+---
+
+## Task 6: push_local_artifacts stage
+
+**Files:**
+- Create: `playbooks/netboot/tasks/push_local_artifacts.yml`
+
+This task copies locally-built kernels/initrds from a control-node path into `/assets/local/<id>/{vmlinuz,initrd}` on TrueNAS, for `kind: local` entries.
+
+- [ ] **Step 1: Create `playbooks/netboot/tasks/push_local_artifacts.yml`**
+
+  Full content:
+
+  ```yaml
+  ---
+  # Copy locally-built kernel/initrd artifacts into the netbootxyz /assets tree.
+  # Source path comes from the entry's kernel_src/initrd_src; destination is
+  # /assets/local/<id>/. Idempotent via copy's checksum comparison.
+
+  - name: Local — define filtered list
+    ansible.builtin.set_fact:
+      _netboot_local_entries: "{{ netboot_entries | selectattr('kind', 'equalto', 'local') | list }}"
+
+  - name: Local — ensure /assets/local/<id> exists
+    ansible.builtin.file:
+      path: "{{ netbootxyz_root }}/assets/local/{{ item.id }}"
+      state: directory
+      owner: "1000"
+      group: "1000"
+      mode: "0755"
+    loop: "{{ _netboot_local_entries }}"
+    loop_control:
+      label: "{{ item.id }}"
+
+  - name: Local — copy vmlinuz
+    ansible.builtin.copy:
+      src: "{{ item.kernel_src }}"
+      dest: "{{ netbootxyz_root }}/assets/local/{{ item.id }}/vmlinuz"
+      owner: "1000"
+      group: "1000"
+      mode: "0644"
+    loop: "{{ _netboot_local_entries }}"
+    loop_control:
+      label: "{{ item.id }} vmlinuz"
+
+  - name: Local — copy initrd
+    ansible.builtin.copy:
+      src: "{{ item.initrd_src }}"
+      dest: "{{ netbootxyz_root }}/assets/local/{{ item.id }}/initrd"
+      owner: "1000"
+      group: "1000"
+      mode: "0644"
+    loop: "{{ _netboot_local_entries }}"
+    loop_control:
+      label: "{{ item.id }} initrd"
+  ```
+
+- [ ] **Step 2: Smoke test with a small fake artifact (the test step)**
+
+  Create local fixtures:
+
+  ```bash
+  mkdir -p /tmp/netboot-local-test
+  echo "fake kernel" > /tmp/netboot-local-test/vmlinuz
+  echo "fake initrd" > /tmp/netboot-local-test/initrd.img
+  ```
+
+  Create `/tmp/netboot-local-test.yml`:
+
+  ```yaml
+  ---
+  netboot_entries:
+    - id: localtest
+      name: "Local artifact test"
+      kind: local
+      kernel_src: /tmp/netboot-local-test/vmlinuz
+      initrd_src: /tmp/netboot-local-test/initrd.img
+      cmdline: "console=ttyS0"
+  netboot_host_pins: []
+  ```
+
+  Run:
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --tags local \
+    -e @/tmp/netboot-local-test.yml \
+    --mode stdout
+  ```
+
+  Expected: copy completes, stat on TrueNAS shows the two files.
+
+- [ ] **Step 3: Verify idempotency**
+
+  Re-run. Expected: `changed=0`.
+
+- [ ] **Step 4: Cleanup**
+
+  ```bash
+  ansible -i igou-inventory/inventory.yaml truenas -m ansible.builtin.file \
+    -a 'path=/mnt/ssd/containers/netbootxyz/assets/local/localtest state=absent' \
+    -b
+  rm -rf /tmp/netboot-local-test /tmp/netboot-local-test.yml
+  ```
+
+- [ ] **Step 5: Lint and commit**
+
+  ```bash
+  ansible-lint --profile=production playbooks/netboot/
+  yamllint playbooks/netboot/
+  git add playbooks/netboot/tasks/push_local_artifacts.yml
+  git commit -m "Add push_local_artifacts stage for kind=local entries"
+  ```
+
+---
+
+## Task 7: verify stage
+
+**Files:**
+- Create: `playbooks/netboot/tasks/verify.yml`
+
+This task does HTTP probes from the control node against the netbootxyz container's HTTP root. Catches misconfigured pins, missing entries, and broken renders at deploy time.
+
+- [ ] **Step 1: Create `playbooks/netboot/tasks/verify.yml`**
+
+  Full content:
+
+  ```yaml
+  ---
+  # HTTP probes against the running netbootxyz container.
+  # delegate_to: localhost — the probes run from wherever the playbook runs,
+  # not from inside TrueNAS.
+
+  - name: Verify — top-level menu.ipxe is reachable and well-formed
+    ansible.builtin.uri:
+      url: "{{ netbootxyz_self_url }}/menu.ipxe"
+      return_content: true
+      status_code: 200
+    register: _verify_menu
+    delegate_to: localhost
+    run_once: true
+    failed_when:
+      - _verify_menu.status != 200
+      - "'#!ipxe' not in (_verify_menu.content | default(''))"
+
+  - name: Verify — every entry's name appears in menu.ipxe
+    ansible.builtin.assert:
+      that:
+        - "item.name in _verify_menu.content"
+      fail_msg: "Entry {{ item.id }} ({{ item.name }}) not found in served menu.ipxe."
+    loop: "{{ netboot_entries }}"
+    loop_control:
+      label: "{{ item.id }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Verify — each entry .ipxe is reachable
+    ansible.builtin.uri:
+      url: "{{ netbootxyz_self_url }}/menus/entries/{{ item.id }}.ipxe"
+      method: GET
+      status_code: 200
+    loop: "{{ netboot_entries }}"
+    loop_control:
+      label: "{{ item.id }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Verify — each kind=iso asset is reachable
+    ansible.builtin.uri:
+      url: "{{ netbootxyz_self_url }}/assets/iso/{{ item.id }}.iso"
+      method: HEAD
+      status_code: 200
+    loop: "{{ netboot_entries | selectattr('kind', 'equalto', 'iso') | list }}"
+    loop_control:
+      label: "{{ item.id }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Verify — each host pin MAC file is reachable
+    ansible.builtin.uri:
+      url: "{{ netbootxyz_self_url }}/menus/host/MAC-{{ item.mac | lower | replace(':', '') }}.ipxe"
+      method: GET
+      status_code: 200
+    loop: "{{ netboot_host_pins }}"
+    loop_control:
+      label: "{{ item.mac }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Verify — each host pin HOSTNAME file is reachable (when set)
+    ansible.builtin.uri:
+      url: "{{ netbootxyz_self_url }}/menus/host/HOSTNAME-{{ item.hostname }}.ipxe"
+      method: GET
+      status_code: 200
+    loop: "{{ netboot_host_pins | selectattr('hostname', 'defined') | list }}"
+    loop_control:
+      label: "{{ item.hostname }}"
+    delegate_to: localhost
+    run_once: true
+
+  - name: Verify — summary
+    ansible.builtin.debug:
+      msg:
+        - "menu.ipxe served (length {{ _verify_menu.content | length }} bytes)"
+        - "entries verified: {{ netboot_entries | length }}"
+        - "host pins verified: {{ netboot_host_pins | length }}"
+    delegate_to: localhost
+    run_once: true
+  ```
+
+- [ ] **Step 2: Run end-to-end against the live container**
+
+  Use the empty inventory (Task 1):
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --mode stdout
+  ```
+
+  Expected: every stage completes; verify reports menu.ipxe served, 0 entries, 0 host pins.
+
+- [ ] **Step 3: Lint and commit**
+
+  ```bash
+  ansible-lint --profile=production playbooks/netboot/
+  yamllint playbooks/netboot/
+  git add playbooks/netboot/tasks/verify.yml
+  git commit -m "Add verify stage with HTTP probes for menu, entries, ISOs, and host pins"
+  ```
+
+---
+
+## Task 8: One-time cutover from `igou-node-bootstrap`
+
+**Files:**
+- Modify: `igou-inventory/group_vars/all/netboot.yml` (populate from existing content)
+- Maybe-create: `playbooks/netboot/files/{kickstart,cloud-init,fragments}/<existing files>`
+
+This is *manual translation work*. The playbook does not auto-import. The operator decides what becomes a declarative entry vs. a fragment vs. a kickstart asset.
+
+- [ ] **Step 1: Inventory existing custom content**
+
+  ```bash
+  ls -la ~/igou-node-bootstrap/netbootxyz-menus/
+  ls -la ~/igou-node-bootstrap/cloud-init/ 2>/dev/null
+  ls -la ~/igou-node-bootstrap/kickstart/ 2>/dev/null
+  ```
+
+  Note each `.ipxe` file under `netbootxyz-menus/` and decide for each:
+  - **Convert to a `netboot_entries` item** if it boots a single OS/installer with a clear kernel/initrd or ISO.
+  - **Drop into `playbooks/netboot/files/fragments/`** if it has bespoke iPXE syntax (multiple choose menus, conditional logic).
+
+- [ ] **Step 2: Translate the simple entries**
+
+  For each "simple" entry, edit `igou-inventory/group_vars/all/netboot.yml` and add to `netboot_entries:`. Use the four kinds documented in the spec.
+
+  Example: if `~/igou-node-bootstrap/netbootxyz-menus/talos.ipxe` was a `chain` to `https://factory.talos.dev/...`, translate it into:
+
+  ```yaml
+  - id: talos-1.9
+    name: "Talos 1.9"
+    kind: chainload
+    url: https://factory.talos.dev/...
+  ```
+
+- [ ] **Step 3: Copy the fragments**
+
+  ```bash
+  cp ~/igou-node-bootstrap/netbootxyz-menus/<complex-file>.ipxe \
+     playbooks/netboot/files/fragments/
+  ```
+
+  Repeat per fragment. Add a header comment (manually, top of file) that says "originated in igou-node-bootstrap on YYYY-MM-DD" so future-you can find it.
+
+- [ ] **Step 4: Copy kickstart and cloud-init**
+
+  ```bash
+  rsync -av ~/igou-node-bootstrap/cloud-init/ playbooks/netboot/files/cloud-init/
+  rsync -av ~/igou-node-bootstrap/kickstart/  playbooks/netboot/files/kickstart/
+  ```
+
+  Replace any embedded URLs that pointed to the old paths so they land at `/assets/cloud-init/...` and `/assets/kickstart/...` under the new layout. Grep for `boot-files` and replace with `assets/`.
+
+- [ ] **Step 5: Add per-host pins**
+
+  If the operator has any hosts that should always boot a specific recipe, add to `netboot_host_pins:` in `igou-inventory/group_vars/all/netboot.yml`. Skip if there are none today.
+
+- [ ] **Step 6: Render-check the new inventory**
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --tags render -e netbootxyz_host=localhost \
+    --mode stdout
+  ```
+
+  Expected: no preflight errors. If preflight fails, fix the inventory entry and re-run.
+
+  Eyeball `.cache/netboot-menus/menu.ipxe` and confirm the listed items match expectations.
+
+- [ ] **Step 7: Real-deploy the cutover**
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --mode stdout
+  ```
+
+  Expected: every stage completes, verify passes. Manually browse to `http://10.10.45.242` in a browser and click around the netbootxyz menu — your custom entries should appear.
+
+- [ ] **Step 8: Smoke-test with a real PXE client**
+
+  PXE-boot a test machine (or KubeVirt VM) and confirm:
+  - The menu appears.
+  - At least one custom entry boots.
+  - If you set up a host pin, that machine bypasses the menu and lands on the pinned recipe.
+
+  This is the ultimate proof. If anything is off, fix in inventory or a fragment file and re-run with `--tags render,push,verify`.
+
+- [ ] **Step 9: Commit (two repos)**
+
+  In `igou-inventory`:
+
+  ```bash
+  cd igou-inventory
+  git add group_vars/all/netboot.yml
+  git commit -m "Populate netboot_entries from igou-node-bootstrap cutover"
+  cd -
+  ```
+
+  In `igou-ansible`:
+
+  ```bash
+  git add playbooks/netboot/files/
+  git commit -m "Migrate custom iPXE fragments, kickstart, and cloud-init from igou-node-bootstrap"
+  ```
+
+---
+
+## Task 9: Delete the legacy playbooks
+
+**Files:**
+- Delete: `playbooks/truenas/configure_netbootxyz.yml`
+- Delete: `playbooks/truenas/sync_boot_files.yml`
+- Modify: `igou-inventory/group_vars/truenas.yml` (drop `truenas_boot_files_*` block)
+
+Only do this *after* Task 8's smoke test passed end-to-end.
+
+- [ ] **Step 1: Confirm the new playbook owns everything**
+
+  Re-run the full suite once more to be safe:
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --mode stdout
+  ```
+
+  Expected: `changed=0` (idempotent re-run). Confirms the new playbook is fully effective and you're not about to delete a still-in-use playbook.
+
+- [ ] **Step 2: Delete the legacy playbooks**
+
+  ```bash
+  git rm playbooks/truenas/configure_netbootxyz.yml playbooks/truenas/sync_boot_files.yml
+  ```
+
+- [ ] **Step 3: Drop `truenas_boot_files_*` from inventory**
+
+  Open `igou-inventory/group_vars/truenas.yml`. Find any `truenas_boot_files_source_dir`, `truenas_boot_files_dest_base`, `truenas_boot_files_owner`, `truenas_boot_files_group` keys and remove them. Verify by grep:
+
+  ```bash
+  grep -n truenas_boot_files igou-inventory/group_vars/truenas.yml
+  ```
+
+  Expected: no matches.
+
+- [ ] **Step 4: Lint**
+
+  ```bash
+  ansible-lint --profile=production
+  yamllint .
+  ```
+
+- [ ] **Step 5: Commit (two repos)**
+
+  In `igou-ansible`:
+
+  ```bash
+  git add playbooks/truenas/
+  git commit -m "Remove configure_netbootxyz.yml and sync_boot_files.yml (replaced by playbooks/netboot/deploy_assets.yml)"
+  ```
+
+  In `igou-inventory`:
+
+  ```bash
+  cd igou-inventory
+  git add group_vars/truenas.yml
+  git commit -m "Drop truenas_boot_files_* vars (replaced by netboot_entries)"
+  cd -
+  ```
+
+---
+
+## Task 10: Final integration check
+
+This task verifies the whole thing one more time in a representative way and produces evidence the cutover is done.
+
+- [ ] **Step 1: Idempotent re-run on the canonical inventory**
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --mode stdout
+  ```
+
+  Expected: `changed=0` across all stages.
+
+- [ ] **Step 2: Touch-up scenario**
+
+  Edit one entry's `cmdline:` in `igou-inventory/group_vars/all/netboot.yml` (e.g., add a benign `quiet` flag). Re-run with the targeted tag set:
+
+  ```bash
+  ansible-navigator run playbooks/netboot/deploy_assets.yml \
+    -i igou-inventory/inventory.yaml \
+    --tags render,push,verify \
+    --mode stdout
+  ```
+
+  Expected: only `entries/<that-id>.ipxe` is reported as changed in the push stage. Verify still passes.
+
+  Revert the change and re-run to confirm it goes back to `changed=0`.
+
+- [ ] **Step 3: Lint pass**
+
+  ```bash
+  ansible-lint --profile=production
+  yamllint .
+  pre-commit run --all-files
+  ```
+
+  All clean.
+
+- [ ] **Step 4: Final summary commit (if any drift)**
+
+  If lint pass produced fixups (whitespace, key order), commit them:
+
+  ```bash
+  git status
+  git add -A
+  git commit -m "Final lint cleanup for netboot deploy_assets cutover"
+  ```
+
+- [ ] **Step 5: Open PR**
+
+  ```bash
+  git push -u origin <feature-branch>
+  gh pr create --title "Replace netbootxyz menu/asset playbooks with declarative deploy_assets" \
+    --body "$(cat <<'EOF'
+  ## Summary
+  - Replaces playbooks/truenas/configure_netbootxyz.yml and sync_boot_files.yml with a single declarative-plus-fragments playbook tree at playbooks/netboot/.
+  - Eliminates the hardcoded /home/igou/igou-node-bootstrap/netbootxyz-menus path so AAP/AWX runs work.
+  - Adds per-host PXE pins by MAC/hostname, auto-served via a header in the generated menu.ipxe.
+  - Spec: docs/superpowers/specs/2026-05-08-netboot-asset-management-design.md.
+
+  ## Test plan
+  - [ ] All stages run idempotently against TrueNAS (changed=0 on second pass).
+  - [ ] Touching one entry's cmdline causes only that file to update.
+  - [ ] HTTP probes pass for menu.ipxe, every entry, every host pin.
+  - [ ] PXE-booting a test machine shows the new menu and a known entry boots.
+  - [ ] PXE-booting a host with a netboot_host_pins entry skips the menu and goes directly to the pinned recipe.
+  - [ ] ansible-lint --profile=production and yamllint clean.
+
+  Companion PR in igou-inventory must merge alongside.
+
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  EOF
+  )"
+  ```
+
+  Companion `igou-inventory` PR — push + open separately.
+
+---
+
+## Self-review summary (against the spec)
+
+Cross-check of every spec section to a task that implements it:
+
+| Spec section | Task |
+|---|---|
+| Goals (in-repo source, declarative entries, per-host pins, fragments, idempotent, host abstraction) | 1, 2, 3, 4, 5, 6, 7 |
+| Non-goals (OpenShift untouched; iPXE binaries untouched; multi-host) | scoped delete in Task 4; binaries playbook untouched |
+| File layout | Task 2 (orchestrator, preflight, dirs), 3 (templates + render), 4-7 (stages) |
+| Inventory schema (`netboot_entries`, `netboot_host_pins`) | Task 1 (file), Task 2 (validation), Task 3 (templating) |
+| Generated layout on TrueNAS | Task 4 (push) |
+| Generated `menu.ipxe` header (per-host hook) | Task 3 (template) |
+| Playbook stages | Task 2 (orchestrator), 2-7 (per-stage) |
+| Idempotency model | Task 4-6 (synchronize/get_url/copy semantics), Task 10 (verification) |
+| Migration plan (single-PR cutover) | Task 8 (translation), Task 9 (legacy delete), Task 10 (PR) |
+| Risks & mitigations | scope of `synchronize delete=true` (Task 4 step 1 + 3); `${mac:hexraw}` (Task 3 menu template); ISO checksum required (Task 2 preflight + Task 5 fetch) |
+| Testing strategy | Task 2 step 5 (preflight failure path), Task 3 step 7 (render with sample), Task 4 step 3 (check-diff), Task 5 step 4 (checksum mismatch), Task 6 step 3 (idempotency), Task 8 step 8 (real PXE), Task 10 step 2 (touch-up scenario) |
+| Repo-level changes | Task 1 (.gitignore + group_vars split), Task 9 (truenas.yml cleanup) |
+| Documentation | Task 2 step 1 (header comment block in deploy_assets.yml) |
+
+No gaps detected.

--- a/docs/superpowers/plans/2026-05-09-test-netboot-pxe-headless.md
+++ b/docs/superpowers/plans/2026-05-09-test-netboot-pxe-headless.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Extend `playbooks/kubevirt/test_netboot_pxe/` so each smoke-test VM verifies — without console scraping — that the netbootxyz nginx access log shows the expected per-host HTTP request (200 if the MAC is pinned, 404 if it isn't).
+**Goal:** Extend `playbooks/kubevirt/test_netboot_pxe/` so each smoke-test VM verifies — without console scraping — that the netbootxyz container's TFTP server (dnsmasq) responded the expected way to the per-host chain: `sent` if the MAC is pinned (file exists), `file not found` if it isn't.
 
-**Architecture:** Preflight stage validates netbootxyz HTTP reachability and pinned-MAC pin-file content (substring check). Per-case verification snapshots the nginx access log line count before the VM boots, reads the VMI to learn the actual MAC, queries rb5009 for the leased IP, and asserts that exactly one new access log line shows `GET /menus/host/MAC-<hexraw>.ipxe` with the expected status (200 or 404) from the VM's IP. Two new shared task files (`_dhcp_lease_lookup.yml`, `_verify_http.yml`) keep serial and parallel paths DRY.
+**Architecture:** Preflight stage validates the netbootxyz container's HTTP reachability and **deploys** the smoke pin files into `/mnt/ssd/containers/netbootxyz/config/menus/host/` from inventory's `netboot_host_pins[…].fragment`, then `docker exec cat`s each deployed file and asserts a substring match. Per-case verification snapshots the container's `docker logs` line count before the VM boots, reads the VMI to learn the actual MAC, queries rb5009 for the leased IP, and asserts that exactly one new `dnsmasq-tftp` line shows the expected outcome on `/config/menus/host/MAC-<hexraw>.ipxe` from the VM's IP. Two new shared task files (`_dhcp_lease_lookup.yml`, `_verify_tftp.yml`) keep serial and parallel paths DRY.
 
-**Tech Stack:** Ansible (kubernetes.core, community.routeros, ansible.builtin.uri/command), `docker exec` over the existing TrueNAS SSH connection, RouterOS DHCP lease API.
+**Tech Stack:** Ansible (kubernetes.core, community.routeros, ansible.builtin.uri/copy/command), `docker exec` and `docker logs` over the existing TrueNAS SSH connection, RouterOS DHCP lease API.
 
 ---
 
@@ -20,19 +20,27 @@
   - MAC `02:00:00:50:58:02` body contains literal `=== pxe-test smoke pin: uefi-x64`
 - **Inventory file path:** `igou-inventory/inventory.yaml`. All commands assume CWD is `/workspace/igou-ansible`.
 
-## Spike outcome (Task 1, completed 2026-05-09)
-
-These three values are the only outputs of the spike. They are referenced verbatim in Task 5.
+## Spike outcome (Task 1, completed 2026-05-09; updated post-pivot)
 
 ```
-runtime         = docker            (TrueNAS SCALE uses Docker, not podman)
-container_name  = ix-netbootxyz-netbootxyz-1   (TrueCharts naming)
-access_log_path = /config/log/nginx/access.log (inside the container)
-read_strategy   = wc -l snapshot before; tail -n +<N> after
-                  (nginx logs to a file, not stdout — `docker logs` only
-                  carries dnsmasq-tftp lines, not nginx access lines)
-http_root_probe = GET netbootxyz_self_url/ → 200 (asset root index;
-                  /menu.ipxe is NOT HTTP-served — that's TFTP)
+runtime          = docker            (TrueNAS SCALE uses Docker, not podman)
+container_name   = ix-netbootxyz-netbootxyz-1   (TrueCharts naming)
+http_root_probe  = GET netbootxyz_self_url/ → 200 (nginx asset root)
+nginx_serves     = ONLY /assets/  (no /menus/ exposed via HTTP)
+chain_protocol   = TFTP for everything (menu.ipxe, host/MAC-*.ipxe, fall-through)
+docker_logs      = carry dnsmasq-tftp lines (NOT nginx access lines)
+pin_files_path   = /config/menus/host/MAC-<hex>.ipxe (inside container)
+host_bind_mount  = /mnt/ssd/containers/netbootxyz/config/menus/host/
+read_strategy    = wc -l on `docker logs` before; tail -n +<N> after; grep
+                   dnsmasq-tftp; parse `sent <path> to <ip>` or
+                   `file <path> not found for <ip>`.
+```
+
+Sample dnsmasq-tftp lines (verified empirically):
+```
+dnsmasq-tftp[23]: sent /config/menus/menu.ipxe to 10.10.9.42
+dnsmasq-tftp[23]: file /config/menus/host/MAC-029f47581bf6.ipxe not found for 10.10.9.42
+dnsmasq-tftp[23]: sent /config/menus/stock-menu.ipxe to 10.10.9.42
 ```
 
 ## Conventions
@@ -54,7 +62,7 @@ http_root_probe = GET netbootxyz_self_url/ → 200 (asset root index;
 **Create:**
 - `playbooks/kubevirt/test_netboot_pxe/_preflight.yml`
 - `playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml`
-- `playbooks/kubevirt/test_netboot_pxe/_verify_http.yml`
+- `playbooks/kubevirt/test_netboot_pxe/_verify_tftp.yml`
 
 **Modify:**
 - `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`
@@ -76,7 +84,7 @@ If any of these is not true, surface it before starting Task 2.
 
 ## Task 1: Spike — DONE
 
-The spike completed on 2026-05-09. Outcomes are recorded in the "Spike outcome" section at the top of this plan and embedded into `_verify_http.yml` in Task 5. **No further action.**
+The spike completed on 2026-05-09. Outcomes are recorded in the "Spike outcome" section at the top of this plan and embedded into `_verify_tftp.yml` in Task 5. **No further action.**
 
 ---
 
@@ -224,40 +232,63 @@ Append to `_preflight.yml`:
          | list }}
 ```
 
-- [ ] **Step 3: Append the per-pin HTTP fetch + substring assertion**
+- [ ] **Step 3 (REWORKED): Pivot _preflight.yml to deploy + read-back**
 
-Append to `_preflight.yml`:
+The previously-committed Task 3 used HTTP fetches against `/menus/host/MAC-<hex>.ipxe`, which always 404s in the actual deployment (nginx serves only `/assets/`; per-host pins are TFTP-served from `/config/menus/host/`). Replace those two tasks with deploy + read-back. Locate in `_preflight.yml` the two tasks named:
+- `Preflight -- fetch each smoke pin file from netbootxyz`
+- `Preflight -- assert each smoke pin body contains its expected substring`
+
+DELETE both, then APPEND in their place:
 
 ```yaml
-- name: Preflight -- fetch each smoke pin file from netbootxyz
-  ansible.builtin.uri:
-    url: "{{ netbootxyz_self_url }}/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe"
-    return_content: true
-    status_code: 200
-    timeout: 10
-  register: _pxe_preflight_pin_results
-  delegate_to: localhost
-  changed_when: false
+- name: Preflight -- ensure host pin directory exists on TrueNAS
+  ansible.builtin.file:
+    path: "/mnt/ssd/containers/netbootxyz/config/menus/host"
+    state: directory
+    mode: '0755'
+  delegate_to: "{{ netbootxyz_host }}"
+  become: true
+
+- name: Preflight -- deploy each smoke pin from inventory to /config/menus/host/
+  ansible.builtin.copy:
+    content: "{{ (netboot_host_pins | selectattr('mac', 'equalto', item) | first).fragment }}"
+    dest: "/mnt/ssd/containers/netbootxyz/config/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe"
+    mode: '0644'
+  delegate_to: "{{ netbootxyz_host }}"
+  become: true
   loop: "{{ _pxe_preflight_pin_macs }}"
   loop_control:
     label: "MAC-{{ item | regex_replace(':', '') }}.ipxe"
 
-- name: Preflight -- assert each smoke pin body contains its expected substring
+- name: Preflight -- read each deployed smoke pin back via docker exec
+  ansible.builtin.command:
+    cmd: >-
+      docker exec ix-netbootxyz-netbootxyz-1
+      cat /config/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe
+  register: _pxe_preflight_pin_readback
+  changed_when: false
+  delegate_to: "{{ netbootxyz_host }}"
+  become: true
+  loop: "{{ _pxe_preflight_pin_macs }}"
+  loop_control:
+    label: "MAC-{{ item | regex_replace(':', '') }}.ipxe"
+
+- name: Preflight -- assert each deployed smoke pin contains its expected substring
   ansible.builtin.assert:
     that:
-      - _expected_substring == '' or _expected_substring in item.content
+      - _expected_substring == '' or _expected_substring in item.stdout
     fail_msg: >-
-      Pin file MAC-{{ item.item | regex_replace(':', '') }}.ipxe at
-      {{ netbootxyz_self_url }} returned 200 but its body does not contain
-      the expected substring '{{ _expected_substring }}'. This usually
-      means inventory's netboot_host_pins was changed but
-      playbooks/netboot/deploy_assets.yml has not been re-run.
-      First 200 chars: {{ item.content[:200] }}
+      Pin file MAC-{{ item.item | regex_replace(':', '') }}.ipxe was
+      deployed to /config/menus/host/ but its body does not contain
+      the expected substring '{{ _expected_substring }}'. This means
+      inventory's netboot_host_pins[].fragment for that MAC has changed
+      and the substring map at pxe_test_substring_defaults is out of
+      sync. First 200 chars of deployed file: {{ item.stdout[:200] }}
   vars:
     _expected_substring: "{{ pxe_test_substring_defaults[item.item] | default('') }}"
-  loop: "{{ _pxe_preflight_pin_results.results }}"
+  loop: "{{ _pxe_preflight_pin_readback.results }}"
   loop_control:
-    label: "MAC-{{ item.item | regex_replace(':', '') }}.ipxe"
+    label: "{{ item.item | regex_replace(':', '') }}.ipxe"
 ```
 
 - [ ] **Step 4: Run the playbook and verify preflight passes**
@@ -267,7 +298,7 @@ ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -i igou-inventory/inventory.yaml
 ```
 
-Expected: the new preflight tasks fetch two pin files and assert their bodies contain the expected substrings. Rest of the playbook still passes.
+Expected: preflight deploys two pin files into `/mnt/ssd/containers/netbootxyz/config/menus/host/`, reads them back via `docker exec cat`, and asserts each contains the expected substring. Re-running shows `ok` (not `changed`) on the deploy step. Rest of the playbook still passes.
 
 - [ ] **Step 5: Demonstrate the failure mode**
 
@@ -287,12 +318,17 @@ Expected: the substring assertion fails for both pins. No VMs applied.
 git add playbooks/kubevirt/test_netboot_pxe/_preflight.yml \
   playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
 git commit -m "$(cat <<'EOF'
-test_netboot_pxe: preflight asserts smoke pin bodies on netbootxyz
+test_netboot_pxe: pivot preflight to TFTP deploy + read-back
 
-Per-MAC substring map catches inventory drift -- if netboot_host_pins
-is updated but deploy_assets.yml is not re-run, preflight fails before
-any VM is applied. Pinned-MAC set is also derived here for the per-
-case 200-vs-404 classifier (Task 6).
+The actual netbootxyz deployment serves nothing through HTTP except
+/assets/. Per-host pins are TFTP-served from /config/menus/host/.
+Replace the always-404 HTTP fetch with copy-from-inventory deploy
+into the TrueCharts bind-mount, then docker exec cat read-back
+substring check.
+
+Smoke pin file deployment is normally deploy_assets.yml's job (per
+docs/superpowers/specs/2026-05-08-netboot-asset-management-design.md);
+inlined here until that playbook lands.
 EOF
 )"
 ```
@@ -405,10 +441,10 @@ EOF
 
 ---
 
-## Task 5: Add `_verify_http.yml` — nginx access-log slice + status-code assertion
+## Task 5: Add `_verify_tftp.yml` — `docker logs` slice + dnsmasq-tftp outcome assertion
 
 **Files:**
-- Create: `playbooks/kubevirt/test_netboot_pxe/_verify_http.yml`
+- Create: `playbooks/kubevirt/test_netboot_pxe/_verify_tftp.yml`
 
 - [ ] **Step 1: Create the file**
 
@@ -416,108 +452,116 @@ Write with this exact content:
 
 ```yaml
 ---
-# Per-case HTTP-side verification for the netboot.xyz smoke test.
+# Per-case TFTP-side verification for the netboot.xyz smoke test.
 # Called from both _arch_test.yml (serial mode) and the inline parallel
 # block in test_netboot_pxe.yml.
 #
-# SPIKE OUTCOME (2026-05-09):
-#   runtime         = docker (TrueNAS SCALE uses Docker, not podman)
+# Spike outcome (2026-05-09, see plan section "Spike outcome"):
+#   runtime          = docker (TrueNAS SCALE uses Docker)
 #   container_name  = ix-netbootxyz-netbootxyz-1   (TrueCharts naming)
-#   access_log_path = /config/log/nginx/access.log (inside the container;
-#                     nginx is configured to log to a file, not stdout --
-#                     `docker logs` only carries dnsmasq-tftp lines)
-#   read_strategy   = wc -l snapshot before, tail -n +<N> after
-#                     (slice-by-line-count survives clock skew and is
-#                     robust regardless of log driver)
+#   docker_logs      = carries dnsmasq-tftp lines (NOT nginx access lines)
+#   read_strategy    = wc -l on `docker logs` before; tail -n +<N> after;
+#                      grep dnsmasq-tftp; parse two patterns.
+#
+# Sample lines:
+#   dnsmasq-tftp[23]: sent /config/menus/host/MAC-020000505801.ipxe to 10.10.9.40
+#   dnsmasq-tftp[23]: file /config/menus/host/MAC-525400deadbe.ipxe not found for 10.10.9.41
 #
 # Inputs (task vars expected on caller):
 #   vm_name              VM name, used in messages
 #   vm_mac               lowercase MAC (with colons)
 #   vm_ip                dotted-quad IP from DHCP lease
-#   expected_status      200 (pinned) or 404 (random) -- the per-case
-#                          discriminator. Pinned MAC has a host file;
-#                          random MAC's GET hits 404 then iPXE falls
-#                          through to the in-binary :main_menu.
-#   pre_log_line_count   line count of access.log captured BEFORE the
-#                          VM was applied (snapshot in caller).
+#   expected_outcome     'sent' (pinned) or 'not_found' (random) --
+#                          the per-case discriminator. Pinned MAC has
+#                          a deployed host file -> dnsmasq sends it.
+#                          Random MAC -> dnsmasq returns "not found"
+#                          and iPXE falls through to stock-menu.ipxe.
+#   pre_log_line_count   line count of `docker logs` captured BEFORE
+#                          the VM was applied (snapshot in caller).
 #
 # Output: assertions only; no facts set.
 
-- name: "Read post-boot nginx access log slice for {{ vm_name }}"
-  ansible.builtin.command:
+- name: "Read post-boot docker logs slice for {{ vm_name }}"
+  ansible.builtin.shell:
     cmd: >-
-      docker exec ix-netbootxyz-netbootxyz-1
-      sh -c "tail -n +{{ pre_log_line_count | int + 1 }} /config/log/nginx/access.log"
+      docker logs ix-netbootxyz-netbootxyz-1 2>&1
+      | tail -n +{{ pre_log_line_count | int + 1 }}
+      | grep dnsmasq-tftp || true
   register: _pxe_log_slice
   changed_when: false
   delegate_to: "{{ netbootxyz_host }}"
   become: true
 
-- name: "Parse access lines into [ip, method, path, status] for {{ vm_name }}"
+- name: "Parse dnsmasq-tftp lines for {{ vm_name }} (sent pattern)"
   ansible.builtin.set_fact:
-    _pxe_parsed_lines: >-
+    _pxe_sent_lines: >-
       {{ _pxe_log_slice.stdout_lines
          | map('regex_search',
-               '^(\S+) - \S+ \[[^\]]+\] \"(\S+) (\S+) [^\"]+\" (\d+) ',
-               '\\1', '\\2', '\\3', '\\4')
+               '^dnsmasq-tftp\[\d+\]: sent (\S+) to ([\d.]+)$',
+               '\\1', '\\2')
          | select('truthy')
          | list }}
 
-- name: "Filter access lines to those from {{ vm_name }}'s IP ({{ vm_ip }})"
+- name: "Parse dnsmasq-tftp lines for {{ vm_name }} (not_found pattern)"
   ansible.builtin.set_fact:
-    _pxe_vm_lines: "{{ _pxe_parsed_lines | selectattr('0', 'equalto', vm_ip) | list }}"
+    _pxe_notfound_lines: >-
+      {{ _pxe_log_slice.stdout_lines
+         | map('regex_search',
+               '^dnsmasq-tftp\[\d+\]: file (\S+) not found for ([\d.]+)$',
+               '\\1', '\\2')
+         | select('truthy')
+         | list }}
 
 - name: "Compute expected per-host path for {{ vm_name }}"
   ansible.builtin.set_fact:
-    _pxe_expected_path: "/menus/host/MAC-{{ vm_mac | regex_replace(':', '') | lower }}.ipxe"
+    _pxe_expected_path: "/config/menus/host/MAC-{{ vm_mac | regex_replace(':', '') | lower }}.ipxe"
 
-- name: "Find access lines matching the expected GET for {{ vm_name }}"
+- name: "Filter sent/not_found lines to {{ vm_name }} (path + IP match)"
   ansible.builtin.set_fact:
-    _pxe_matching_lines: >-
-      {{ _pxe_vm_lines
-         | selectattr('1', 'equalto', 'GET')
-         | selectattr('2', 'equalto', _pxe_expected_path)
+    _pxe_match_sent: >-
+      {{ _pxe_sent_lines
+         | selectattr('0', 'equalto', _pxe_expected_path)
+         | selectattr('1', 'equalto', vm_ip)
+         | list }}
+    _pxe_match_notfound: >-
+      {{ _pxe_notfound_lines
+         | selectattr('0', 'equalto', _pxe_expected_path)
+         | selectattr('1', 'equalto', vm_ip)
          | list }}
 
-- name: "Assert {{ vm_name }} made at least one request to netbootxyz"
+- name: "Assert {{ vm_name }} produced exactly one matching dnsmasq-tftp line"
   ansible.builtin.assert:
     that:
-      - _pxe_vm_lines | length > 0
+      - (_pxe_match_sent | length) + (_pxe_match_notfound | length) == 1
     fail_msg: >-
-      VM {{ vm_name }} (IP {{ vm_ip }}) made NO HTTP requests to
-      netbootxyz. iPXE never reached the chainload step. Check the
-      rb5009 TFTP server, the chain target inside the iPXE binary, or
-      VLAN reachability between the VM CUDN and {{ netbootxyz_host }}.
+      VM {{ vm_name }} (IP {{ vm_ip }}) -- expected exactly one
+      dnsmasq-tftp line for {{ _pxe_expected_path }} from this IP.
+      Found {{ _pxe_match_sent | length }} 'sent' and
+      {{ _pxe_match_notfound | length }} 'not_found' matches. Either
+      iPXE never reached the netbootxyz chainload step (check the
+      rb5009 -> netbootxyz path), or the menu.ipxe served by netbootxyz
+      doesn't chain to host/MAC-<hex>.ipxe at all.
 
-- name: "Assert {{ vm_name }} fetched {{ _pxe_expected_path }} exactly once"
+- name: "Assert {{ vm_name }} got the expected outcome '{{ expected_outcome }}' on {{ _pxe_expected_path }}"
   ansible.builtin.assert:
     that:
-      - _pxe_matching_lines | length == 1
-    fail_msg: >-
-      VM {{ vm_name }} (IP {{ vm_ip }}) -- expected exactly one GET
-      {{ _pxe_expected_path }}, but the access log slice shows
-      {{ _pxe_matching_lines | length }} matches. All lines from this
-      VM: {{ _pxe_vm_lines }}.
-
-- name: "Assert {{ vm_name }} got HTTP {{ expected_status }} on {{ _pxe_expected_path }}"
-  ansible.builtin.assert:
-    that:
-      - _pxe_matching_lines[0][3] | int == expected_status | int
+      - (expected_outcome == 'sent' and _pxe_match_sent | length == 1)
+        or
+        (expected_outcome == 'not_found' and _pxe_match_notfound | length == 1)
     fail_msg: >-
       VM {{ vm_name }} (IP {{ vm_ip }}) hit {{ _pxe_expected_path }} but
-      got HTTP {{ _pxe_matching_lines[0][3] }} (expected
-      {{ expected_status }}). For a pinned MAC, this means the host
-      file is missing or stale -- run playbooks/netboot/deploy_assets.yml
-      and check inventory's netboot_host_pins. For a random MAC, this
-      means a per-host file exists for what should be an unpinned MAC
-      -- check whether that MAC was added to netboot_host_pins by
-      mistake, or whether deploy_assets.yml left a stale file behind.
+      dnsmasq returned the wrong outcome (expected '{{ expected_outcome }}').
+      For a pinned MAC ('sent' expected), this means the deploy step
+      in preflight failed silently or the file was removed since.
+      For a random MAC ('not_found' expected), this means a per-host
+      file exists for what should be an unpinned MAC -- check
+      /config/menus/host/ on the netbootxyz container for stale files.
 ```
 
 - [ ] **Step 2: yamllint**
 
 ```bash
-yamllint playbooks/kubevirt/test_netboot_pxe/_verify_http.yml
+yamllint playbooks/kubevirt/test_netboot_pxe/_verify_tftp.yml
 ```
 
 Expected: no errors.
@@ -525,22 +569,22 @@ Expected: no errors.
 - [ ] **Step 3: Commit**
 
 ```bash
-git add playbooks/kubevirt/test_netboot_pxe/_verify_http.yml
+git add playbooks/kubevirt/test_netboot_pxe/_verify_tftp.yml
 git commit -m "$(cat <<'EOF'
-test_netboot_pxe: add _verify_http helper
+test_netboot_pxe: add _verify_tftp helper
 
-Slices the netbootxyz nginx access log via docker exec tail (since
-nginx logs to a file, not stdout). Asserts exactly one GET on the
-per-host path with the expected status (200 for pinned, 404 for
-random). Status code is the per-case discriminator -- it captures
-both classes of regression with a single observable.
+Slices the netbootxyz container's `docker logs` (which carries
+dnsmasq-tftp lines), parses the two stable formats (`sent <path> to
+<ip>` and `file <path> not found for <ip>`), and asserts exactly one
+match for the VM's expected per-host path with the expected outcome
+('sent' for pinned MACs, 'not_found' for random MACs).
 EOF
 )"
 ```
 
 ---
 
-## Task 6: Wire HTTP verification into serial mode (`_arch_test.yml`)
+## Task 6: Wire TFTP verification into serial mode (`_arch_test.yml`)
 
 **Files:**
 - Modify: `playbooks/kubevirt/test_netboot_pxe/_arch_test.yml`
@@ -548,15 +592,15 @@ EOF
 The existing per-arch flow becomes:
 
 ```
-snapshot pre log line count (docker exec wc -l)
+snapshot pre `docker logs` line count (docker logs ... | wc -l)
 TFTP hits BEFORE
 apply VM, wait Ready
 include _dhcp_lease_lookup.yml -> _vm_mac, _vm_ip
 pause for boot
 TFTP hits AFTER
 assert TFTP hits incremented (existing)
-compute expected_status from _vm_mac in _pxe_pinned_macs
-include _verify_http.yml
+compute expected_outcome ('sent' if pinned else 'not_found')
+include _verify_tftp.yml
 always: delete VM
 ```
 
@@ -578,20 +622,19 @@ Open `_arch_test.yml` and replace its entire contents with:
 #
 # Per-case assertions:
 #   1. rb5009 TFTP hit counter for `item.binary` incremented (existing).
-#   2. netbootxyz access log shows the VM's leased IP fetched
-#      /menus/host/MAC-<hexraw>.ipxe with HTTP 200 (pinned MAC) or 404
-#      (random MAC). See _verify_http.yml.
+#   2. netbootxyz dnsmasq-tftp logs show the VM's leased IP requested
+#      /config/menus/host/MAC-<hexraw>.ipxe with outcome 'sent' (pinned
+#      MAC, file exists) or 'not_found' (random MAC, falls through to
+#      stock-menu.ipxe). See _verify_tftp.yml.
 
 - name: "Smoke-test {{ _vm_name }}"
   vars:
     _vm_name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
     _wait: "{{ item.boot_wait_seconds | default(pxe_test_boot_wait_seconds) }}"
   block:
-    - name: "Snapshot nginx access log line count BEFORE {{ _vm_name }}"
-      ansible.builtin.command:
-        cmd: >-
-          docker exec ix-netbootxyz-netbootxyz-1
-          wc -l /config/log/nginx/access.log
+    - name: "Snapshot docker logs line count BEFORE {{ _vm_name }}"
+      ansible.builtin.shell:
+        cmd: docker logs ix-netbootxyz-netbootxyz-1 2>&1 | wc -l
       register: _pxe_log_pre
       changed_when: false
       delegate_to: "{{ netbootxyz_host }}"
@@ -599,7 +642,7 @@ Open `_arch_test.yml` and replace its entire contents with:
 
     - name: "Capture pre log line count for {{ _vm_name }}"
       ansible.builtin.set_fact:
-        _pre_log_line_count: "{{ _pxe_log_pre.stdout.split() | first | int }}"
+        _pre_log_line_count: "{{ _pxe_log_pre.stdout | int }}"
 
     - name: "Snapshot rb5009 TFTP hits BEFORE boot for {{ item.binary }}"
       community.routeros.command:
@@ -660,13 +703,13 @@ Open `_arch_test.yml` and replace its entire contents with:
           that the matcher table still routes option-93 to the right
           binary.
 
-    - name: "Verify HTTP fetch for {{ _vm_name }}"
-      ansible.builtin.include_tasks: _verify_http.yml
+    - name: "Verify TFTP dispatch for {{ _vm_name }}"
+      ansible.builtin.include_tasks: _verify_tftp.yml
       vars:
         vm_name: "{{ _vm_name }}"
         vm_mac: "{{ _vm_mac }}"
         vm_ip: "{{ _vm_ip }}"
-        expected_status: "{{ 200 if (_vm_mac in _pxe_pinned_macs) else 404 }}"
+        expected_outcome: "{{ 'sent' if (_vm_mac in _pxe_pinned_macs) else 'not_found' }}"
         pre_log_line_count: "{{ _pre_log_line_count }}"
 
   always:
@@ -689,9 +732,9 @@ ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -i igou-inventory/inventory.yaml
 ```
 
-Expected: 4 cases run sequentially. Each: TFTP-hits assertion (existing) + HTTP-verify assertion (new). Pinned cases see status 200; random cases see status 404. All pass; `failed=0`.
+Expected: 4 cases run sequentially. Each: TFTP-hits assertion (existing) + TFTP-dispatch assertion (new). Pinned cases see dnsmasq `sent`; random cases see `not_found`. All pass; `failed=0`.
 
-If a case fails on HTTP-verify: read the failure message — it differentiates between (a) no HTTP at all from the VM, (b) wrong path, (c) right path wrong status.
+If a case fails on TFTP-dispatch: read the failure message — it differentiates between (a) no dnsmasq-tftp lines from the VM at all, (b) lines exist but for a different path, (c) right path wrong outcome.
 
 - [ ] **Step 3: Demonstrate the failure mode (pin file missing)**
 
@@ -725,19 +768,20 @@ Re-run normally; expect pass.
 ```bash
 git add playbooks/kubevirt/test_netboot_pxe/_arch_test.yml
 git commit -m "$(cat <<'EOF'
-test_netboot_pxe: serial mode asserts HTTP-side fetch per case
+test_netboot_pxe: serial mode asserts TFTP-side dispatch per case
 
-Snapshots the nginx access log line count, applies the VM, resolves
-its MAC and DHCP IP, then asserts exactly one GET on
-/menus/host/MAC-<hex>.ipxe from the VM's IP with status 200 (pinned)
-or 404 (random). Status is the per-case discriminator.
+Snapshots the netbootxyz container's docker logs line count, applies
+the VM, resolves its MAC and DHCP IP, then asserts exactly one
+dnsmasq-tftp line for /config/menus/host/MAC-<hex>.ipxe from the VM's
+IP with outcome 'sent' (pinned) or 'not_found' (random). The outcome
+is the per-case discriminator.
 EOF
 )"
 ```
 
 ---
 
-## Task 7: Wire HTTP verification into parallel mode (`test_netboot_pxe.yml`)
+## Task 7: Wire TFTP verification into parallel mode (`test_netboot_pxe.yml`)
 
 **Files:**
 - Modify: `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`
@@ -750,11 +794,9 @@ Locate the block named `Smoke-test architectures in parallel` (`when: pxe_test_p
     - name: Smoke-test architectures in parallel
       when: pxe_test_parallel
       block:
-        - name: Snapshot nginx access log line count BEFORE the parallel batch
-          ansible.builtin.command:
-            cmd: >-
-              docker exec ix-netbootxyz-netbootxyz-1
-              wc -l /config/log/nginx/access.log
+        - name: Snapshot docker logs line count BEFORE the parallel batch
+          ansible.builtin.shell:
+            cmd: docker logs ix-netbootxyz-netbootxyz-1 2>&1 | wc -l
           register: _pxe_log_pre_parallel
           changed_when: false
           delegate_to: "{{ netbootxyz_host }}"
@@ -762,7 +804,7 @@ Locate the block named `Smoke-test architectures in parallel` (`when: pxe_test_p
 
         - name: Capture pre log line count (parallel mode, shared)
           ansible.builtin.set_fact:
-            _pre_log_line_count_parallel: "{{ _pxe_log_pre_parallel.stdout.split() | first | int }}"
+            _pre_log_line_count_parallel: "{{ _pxe_log_pre_parallel.stdout | int }}"
 
         - name: Snapshot rb5009 TFTP hits BEFORE boot (all)
           community.routeros.command:
@@ -862,14 +904,14 @@ Locate the block named `Smoke-test architectures in parallel` (`when: pxe_test_p
           loop_control:
             label: "{{ item.0.item.name | default('pxe-test-' ~ item.0.item.arch) }}"
 
-        - name: Verify HTTP fetch for every VM (parallel)
-          ansible.builtin.include_tasks: _verify_http.yml
+        - name: Verify TFTP dispatch for every VM (parallel)
+          ansible.builtin.include_tasks: _verify_tftp.yml
           vars:
             _vm_name_inner: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
             vm_name: "{{ _vm_name_inner }}"
             vm_mac: "{{ _pxe_parallel_addr_map[_vm_name_inner].mac }}"
             vm_ip: "{{ _pxe_parallel_addr_map[_vm_name_inner].ip }}"
-            expected_status: "{{ 200 if (_pxe_parallel_addr_map[_vm_name_inner].mac in _pxe_pinned_macs) else 404 }}"
+            expected_outcome: "{{ 'sent' if (_pxe_parallel_addr_map[_vm_name_inner].mac in _pxe_pinned_macs) else 'not_found' }}"
             pre_log_line_count: "{{ _pre_log_line_count_parallel }}"
           loop: "{{ pxe_test_arches }}"
           loop_control:
@@ -899,7 +941,7 @@ ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -e 'pxe_test_parallel=true'
 ```
 
-Expected: 4 VMs apply concurrently, all reach Ready, addressing resolved per-VM, single shared pause, TFTP-hits AND HTTP-verify assertions for each. All pass.
+Expected: 4 VMs apply concurrently, all reach Ready, addressing resolved per-VM, single shared pause, TFTP-hits AND TFTP-dispatch assertions for each. All pass.
 
 - [ ] **Step 3: Re-run in serial mode (no regression)**
 
@@ -915,12 +957,12 @@ Expected: same end state, sequential execution, all assertions pass.
 ```bash
 git add playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
 git commit -m "$(cat <<'EOF'
-test_netboot_pxe: parallel mode asserts HTTP-side fetch per case
+test_netboot_pxe: parallel mode asserts TFTP-side dispatch per case
 
-Shared pre-snapshot of the nginx access log line count covers the
-whole batch; per-VM-IP filtering inside _verify_http.yml keeps cases
-independent. Same per-case discriminator as serial mode (200 pinned /
-404 random).
+Shared pre-snapshot of the docker logs line count covers the whole
+batch; per-VM-IP filtering inside _verify_tftp.yml keeps cases
+independent. Same per-case discriminator as serial mode ('sent'
+pinned / 'not_found' random).
 EOF
 )"
 ```
@@ -964,15 +1006,16 @@ Replace this paragraph with:
 # Verification (two layers):
 #   * TFTP hit counter on rb5009 increments for the expected binary
 #     (catches DHCP / matcher / TFTP regressions).
-#   * netbootxyz nginx access log shows the VM's leased IP made
-#     exactly one GET /menus/host/MAC-<hexraw>.ipxe -- with status 200
-#     for pinned MACs (host file served) or 404 for random MACs (file
-#     absent, iPXE falls through to in-binary :main_menu). Single
+#   * netbootxyz dnsmasq-tftp logs show the VM's leased IP made
+#     exactly one TFTP RRQ for /config/menus/host/MAC-<hexraw>.ipxe --
+#     with outcome 'sent' for pinned MACs (host file served) or
+#     'not_found' for random MACs (file absent; iPXE falls through to
+#     stock-menu.ipxe). Single
 #     observable, two interpretations; status code is the per-case
 #     discriminator. Substring assertions on pinned bodies catch
 #     deploy_assets.yml drift at preflight.
 #   No per-entry override fields; expectations are fully derived from
-#   inventory's netboot_host_pins (see _preflight.yml + _verify_http.yml).
+#   inventory's netboot_host_pins (see _preflight.yml + _verify_tftp.yml).
 ```
 
 - [ ] **Step 4: Final end-to-end runs (both modes)**
@@ -996,7 +1039,7 @@ git commit -m "$(cat <<'EOF'
 test_netboot_pxe: refresh header comment for headless verification
 
 The 'console scraping intentionally deferred' caveat no longer applies:
-the nginx access-log status-code assertion replaces it with a headless
+the dnsmasq-tftp outcome assertion replaces it with a headless
 equivalent.
 EOF
 )"
@@ -1029,6 +1072,6 @@ EOF
 **Identifier consistency:**
 - Fact names: `_pxe_pinned_macs`, `_pxe_preflight_pin_macs`, `_pxe_preflight_pin_results`, `_pxe_tftp_pre`, `_pxe_tftp_post`, `_pxe_hits_pre`, `_pxe_hits_post`, `_pxe_log_pre`, `_pre_log_line_count`, `_pxe_log_pre_parallel`, `_pre_log_line_count_parallel`, `_pxe_log_slice`, `_pxe_parsed_lines`, `_pxe_vm_lines`, `_pxe_expected_path`, `_pxe_matching_lines`, `_pxe_lease_query`, `_pxe_vmi_result`, `_pxe_parallel_addr_results`, `_pxe_parallel_addr_map`, `_vm_name`, `_vm_mac`, `_vm_ip`, `_wait`. All consistent across tasks.
 - `_dhcp_lease_lookup.yml` outputs `_vm_mac` and `_vm_ip` as facts; both serial (Task 6) and parallel (Task 7) consume identically.
-- `_verify_http.yml` inputs: `vm_name`, `vm_mac`, `vm_ip`, `expected_status`, `pre_log_line_count`. Used identically in serial and parallel call sites.
-- Path constant: `/menus/host/MAC-<hexraw>.ipxe` — produced identically in Tasks 3 (URL fetch), 5 (computed expectation).
+- `_verify_tftp.yml` inputs: `vm_name`, `vm_mac`, `vm_ip`, `expected_outcome`, `pre_log_line_count`. Used identically in serial and parallel call sites.
+- Path constant: `/config/menus/host/MAC-<hexraw>.ipxe` — produced identically in Tasks 3 (deploy dest), 5 (computed expectation).
 - Container literal: `ix-netbootxyz-netbootxyz-1` appears in Tasks 5, 6, 7. Identical spelling.

--- a/docs/superpowers/plans/2026-05-09-test-netboot-pxe-headless.md
+++ b/docs/superpowers/plans/2026-05-09-test-netboot-pxe-headless.md
@@ -1,0 +1,1183 @@
+# Headless verification for `test_netboot_pxe` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `playbooks/kubevirt/test_netboot_pxe/` so each smoke-test VM verifies — without console scraping — that the netbootxyz HTTP server served the *expected* file (per-host pin or main menu) to the VM's leased IP.
+
+**Architecture:** Add a preflight stage that statically validates netbootxyz HTTP reachability and smoke-pin file content, plus computes per-case `expected_fetch_path` / `expected_substring` from inventory's `netboot_host_pins`. Add per-case HTTP-side verification that correlates the VM's leased IP (queried from rb5009 DHCP) against new lines in the netbootxyz container access log. Two new shared task files keep serial and parallel orchestration paths DRY.
+
+**Tech Stack:** Ansible (kubernetes.core, community.routeros, ansible.builtin.uri), `podman logs` over the existing TrueNAS SSH connection, RouterOS DHCP API.
+
+---
+
+## Reference material
+
+- **Spec:** `docs/superpowers/specs/2026-05-09-test-netboot-pxe-headless-design.md` — read this first; it explains every design decision.
+- **Existing playbook tree:** `playbooks/kubevirt/test_netboot_pxe/{test_netboot_pxe.yml,_arch_test.yml,vm.yaml.j2}`.
+- **Inventory:** `igou-inventory/group_vars/all/netboot.yml` defines `netboot_host_pins`, `netbootxyz_host`, `netbootxyz_self_url`. `netboot_host_pins` is **read-only** from this plan's perspective — do not modify it.
+- **Smoke pin fragments to assert against** (already in inventory):
+  - MAC `02:00:00:50:58:01` body contains literal `=== pxe-test smoke pin: bios`
+  - MAC `02:00:00:50:58:02` body contains literal `=== pxe-test smoke pin: uefi-x64`
+- **Inventory file path:** `igou-inventory/inventory.yaml`. All commands assume CWD is the repo root.
+
+## Conventions
+
+- **Run commands from:** repository root `/workspace/igou-ansible`.
+- **Run-the-playbook command:** `ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml -i igou-inventory/inventory.yaml`.
+- **Linters:** `ansible-lint --profile=production playbooks/kubevirt/test_netboot_pxe/` and `yamllint playbooks/kubevirt/test_netboot_pxe/`.
+- **YAML style** (matches the rest of the repo and the existing files in this tree):
+  - `---` at file top, 2-space indent.
+  - YAML 1.2 booleans (`true`/`false`).
+  - `gather_facts: false` on plays.
+  - Fact names prefixed `_pxe_…` to scope them; transient block-local vars use leading `_` plus a short name.
+  - Tasks named with imperative phrasing; per-loop labels via `loop_control: { label: "<name>" }`.
+- **Connection assumptions** (already configured by group_vars and used by the existing playbook):
+  - `rb5009.igou.systems` — RouterOS over the `community.routeros.*` collection. The existing TFTP-hits step works; reuse the same `delegate_to`.
+  - `truenas` — SSH with `become: true` available. Other playbooks in `playbooks/truenas/` use the same connection.
+
+## Files Created/Modified/Deleted
+
+**Create:**
+- `playbooks/kubevirt/test_netboot_pxe/_preflight.yml`
+- `playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml`
+- `playbooks/kubevirt/test_netboot_pxe/_verify_http.yml`
+
+**Modify:**
+- `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`
+- `playbooks/kubevirt/test_netboot_pxe/_arch_test.yml`
+
+**Delete:** none.
+
+## Pre-flight assumptions (verify before Task 1)
+
+- `KUBECONFIG` is set in the environment and points at the OpenShift cluster (the existing playbook already depends on this).
+- The user can connect to `rb5009.igou.systems` and `truenas` from the current shell using the existing inventory (validated by running the existing playbook end-to-end first).
+- Static DHCP leases on rb5009 already exist for MACs `02:00:00:50:58:01` and `02:00:00:50:58:02` (referenced in the existing playbook header comment as "matches static DHCP leases on rb5009"). Random-MAC test cases will get dynamic leases from the pool.
+- `playbooks/netboot/deploy_assets.yml` has been run recently enough that the rendered `host/MAC-020000505801.ipxe` and `host/MAC-020000505802.ipxe` files exist on the TrueNAS netbootxyz container with bodies containing the smoke pin substrings above.
+
+If any of these are not true, stop and surface it before starting Task 1.
+
+---
+
+## Task 1: Spike — confirm netbootxyz container name and log driver on truenas
+
+This unblocks Task 5 (`_verify_http.yml`). The spec calls for documenting the spike outcome as a header comment in `_verify_http.yml`.
+
+**Files:**
+- Create: none yet.
+- Modify: none yet.
+- Output: a short note recorded in this plan's task body for downstream tasks to reference.
+
+- [ ] **Step 1: Identify the running netbootxyz container on truenas**
+
+Run:
+```bash
+ansible truenas -i igou-inventory/inventory.yaml -m ansible.builtin.command \
+  -a 'podman ps --format "{{ "{{" }}.Names{{ "}}" }}\t{{ "{{" }}.Image{{ "}}" }}"' \
+  -b
+```
+
+Expected: one row whose Image is something like `lscr.io/linuxserver/netbootxyz` (or the equivalent linuxserver image used in the TrueNAS app deployment). Capture the value from the Names column — call it `<NBXYZ_CTR>`. Common value: `netbootxyz`.
+
+If multiple matches or zero matches: stop and surface this — the deployment is not in the expected shape.
+
+- [ ] **Step 2: Inspect the log driver**
+
+Run:
+```bash
+ansible truenas -i igou-inventory/inventory.yaml -m ansible.builtin.command \
+  -a 'podman inspect <NBXYZ_CTR> --format "{{ "{{" }}.HostConfig.LogConfig.Type{{ "}}" }}"' \
+  -b
+```
+
+(Replace `<NBXYZ_CTR>` with the value from Step 1.)
+
+Expected output: `k8s-file` or `journald` or `json-file`. Any of these are fine — `podman logs` works against all three.
+
+If the output is `none`: stop. The container was started with logging disabled and `podman logs` cannot read access lines.
+
+- [ ] **Step 3: Confirm nginx access lines reach `podman logs`**
+
+Run:
+```bash
+ansible truenas -i igou-inventory/inventory.yaml -m ansible.builtin.command \
+  -a 'podman logs --tail=20 <NBXYZ_CTR>' \
+  -b
+```
+
+Expected: nginx access lines visible, format roughly:
+```
+<source_ip> - - [<timestamp>] "GET /menu.ipxe HTTP/1.1" 200 1234 "-" "iPXE/..."
+```
+
+If the output contains no nginx access lines (only s6-overlay startup messages): stop. The image is configured to log access to a file rather than stdout. Document the file path and switch the strategy in Task 5 to `cat <log_path>` over SSH; otherwise the rest of the plan stands.
+
+- [ ] **Step 4: Hit the HTTP root once and confirm a fresh access line appears**
+
+Run (from the test-runner shell):
+```bash
+curl -sf http://10.10.45.242/menu.ipxe > /dev/null && echo OK
+```
+
+Then re-run the `podman logs --tail=20` from Step 3. Expected: a new access line for the test-runner's source IP fetching `/menu.ipxe`.
+
+- [ ] **Step 5: Record findings**
+
+Add a single-line comment to the top of this task's local notes:
+
+```
+SPIKE OUTCOME (2026-05-09):
+  container_name = <NBXYZ_CTR>          # e.g. "netbootxyz"
+  log_driver     = <log_driver>          # k8s-file | journald | json-file
+  access_log_via = podman_logs           # confirmed nginx access lines appear in `podman logs`
+```
+
+These three values will be embedded as a comment block in `_verify_http.yml` in Task 5. Carry them forward.
+
+- [ ] **Step 6: No commit for this task**
+
+This is a read-only investigation. Nothing to commit yet.
+
+---
+
+## Task 2: Add `_preflight.yml` — netbootxyz HTTP root probe + wire into the playbook
+
+Goal: a runnable preflight stage that fails fast if netbootxyz is unreachable, with no other behaviour yet.
+
+**Files:**
+- Create: `playbooks/kubevirt/test_netboot_pxe/_preflight.yml`
+- Modify: `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`
+
+- [ ] **Step 1: Create `_preflight.yml`**
+
+Write the file with this exact content:
+
+```yaml
+---
+# Preflight for the netboot.xyz HTTP-side smoke test. Runs once at the
+# top of test_netboot_pxe.yml, before any VM is applied.
+#
+# Stages (each gated on the previous):
+#   1. HTTP-probe netbootxyz_self_url/menu.ipxe -- fail fast if down.
+#   2. (Task 3) Build the set of pinned MACs from netboot_host_pins,
+#      HTTP-fetch every smoke pin file referenced by pxe_test_arches,
+#      and assert each body contains the expected substring.
+#   3. (Task 4) Resolve expected_fetch_path / expected_substring per
+#      pxe_test_arches entry into _pxe_resolved_cases.
+#
+# All preflight tasks are delegate_to: localhost -- no TrueNAS or rb5009
+# contact at this stage.
+
+- name: Preflight -- netbootxyz HTTP root is reachable and serving menu.ipxe
+  ansible.builtin.uri:
+    url: "{{ netbootxyz_self_url }}/menu.ipxe"
+    return_content: true
+    status_code: 200
+    timeout: 10
+  register: _pxe_preflight_menu
+  delegate_to: localhost
+  changed_when: false
+
+- name: Preflight -- assert menu.ipxe body looks like an iPXE script
+  ansible.builtin.assert:
+    that:
+      - _pxe_preflight_menu.content is defined
+      - _pxe_preflight_menu.content.startswith('#!ipxe')
+    fail_msg: >-
+      {{ netbootxyz_self_url }}/menu.ipxe responded 200 but the body did
+      not start with '#!ipxe'. Either nginx is fronting a default page
+      because the netbootxyz container's /config/menus/ is empty, or
+      playbooks/netboot/deploy_assets.yml has never been run on this
+      host. First 200 chars of body: {{ _pxe_preflight_menu.content[:200] }}
+
+- name: Preflight -- cache menu.ipxe body for later substring checks
+  ansible.builtin.set_fact:
+    _pxe_preflight_bodies:
+      menu: "{{ _pxe_preflight_menu.content }}"
+```
+
+- [ ] **Step 2: Wire `_preflight.yml` into `test_netboot_pxe.yml`**
+
+Modify `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`. Locate the `tasks:` block (after the `vars:` block, around the comment `# --- Pre-flight (idempotent, never destructive) -----`). Insert the new include as the **first** task in `tasks:`, before the existing CUDN read:
+
+```yaml
+  tasks:
+    - name: Preflight -- netbootxyz HTTP-side checks
+      ansible.builtin.include_tasks: _preflight.yml
+
+    # --- Pre-flight (idempotent, never destructive) --------------------------
+
+    - name: Read each ClusterUserDefinedNetwork referenced by pxe_test_arches
+      ...
+```
+
+The existing CUDN-read block stays exactly where it is; only a new include is inserted above it.
+
+- [ ] **Step 3: Run the playbook end-to-end and confirm the new preflight runs**
+
+Run:
+```bash
+ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+  -i igou-inventory/inventory.yaml
+```
+
+Expected: the first task to print is `Preflight -- netbootxyz HTTP root is reachable and serving menu.ipxe`. The full playbook should still pass end-to-end (TFTP-hits checks behave the same as before).
+
+- [ ] **Step 4: Demonstrate the failure mode**
+
+Run a one-off invocation with a deliberately broken `netbootxyz_self_url` to confirm the preflight catches a down service:
+
+```bash
+ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+  -i igou-inventory/inventory.yaml \
+  -e 'netbootxyz_self_url=http://127.0.0.1:1'
+```
+
+Expected: the `Preflight -- netbootxyz HTTP root is reachable...` task fails with a connection error. No VM is applied. The playbook exits with a non-zero return code.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add playbooks/kubevirt/test_netboot_pxe/_preflight.yml \
+  playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
+git commit -m "$(cat <<'EOF'
+test_netboot_pxe: add preflight HTTP probe of netbootxyz_self_url
+
+Fails fast if netbootxyz is down before any VM is applied. First step
+of the headless verification design (see
+docs/superpowers/specs/2026-05-09-test-netboot-pxe-headless-design.md).
+EOF
+)"
+```
+
+---
+
+## Task 3: Preflight — pin lookup + smoke-pin substring assertions
+
+**Files:**
+- Modify: `playbooks/kubevirt/test_netboot_pxe/_preflight.yml`
+- Modify: `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml` (add the `pxe_test_substring_defaults` map to `vars:`)
+
+- [ ] **Step 1: Add the substring defaults map to the playbook vars**
+
+Modify `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`. In the `vars:` block, just below `pxe_test_parallel: false` and above the `pxe_test_arches:` list comment, insert:
+
+```yaml
+    # Default substring to grep for in each smoke pin's served body,
+    # keyed by lowercase MAC. Per-entry expected_substring (Task 4)
+    # overrides; an unmapped MAC defaults to no substring check.
+    pxe_test_substring_defaults:
+      "02:00:00:50:58:01": "=== pxe-test smoke pin: bios"
+      "02:00:00:50:58:02": "=== pxe-test smoke pin: uefi-x64"
+```
+
+- [ ] **Step 2: Extend `_preflight.yml` with the pin lookup**
+
+Append the following after the existing `_pxe_preflight_bodies` set_fact in `_preflight.yml`:
+
+```yaml
+- name: Preflight -- build set of pinned MACs (lowercase) from inventory
+  ansible.builtin.set_fact:
+    _pxe_pinned_macs: >-
+      {{ netboot_host_pins
+         | default([])
+         | selectattr('mac', 'defined')
+         | map(attribute='mac')
+         | map('lower')
+         | list }}
+
+- name: Preflight -- collect smoke-pin MACs referenced by pxe_test_arches that resolve to a pin
+  ansible.builtin.set_fact:
+    _pxe_preflight_pin_macs: >-
+      {{ pxe_test_arches
+         | selectattr('mac', 'defined')
+         | map(attribute='mac')
+         | map('lower')
+         | unique
+         | select('in', _pxe_pinned_macs)
+         | list }}
+```
+
+- [ ] **Step 3: Append the per-pin HTTP fetch + substring assertion**
+
+Append (still in `_preflight.yml`) the loop that fetches each pin file and asserts its substring:
+
+```yaml
+- name: Preflight -- fetch each smoke pin file from netbootxyz
+  ansible.builtin.uri:
+    url: "{{ netbootxyz_self_url }}/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe"
+    return_content: true
+    status_code: 200
+    timeout: 10
+  register: _pxe_preflight_pin_results
+  delegate_to: localhost
+  changed_when: false
+  loop: "{{ _pxe_preflight_pin_macs }}"
+  loop_control:
+    label: "MAC-{{ item | regex_replace(':', '') }}.ipxe"
+
+- name: Preflight -- assert each smoke pin body contains its expected substring
+  ansible.builtin.assert:
+    that:
+      - _expected_substring == '' or _expected_substring in item.content
+    fail_msg: >-
+      Pin file MAC-{{ item.item | regex_replace(':', '') }}.ipxe at
+      {{ netbootxyz_self_url }} returned 200 but its body does not contain
+      the expected substring '{{ _expected_substring }}'. This usually
+      means inventory's netboot_host_pins was changed but
+      playbooks/netboot/deploy_assets.yml has not been re-run.
+      First 200 chars: {{ item.content[:200] }}
+  vars:
+    _expected_substring: "{{ pxe_test_substring_defaults[item.item] | default('') }}"
+  loop: "{{ _pxe_preflight_pin_results.results }}"
+  loop_control:
+    label: "MAC-{{ item.item | regex_replace(':', '') }}.ipxe"
+
+- name: Preflight -- cache pin bodies keyed by lowercase MAC for per-case re-use
+  ansible.builtin.set_fact:
+    _pxe_preflight_bodies: >-
+      {{ _pxe_preflight_bodies
+         | combine({ ('pin:' ~ item.item): item.content }) }}
+  loop: "{{ _pxe_preflight_pin_results.results }}"
+  loop_control:
+    label: "MAC-{{ item.item | regex_replace(':', '') }}.ipxe"
+```
+
+- [ ] **Step 4: Run the playbook and verify preflight passes**
+
+```bash
+ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+  -i igou-inventory/inventory.yaml
+```
+
+Expected: the new preflight tasks run successfully, fetching two pin files and asserting their bodies contain the expected substrings. The rest of the playbook (TFTP-hits checks) still passes.
+
+- [ ] **Step 5: Demonstrate the failure mode**
+
+Override the substring map to a value that won't appear in the pin body, to confirm the assertion fires:
+
+```bash
+ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+  -i igou-inventory/inventory.yaml \
+  -e '{"pxe_test_substring_defaults": {"02:00:00:50:58:01": "DEFINITELY-NOT-IN-THE-BODY", "02:00:00:50:58:02": "DEFINITELY-NOT-IN-THE-BODY"}}'
+```
+
+Expected: the `Preflight -- assert each smoke pin body...` task fails for both pins. No VMs applied.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add playbooks/kubevirt/test_netboot_pxe/_preflight.yml \
+  playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
+git commit -m "$(cat <<'EOF'
+test_netboot_pxe: preflight asserts smoke pin bodies on netbootxyz
+
+Per-MAC substring map catches inventory drift -- if netboot_host_pins
+is updated but deploy_assets.yml is not re-run, preflight fails before
+any VM is applied. Bodies are cached for per-case re-use (Task 5).
+EOF
+)"
+```
+
+---
+
+## Task 4: Preflight — resolve `expected_fetch_path` / `expected_substring` per case
+
+**Files:**
+- Modify: `playbooks/kubevirt/test_netboot_pxe/_preflight.yml`
+
+- [ ] **Step 1: Append the per-case resolution to `_preflight.yml`**
+
+Append at the end of `_preflight.yml`:
+
+```yaml
+- name: Preflight -- resolve expected_fetch_path and expected_substring per pxe_test_arches entry
+  ansible.builtin.set_fact:
+    _pxe_resolved_cases: "{{ _pxe_resolved_cases | default([]) + [_resolved] }}"
+  vars:
+    _name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+    _mac_raw: "{{ item.mac | default('') }}"
+    _mac: "{{ _mac_raw | lower }}"
+    _has_mac: "{{ _mac_raw | length > 0 }}"
+    _is_pinned: "{{ _has_mac and _mac in _pxe_pinned_macs }}"
+    _hexraw: "{{ _mac | regex_replace(':', '') }}"
+    _pin_path: "/menus/host/MAC-{{ _hexraw }}.ipxe"
+    _mode: "{{ item.expected_fetch | default('auto') }}"
+    _expected_fetch_path: >-
+      {%- if _mode == 'auto' -%}
+      {{ _pin_path if _is_pinned else '/menu.ipxe' }}
+      {%- elif _mode == 'host_pin' -%}
+      {{ _pin_path }}
+      {%- elif _mode == 'menu' -%}
+      /menu.ipxe
+      {%- else -%}
+      {{ _mode }}
+      {%- endif -%}
+    _default_substring: "{{ pxe_test_substring_defaults[_mac] | default('') if _is_pinned else '' }}"
+    _resolved:
+      name: "{{ _name }}"
+      arch: "{{ item.arch }}"
+      binary: "{{ item.binary }}"
+      mac: "{{ _mac }}"
+      has_mac: "{{ _has_mac }}"
+      is_pinned: "{{ _is_pinned }}"
+      expected_fetch_path: "{{ _expected_fetch_path | trim }}"
+      expected_substring: "{{ item.expected_substring | default(_default_substring) }}"
+  loop: "{{ pxe_test_arches }}"
+  loop_control:
+    label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+
+- name: Preflight -- assert host_pin mode entries declare a MAC
+  ansible.builtin.assert:
+    that:
+      - item.has_mac
+    fail_msg: >-
+      pxe_test_arches entry '{{ item.name }}' specifies expected_fetch:
+      host_pin but no mac. host_pin mode requires a MAC so the per-host
+      pin path can be computed.
+  loop: "{{ _pxe_resolved_cases }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: item.expected_fetch_path is search('/menus/host/MAC-')
+
+- name: Preflight -- print resolved test cases (for visibility)
+  ansible.builtin.debug:
+    msg: "{{ item.name }}: fetch={{ item.expected_fetch_path }} substring='{{ item.expected_substring }}'"
+  loop: "{{ _pxe_resolved_cases }}"
+  loop_control:
+    label: "{{ item.name }}"
+```
+
+- [ ] **Step 2: Run the playbook; verify resolution**
+
+```bash
+ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+  -i igou-inventory/inventory.yaml
+```
+
+Expected `debug` output (exact paths, hexraw lowercase, no separators):
+
+```
+pxe-test-bios-random:        fetch=/menu.ipxe                                      substring=''
+pxe-test-bios-pinned:        fetch=/menus/host/MAC-020000505801.ipxe                substring='=== pxe-test smoke pin: bios'
+pxe-test-uefi-x64-random:    fetch=/menu.ipxe                                      substring=''
+pxe-test-uefi-x64-pinned:    fetch=/menus/host/MAC-020000505802.ipxe                substring='=== pxe-test smoke pin: uefi-x64'
+```
+
+Whitespace alignment doesn't matter; the values do. If any value is wrong, the resolution logic is broken — fix and re-run before commit.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add playbooks/kubevirt/test_netboot_pxe/_preflight.yml
+git commit -m "$(cat <<'EOF'
+test_netboot_pxe: preflight resolves expected fetch path per case
+
+Each pxe_test_arches entry resolves to {expected_fetch_path,
+expected_substring} from its mac + inventory's netboot_host_pins, with
+mode override (auto|host_pin|menu|<literal>). Resolution is the input
+to the per-case HTTP assertion added in later tasks.
+EOF
+)"
+```
+
+---
+
+## Task 5: Add `_dhcp_lease_lookup.yml` — VM IP from rb5009
+
+**Files:**
+- Create: `playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml`
+
+- [ ] **Step 1: Create the file**
+
+Write the file with this exact content:
+
+```yaml
+---
+# Look up a VM's leased IP from rb5009's DHCP server, given its MAC.
+# Polls up to 30s (5s interval) -- iPXE's DHCP exchange can lag VMI
+# Ready by a few seconds, especially in parallel mode where multiple
+# discovers race the rb5009 DHCP daemon.
+#
+# Inputs (task vars expected on caller):
+#   _vm_name   for the loop label / failure message
+#   _vm_mac    MAC to query, any case, with-or-without separators
+#
+# Outputs:
+#   _vm_ip     populated with the IP string (e.g. "10.10.9.42")
+#
+# Failure mode: if no lease appears within 30s, fails with a network-
+# layer-flavoured message that does NOT confuse the failure with a
+# netbootxyz problem.
+
+- name: "Wait for {{ _vm_name }} DHCP lease (MAC {{ _vm_mac }})"
+  community.routeros.command:
+    commands:
+      - >-
+        /ip dhcp-server lease print detail without-paging
+        where mac-address="{{ _vm_mac | upper }}"
+  register: _pxe_lease_query
+  changed_when: false
+  delegate_to: rb5009.igou.systems
+  retries: 6
+  delay: 5
+  until: _pxe_lease_query.stdout[0] is search('address=')
+
+- name: "Extract IP from lease for {{ _vm_name }}"
+  ansible.builtin.set_fact:
+    _vm_ip: "{{ _pxe_lease_query.stdout[0] | regex_search('address=([0-9.]+)', '\\1') | first }}"
+
+- name: "Assert IP was extracted for {{ _vm_name }}"
+  ansible.builtin.assert:
+    that:
+      - _vm_ip is defined
+      - _vm_ip | length > 0
+    fail_msg: >-
+      VM {{ _vm_name }} (MAC {{ _vm_mac }}) appears to have a lease entry
+      on rb5009 but no address= field could be parsed. Raw output:
+      {{ _pxe_lease_query.stdout[0] }}
+```
+
+- [ ] **Step 2: Stand-alone smoke test by running the existing playbook tasks once**
+
+This file has no callers yet (those come in Tasks 7-8). The smoke check is just `yamllint` for now:
+
+```bash
+yamllint playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
+git commit -m "$(cat <<'EOF'
+test_netboot_pxe: add _dhcp_lease_lookup helper
+
+Polls rb5009 for the VM's DHCP lease (MAC -> IP), 30s budget. Wired
+in by Task 7 (serial) and Task 8 (parallel) of the headless plan.
+EOF
+)"
+```
+
+---
+
+## Task 6: Add `_verify_http.yml` — log grep + per-case HTTP assertions
+
+**Files:**
+- Create: `playbooks/kubevirt/test_netboot_pxe/_verify_http.yml`
+
+This file uses three values from the Task 1 spike:
+- `<NBXYZ_CTR>` — the netbootxyz container name on truenas. Substitute literally; do not parametrise unless other playbooks already vary it.
+- `<log_driver>` — recorded in a comment block.
+- `access_log_via=podman_logs` — confirmed.
+
+If the spike found that `podman logs` does NOT carry nginx access lines (Step 3 of Task 1), replace the `podman logs` invocation in Step 1 below with `cat <log_path>` over the same `delegate_to`, and adjust the `--since` filtering accordingly (drop `--since`, do client-side line counting instead).
+
+- [ ] **Step 1: Create the file**
+
+Write the file with this exact content (substitute `<NBXYZ_CTR>` with the literal container name from the spike — typically `netbootxyz`):
+
+```yaml
+---
+# Per-case HTTP-side verification for the netboot.xyz smoke test.
+# Called from both _arch_test.yml (serial mode) and the inline parallel
+# block in test_netboot_pxe.yml.
+#
+# SPIKE OUTCOME (2026-05-09):
+#   container_name = <NBXYZ_CTR>
+#   log_driver     = <log_driver from Task 1, e.g. k8s-file>
+#   access_log_via = podman_logs   # nginx access lines reach `podman logs`
+#
+# Inputs (task vars expected on caller):
+#   vm_name              VM name, used in messages and loop labels
+#   vm_mac               lowercase MAC of the VM (already normalised)
+#   vm_ip                IP the VM was leased by rb5009
+#   expected_fetch_path  path the netbootxyz access log should show GET'd
+#   expected_substring   substring the served body must contain (or '')
+#   case_start_seconds   integer seconds elapsed since the case began
+#                          (used as `--since=<N>s` for `podman logs`)
+#
+# Side effect: emits two assertions per case (positive fetch + optional
+# negative menu assertion + optional substring check).
+
+- name: "Fetch netbootxyz access log lines since case start ({{ vm_name }})"
+  ansible.builtin.command:
+    cmd: "podman logs --since={{ case_start_seconds }}s <NBXYZ_CTR>"
+  register: _pxe_nbxyz_logs
+  changed_when: false
+  delegate_to: "{{ netbootxyz_host }}"
+  become: true
+
+- name: "Extract fetched paths for {{ vm_name }} (IP {{ vm_ip }})"
+  ansible.builtin.set_fact:
+    _pxe_fetched_paths: >-
+      {{ _pxe_nbxyz_logs.stdout_lines
+         | select('search', '^' ~ vm_ip ~ ' ')
+         | map('regex_search', '\"GET ([^ ]+) HTTP', '\\1')
+         | select('truthy')
+         | map('first')
+         | list }}
+
+- name: "Assert {{ vm_name }} fetched {{ expected_fetch_path }} from netbootxyz"
+  ansible.builtin.assert:
+    that:
+      - expected_fetch_path in _pxe_fetched_paths
+    fail_msg: >-
+      VM {{ vm_name }} (IP {{ vm_ip }}) was expected to fetch
+      {{ expected_fetch_path }} from netbootxyz, but the access log
+      shows: {{ _pxe_fetched_paths }}. Either iPXE never reached the
+      netbootxyz HTTP root (check the chain to {{ netbootxyz_self_url }}
+      from the binary, or the rb5009 DHCP option-67 setting), or the
+      matcher table is wrong.
+
+- name: "Assert {{ vm_name }} did NOT fetch any host/MAC-* file (menu fall-through case)"
+  ansible.builtin.assert:
+    that:
+      - _pxe_fetched_paths | select('match', '^/menus/host/MAC-') | list | length == 0
+    fail_msg: >-
+      Random-MAC VM {{ vm_name }} unexpectedly fetched a per-host file:
+      {{ _pxe_fetched_paths | select('match', '^/menus/host/MAC-') | list }}.
+      Either the menu fall-through is broken, or a stale per-host file
+      is being served for this MAC. The pinned MAC's hexraw appears in
+      the fetched path; cross-check against netboot_host_pins.
+  when: expected_fetch_path == '/menu.ipxe'
+
+- name: "Assert served body for {{ vm_name }} contains expected substring"
+  when: expected_substring | length > 0
+  block:
+    - name: "Re-use cached body for {{ vm_name }} if available, else fetch fresh"
+      ansible.builtin.set_fact:
+        _pxe_served_body: >-
+          {{ _pxe_preflight_bodies['pin:' ~ vm_mac]
+             | default(_pxe_preflight_bodies['menu'])
+             if (expected_fetch_path == '/menu.ipxe'
+                 or ('pin:' ~ vm_mac) in _pxe_preflight_bodies)
+             else '' }}
+
+    - name: "Fetch served body for {{ vm_name }} (cache miss)"
+      ansible.builtin.uri:
+        url: "{{ netbootxyz_self_url }}{{ expected_fetch_path }}"
+        return_content: true
+        status_code: 200
+        timeout: 10
+      register: _pxe_fresh_body
+      delegate_to: localhost
+      changed_when: false
+      when: _pxe_served_body | length == 0
+
+    - name: "Substring assert for {{ vm_name }}"
+      ansible.builtin.assert:
+        that:
+          - expected_substring in (_pxe_served_body if _pxe_served_body | length > 0 else _pxe_fresh_body.content)
+        fail_msg: >-
+          Served body for {{ vm_name }} at {{ expected_fetch_path }}
+          does not contain '{{ expected_substring }}'.
+```
+
+- [ ] **Step 2: yamllint the file**
+
+```bash
+yamllint playbooks/kubevirt/test_netboot_pxe/_verify_http.yml
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add playbooks/kubevirt/test_netboot_pxe/_verify_http.yml
+git commit -m "$(cat <<'EOF'
+test_netboot_pxe: add _verify_http helper
+
+Per-case HTTP-side assertion: greps the netbootxyz container access
+log (since case start) for GETs from the VM's leased IP, asserts the
+expected path was fetched, and (for menu cases) asserts no per-host
+file was fetched. Substring check re-uses the body cached at preflight
+when available, otherwise fetches fresh.
+EOF
+)"
+```
+
+---
+
+## Task 7: Wire HTTP verification into serial mode (`_arch_test.yml`)
+
+**Files:**
+- Modify: `playbooks/kubevirt/test_netboot_pxe/_arch_test.yml`
+
+The existing per-arch flow becomes:
+
+```
+capture _case_start_seconds (now)
+TFTP hits BEFORE
+apply VM, wait Ready
+DHCP lease lookup -> _vm_ip
+pause for boot
+TFTP hits AFTER
+assert TFTP hits incremented (existing)
+HTTP verify (new)
+always: delete VM
+```
+
+- [ ] **Step 1: Replace `_arch_test.yml` with the augmented version**
+
+Open `playbooks/kubevirt/test_netboot_pxe/_arch_test.yml` and replace its entire contents with:
+
+```yaml
+---
+# Per-architecture smoke test, included once per entry in pxe_test_arches
+# by ../test_netboot_pxe.yml when pxe_test_parallel is false. Wrapped in
+# block/always so a failed assertion still tears down the VM before the
+# next entry attempts.
+#
+# Expects loop variables on `item`:
+#   item.arch    free-form arch label
+#   item.binary  TFTP filename to watch on rb5009
+# Optional per-entry overrides are documented in the parent playbook.
+#
+# Per-case assertions:
+#   1. rb5009 TFTP hit counter for `item.binary` incremented (existing).
+#   2. netbootxyz access log shows the VM's leased IP fetched the
+#      expected path (host/MAC-<hexraw>.ipxe for pinned cases, /menu.ipxe
+#      for random-MAC cases). See _verify_http.yml.
+
+- name: "Smoke-test {{ _vm_name }}"
+  vars:
+    _vm_name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+    _vm_mac: "{{ item.mac | default('') | lower }}"
+    _wait: "{{ item.boot_wait_seconds | default(pxe_test_boot_wait_seconds) }}"
+    _resolved: "{{ _pxe_resolved_cases | selectattr('name', 'equalto', _vm_name) | first }}"
+  block:
+    - name: "Capture case-start timestamp for {{ _vm_name }}"
+      ansible.builtin.set_fact:
+        _case_start_epoch: "{{ ansible_date_time.epoch | default(lookup('pipe','date -u +%s')) | int }}"
+
+    - name: "Snapshot rb5009 TFTP hits BEFORE boot for {{ item.binary }}"
+      community.routeros.command:
+        commands:
+          - >-
+            /ip tftp print detail without-paging where
+            req-filename="{{ item.binary }}"
+      register: _pxe_tftp_pre
+      changed_when: false
+      delegate_to: rb5009.igou.systems
+
+    - name: "Extract pre-boot hit count"
+      ansible.builtin.set_fact:
+        _pxe_hits_pre: "{{ _pxe_tftp_pre.stdout[0] | regex_search('hits=\\d+') | default('hits=0') | regex_replace('^hits=', '') | int }}"
+
+    - name: "Apply diskless PXE-boot VM ({{ _vm_name }})"
+      kubernetes.core.k8s:
+        state: present
+        validate_certs: false
+        namespace: "{{ pxe_test_namespace }}"
+        definition: "{{ lookup('ansible.builtin.template', 'vm.yaml.j2') | from_yaml }}"
+        wait: true
+        wait_condition:
+          type: Ready
+          status: "True"
+        wait_timeout: 180
+
+    - name: "Look up DHCP lease IP for {{ _vm_name }}"
+      ansible.builtin.include_tasks: _dhcp_lease_lookup.yml
+
+    - name: "Pause to let iPXE complete its boot attempt ({{ _vm_name }})"
+      ansible.builtin.pause:
+        seconds: "{{ _wait }}"
+
+    - name: "Snapshot rb5009 TFTP hits AFTER boot for {{ item.binary }}"
+      community.routeros.command:
+        commands:
+          - >-
+            /ip tftp print detail without-paging where
+            req-filename="{{ item.binary }}"
+      register: _pxe_tftp_post
+      changed_when: false
+      delegate_to: rb5009.igou.systems
+
+    - name: "Extract post-boot hit count"
+      ansible.builtin.set_fact:
+        _pxe_hits_post: "{{ _pxe_tftp_post.stdout[0] | regex_search('hits=\\d+') | default('hits=0') | regex_replace('^hits=', '') | int }}"
+
+    - name: "Assert TFTP hits incremented for {{ item.binary }}"
+      ansible.builtin.assert:
+        that:
+          - (_pxe_hits_post | int) > (_pxe_hits_pre | int)
+        fail_msg: >-
+          VM {{ _vm_name }} did not fetch {{ item.binary }} from rb5009
+          within {{ _wait }}s. hits {{ _pxe_hits_pre }} ->
+          {{ _pxe_hits_post }}. Check the VMI status, the DHCP offer to
+          its MAC (`/log print where topics~"dhcp"` on rb5009), and that
+          the matcher table still routes option-93 to the right binary.
+
+    - name: "Verify HTTP fetch for {{ _vm_name }}"
+      ansible.builtin.include_tasks: _verify_http.yml
+      vars:
+        vm_name: "{{ _vm_name }}"
+        vm_mac: "{{ _vm_mac }}"
+        vm_ip: "{{ _vm_ip }}"
+        expected_fetch_path: "{{ _resolved.expected_fetch_path }}"
+        expected_substring: "{{ _resolved.expected_substring }}"
+        case_start_seconds: "{{ ((lookup('pipe','date -u +%s') | int) - (_case_start_epoch | int)) + 5 }}"
+
+  always:
+    - name: "Delete test VM ({{ _vm_name }})"
+      kubernetes.core.k8s:
+        state: absent
+        validate_certs: false
+        api_version: kubevirt.io/v1
+        kind: VirtualMachine
+        namespace: "{{ pxe_test_namespace }}"
+        name: "{{ _vm_name }}"
+        wait: true
+        wait_timeout: 120
+```
+
+- [ ] **Step 2: Run the playbook in serial mode and verify all 4 cases pass**
+
+```bash
+ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+  -i igou-inventory/inventory.yaml
+```
+
+Default mode is `pxe_test_parallel: false` so this exercises the serial path.
+
+Expected: 4 cases run, each with a TFTP-hits assertion (existing) AND an HTTP-verify assertion (new). All pass. The playbook completes with `failed=0`.
+
+If a case fails on the HTTP-verify assertion: read the failure message — it tells you whether the access log saw the wrong path, didn't see the IP at all, or the substring check tripped.
+
+- [ ] **Step 3: Demonstrate the HTTP-verify failure mode**
+
+To prove the new assertion can detect a regression, temporarily corrupt the smoke pin (or rename the file on truenas):
+
+```bash
+ansible truenas -i igou-inventory/inventory.yaml -m ansible.builtin.command \
+  -a 'mv /mnt/ssd/containers/netbootxyz/config/menus/host/MAC-020000505801.ipxe /mnt/ssd/containers/netbootxyz/config/menus/host/MAC-020000505801.ipxe.bak' \
+  -b
+```
+
+Then run only the BIOS-pinned case:
+```bash
+ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+  -i igou-inventory/inventory.yaml \
+  -e '{"pxe_test_arches": [{"name": "pxe-test-bios-pinned", "arch": "bios", "binary": "netboot.xyz.kpxe", "mac": "02:00:00:50:58:01"}]}'
+```
+
+Expected: the new "Preflight -- assert each smoke pin body..." catches it BEFORE any VM boots — the pin file is missing, preflight fails with a 404. (This is the design intent: cheap static check fails fast.)
+
+Restore the file:
+```bash
+ansible truenas -i igou-inventory/inventory.yaml -m ansible.builtin.command \
+  -a 'mv /mnt/ssd/containers/netbootxyz/config/menus/host/MAC-020000505801.ipxe.bak /mnt/ssd/containers/netbootxyz/config/menus/host/MAC-020000505801.ipxe' \
+  -b
+```
+
+Re-run normally; expect pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add playbooks/kubevirt/test_netboot_pxe/_arch_test.yml
+git commit -m "$(cat <<'EOF'
+test_netboot_pxe: serial mode asserts HTTP-side fetch per case
+
+Each case now also verifies that the netbootxyz access log shows the
+VM's leased IP fetching the expected path -- catches the iPXE -> nbxyz
+chain regression that the existing TFTP-hits check cannot see.
+EOF
+)"
+```
+
+---
+
+## Task 8: Wire HTTP verification into parallel mode (`test_netboot_pxe.yml`)
+
+**Files:**
+- Modify: `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`
+
+- [ ] **Step 1: Replace the parallel block**
+
+In `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`, locate the block named `Smoke-test architectures in parallel` (the `when: pxe_test_parallel` block, around line ~150 in the existing file). Replace the entire block (from `- name: Smoke-test architectures in parallel` through the matching `always:` block, inclusive) with:
+
+```yaml
+    - name: Smoke-test architectures in parallel
+      when: pxe_test_parallel
+      block:
+        - name: Capture case-start epoch (parallel mode, shared)
+          ansible.builtin.set_fact:
+            _pxe_parallel_start_epoch: "{{ lookup('pipe','date -u +%s') | int }}"
+
+        - name: Snapshot rb5009 TFTP hits BEFORE boot (all)
+          community.routeros.command:
+            commands:
+              - >-
+                /ip tftp print detail without-paging where
+                req-filename="{{ item.binary }}"
+          register: _pxe_tftp_pre_all
+          changed_when: false
+          delegate_to: rb5009.igou.systems
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+
+        - name: Apply all diskless PXE-boot VMs (no per-VM wait)
+          kubernetes.core.k8s:
+            state: present
+            validate_certs: false
+            namespace: "{{ pxe_test_namespace }}"
+            definition: "{{ lookup('ansible.builtin.template', 'vm.yaml.j2') | from_yaml }}"
+            wait: false
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+
+        - name: Wait for all VMs to reach Ready
+          kubernetes.core.k8s_info:
+            api_version: kubevirt.io/v1
+            kind: VirtualMachine
+            namespace: "{{ pxe_test_namespace }}"
+            name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+            validate_certs: false
+            wait: true
+            wait_condition:
+              type: Ready
+              status: "True"
+            wait_timeout: 180
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+
+        - name: Look up DHCP lease IP for every VM (parallel)
+          ansible.builtin.include_tasks: _dhcp_lease_lookup.yml
+          vars:
+            _vm_name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+            _vm_mac: "{{ item.mac | default('') | lower }}"
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+          register: _pxe_parallel_ip_results
+
+        - name: Build {vm_name -> ip} map for the parallel batch
+          ansible.builtin.set_fact:
+            _pxe_parallel_ip_map: >-
+              {{ _pxe_parallel_ip_map | default({})
+                 | combine({ (item.item.name | default('pxe-test-' ~ item.item.arch)):
+                             item.ansible_facts._vm_ip }) }}
+          loop: "{{ _pxe_parallel_ip_results.results }}"
+          loop_control:
+            label: "{{ item.item.name | default('pxe-test-' ~ item.item.arch) }}"
+
+        - name: Pause to let iPXE complete its boot attempts (longest effective wait)
+          ansible.builtin.pause:
+            seconds: >-
+              {{ pxe_test_arches
+                 | map(attribute='boot_wait_seconds', default=pxe_test_boot_wait_seconds)
+                 | map('int') | max }}
+
+        - name: Snapshot rb5009 TFTP hits AFTER boot (all)
+          community.routeros.command:
+            commands:
+              - >-
+                /ip tftp print detail without-paging where
+                req-filename="{{ item.binary }}"
+          register: _pxe_tftp_post_all
+          changed_when: false
+          delegate_to: rb5009.igou.systems
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+
+        - name: Assert TFTP hits incremented for each binary
+          ansible.builtin.assert:
+            that:
+              - (_pxe_post_hits | int) > (_pxe_pre_hits | int)
+            fail_msg: >-
+              VM {{ item.0.item.name | default('pxe-test-' ~ item.0.item.arch) }}
+              did not fetch {{ item.0.item.binary }} from rb5009. hits
+              {{ _pxe_pre_hits }} -> {{ _pxe_post_hits }}. Check the VMI
+              status, the DHCP offer to its MAC (`/log print where
+              topics~"dhcp"` on rb5009), and that the matcher table
+              still routes option-93 to the right binary.
+          vars:
+            _pxe_pre_hits: "{{ item.0.stdout[0] | regex_search('hits=\\d+') | default('hits=0') | regex_replace('^hits=', '') | int }}"
+            _pxe_post_hits: "{{ item.1.stdout[0] | regex_search('hits=\\d+') | default('hits=0') | regex_replace('^hits=', '') | int }}"
+          loop: "{{ _pxe_tftp_pre_all.results | zip(_pxe_tftp_post_all.results) | list }}"
+          loop_control:
+            label: "{{ item.0.item.name | default('pxe-test-' ~ item.0.item.arch) }}"
+
+        - name: Verify HTTP fetch for every VM (parallel)
+          ansible.builtin.include_tasks: _verify_http.yml
+          vars:
+            _vm_name_inner: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+            _resolved: "{{ _pxe_resolved_cases | selectattr('name', 'equalto', _vm_name_inner) | first }}"
+            vm_name: "{{ _vm_name_inner }}"
+            vm_mac: "{{ item.mac | default('') | lower }}"
+            vm_ip: "{{ _pxe_parallel_ip_map[_vm_name_inner] }}"
+            expected_fetch_path: "{{ _resolved.expected_fetch_path }}"
+            expected_substring: "{{ _resolved.expected_substring }}"
+            case_start_seconds: "{{ ((lookup('pipe','date -u +%s') | int) - (_pxe_parallel_start_epoch | int)) + 5 }}"
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+
+      always:
+        - name: Delete all test VMs
+          kubernetes.core.k8s:
+            state: absent
+            api_version: kubevirt.io/v1
+            kind: VirtualMachine
+            namespace: "{{ pxe_test_namespace }}"
+            name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+            validate_certs: false
+            wait: true
+            wait_timeout: 120
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+```
+
+Note: the existing parallel block also has a `delegate_to: "{{ pxe_test_router }}"` on the routeros tasks. The default for `pxe_test_router` is `rb5009.igou.systems`. To match the serial-mode style being introduced (literal hostname), use `delegate_to: rb5009.igou.systems` directly. If preserving the var-driven delegate is preferred, swap the literal back — both work.
+
+- [ ] **Step 2: Run the playbook in parallel mode**
+
+```bash
+ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+  -i igou-inventory/inventory.yaml \
+  -e 'pxe_test_parallel=true'
+```
+
+Expected: 4 VMs apply concurrently, all reach Ready, all leases looked up, single 180s pause, both TFTP-hits AND HTTP-verify assertions run for each. All pass. Playbook reports `failed=0`.
+
+- [ ] **Step 3: Re-run in serial mode to confirm no regression**
+
+```bash
+ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+  -i igou-inventory/inventory.yaml
+```
+
+Expected: same end state, sequential per-case execution, all assertions pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
+git commit -m "$(cat <<'EOF'
+test_netboot_pxe: parallel mode asserts HTTP-side fetch per case
+
+Lease lookups happen once per VM after batch Ready, before the long
+pause. The shared --since marker captures the whole window; per-VM-IP
+grep narrows the access log to each case. Same assertions as serial.
+EOF
+)"
+```
+
+---
+
+## Task 9: Lint, end-to-end verification, header-comment update
+
+**Files:**
+- Modify: `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml` (header comment)
+
+- [ ] **Step 1: ansible-lint**
+
+```bash
+ansible-lint --profile=production playbooks/kubevirt/test_netboot_pxe/
+```
+
+Expected: zero errors. Fix any warnings before proceeding.
+
+- [ ] **Step 2: yamllint**
+
+```bash
+yamllint playbooks/kubevirt/test_netboot_pxe/
+```
+
+Expected: zero errors.
+
+- [ ] **Step 3: Update the header comment in `test_netboot_pxe.yml`**
+
+The existing header includes:
+```
+# Iteration 1 scope:
+#   * Verifies the binary fetch via TFTP hit counter delta. Does NOT
+#     verify the iPXE -> TrueNAS chainload; that needs console
+#     scraping, which is intentionally deferred.
+```
+
+Replace this paragraph with:
+
+```
+# Verification (two layers):
+#   * TFTP hit counter on rb5009 increments for the expected binary
+#     (catches DHCP / matcher / TFTP regressions).
+#   * netbootxyz HTTP access log shows the VM's leased IP GET'd the
+#     expected path: /menus/host/MAC-<hexraw>.ipxe for pinned MACs,
+#     /menu.ipxe for random-MAC fall-through cases (catches the
+#     iPXE -> netbootxyz chain regression). Substring assertions on
+#     pinned bodies catch deploy_assets.yml drift.
+#   Per-entry expected_fetch / expected_substring overrides are
+#   honoured when set; otherwise resolved from inventory's
+#   netboot_host_pins (see the vars block + _preflight.yml).
+```
+
+The "Namespace selector label" paragraph and the example-invocation paragraph below it are unchanged.
+
+- [ ] **Step 4: Final end-to-end runs (both modes)**
+
+```bash
+ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+  -i igou-inventory/inventory.yaml
+
+ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+  -i igou-inventory/inventory.yaml \
+  -e 'pxe_test_parallel=true'
+```
+
+Expected: both runs report `failed=0` and `unreachable=0`. The serial run takes ~12 minutes (4 cases × ~3 min each); the parallel run takes ~5 minutes (single 180s pause + setup + assertion phase).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
+git commit -m "$(cat <<'EOF'
+test_netboot_pxe: refresh header comment for headless verification
+
+The 'console scraping intentionally deferred' caveat no longer applies:
+the HTTP access-log assertion replaces it with a headless equivalent.
+EOF
+)"
+```
+
+---
+
+## Self-review summary (against the spec)
+
+**Spec coverage check** (each item in the spec maps to one or more tasks):
+
+- Goal: assert per-host pin / main-menu fetch headlessly → **Tasks 6, 7, 8**.
+- Goal: detect three regression classes (stale pin, no chain, wrong fall-through) → **Task 3** (stale pin via preflight substring), **Task 6** (no chain via positive log assertion), **Task 6** (wrong fall-through via negative `host/MAC-*` assertion).
+- Goal: leave reusable primitives → **Tasks 5 (DHCP lookup), 6 (log grep + uri assertion)**. `mac_to_pin_path` is a pure jinja expression embedded where used (no separate file justified for a one-line transform).
+- Goal: honour block/always cleanup contract → **Task 7** keeps the existing `block:`/`always:` shape; the new HTTP-verify step lives inside `block:` so a failure still tears down via `always:`.
+- Goal: serial AND parallel mode → **Tasks 7 and 8** respectively.
+- Non-goal: boot-flip helper → not implemented; spec is explicit and the plan honours that.
+- Non-goal: fragment-execution proof → not implemented (no virtctl, no probe URL).
+- Non-goal: real-host pin booting → `pxe_test_arches` default unchanged (still only the two smoke pins).
+- Non-goal: inventory schema changes → no edits to `igou-inventory/`.
+- Architecture: preflight + per-case + always-cleanup → reflected in Tasks 2-4 (preflight) + 5-8 (per-case).
+- Test-case schema two new optional fields → introduced in **Task 4** with default + override semantics; substring map default in **Task 3**.
+- Verification primitives 1-4 → primitive 1 (mac→pin path) is inlined as Jinja in Tasks 3 & 4 & 6; primitive 2 (assert_pin_file_served) is the preflight URI step (Task 3) reused by Task 6 substring branch; primitive 3 (DHCP lease lookup) is Task 5; primitive 4 (log grep) is Task 6.
+- Edge cases (container name spike, lease retry budget, log lookback collisions, time skew, 200-but-wrong-body, never-fetched) → Task 1 spike; Task 5 retry config; relative-seconds `--since` in Task 6; preflight substring check in Task 3; negative log assertion in Task 6.
+- Risks (container name unknown, time skew, log rotation, 200-on-default-page, drift) → Task 1, Task 6 (relative since), bounded `pause` (already in playbook), Task 3, Task 3 substring.
+- Testing strategy (4 default cases pass, rename-pin-file, corrupt body, stop nbxyz, idempotent re-runs, lints) → Tasks 7 step 3 (rename), Task 3 step 5 (corrupt-body via substring override), Task 2 step 4 (down service), Tasks 7 step 2 + 8 step 3 (re-runs), Task 9 (lints).
+
+**Placeholder scan:** none. Each step has the actual file content, the actual command, and the expected output.
+
+**Type/identifier consistency check:**
+- Fact names: `_pxe_preflight_menu`, `_pxe_preflight_bodies`, `_pxe_pinned_macs`, `_pxe_preflight_pin_macs`, `_pxe_preflight_pin_results`, `_pxe_resolved_cases`, `_pxe_tftp_pre`, `_pxe_tftp_post`, `_pxe_hits_pre`, `_pxe_hits_post`, `_case_start_epoch`, `_pxe_parallel_start_epoch`, `_pxe_parallel_ip_map`, `_pxe_parallel_ip_results`, `_pxe_lease_query`, `_pxe_nbxyz_logs`, `_pxe_fetched_paths`, `_pxe_served_body`, `_pxe_fresh_body`, `_vm_name`, `_vm_mac`, `_vm_ip`, `_resolved`, `_wait`. Cross-referenced across tasks; all consistent.
+- Resolved-case fields: `name`, `arch`, `binary`, `mac`, `has_mac`, `is_pinned`, `expected_fetch_path`, `expected_substring`. Used identically in Tasks 4, 7, 8.
+- Body cache key scheme: `'menu'` for menu.ipxe; `'pin:' ~ vm_mac` (lowercase MAC with colons) for per-host pins. Consistent across Tasks 2, 3, 6.
+- Path constant: `/menus/host/MAC-<hexraw>.ipxe` — produced identically in Tasks 3 (URL fetch), 4 (resolution), 6 (negative assert regex anchor).
+
+If any inconsistency surfaces during execution, fix it inline rather than mid-stream restructuring the plan.

--- a/docs/superpowers/plans/2026-05-09-test-netboot-pxe-headless.md
+++ b/docs/superpowers/plans/2026-05-09-test-netboot-pxe-headless.md
@@ -246,7 +246,7 @@ DELETE both, then APPEND in their place:
     path: "/mnt/ssd/containers/netbootxyz/config/menus/host"
     state: directory
     mode: '0755'
-  delegate_to: "{{ netbootxyz_host }}"
+  delegate_to: "{{ groups[netbootxyz_host][0] }}"
   become: true
 
 - name: Preflight -- deploy each smoke pin from inventory to /config/menus/host/
@@ -254,7 +254,7 @@ DELETE both, then APPEND in their place:
     content: "{{ (netboot_host_pins | selectattr('mac', 'equalto', item) | first).fragment }}"
     dest: "/mnt/ssd/containers/netbootxyz/config/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe"
     mode: '0644'
-  delegate_to: "{{ netbootxyz_host }}"
+  delegate_to: "{{ groups[netbootxyz_host][0] }}"
   become: true
   loop: "{{ _pxe_preflight_pin_macs }}"
   loop_control:
@@ -267,7 +267,7 @@ DELETE both, then APPEND in their place:
       cat /config/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe
   register: _pxe_preflight_pin_readback
   changed_when: false
-  delegate_to: "{{ netbootxyz_host }}"
+  delegate_to: "{{ groups[netbootxyz_host][0] }}"
   become: true
   loop: "{{ _pxe_preflight_pin_macs }}"
   loop_control:
@@ -489,7 +489,7 @@ Write with this exact content:
       | grep dnsmasq-tftp || true
   register: _pxe_log_slice
   changed_when: false
-  delegate_to: "{{ netbootxyz_host }}"
+  delegate_to: "{{ groups[netbootxyz_host][0] }}"
   become: true
 
 - name: "Parse dnsmasq-tftp lines for {{ vm_name }} (sent pattern)"
@@ -637,7 +637,7 @@ Open `_arch_test.yml` and replace its entire contents with:
         cmd: docker logs ix-netbootxyz-netbootxyz-1 2>&1 | wc -l
       register: _pxe_log_pre
       changed_when: false
-      delegate_to: "{{ netbootxyz_host }}"
+      delegate_to: "{{ groups[netbootxyz_host][0] }}"
       become: true
 
     - name: "Capture pre log line count for {{ _vm_name }}"
@@ -799,7 +799,7 @@ Locate the block named `Smoke-test architectures in parallel` (`when: pxe_test_p
             cmd: docker logs ix-netbootxyz-netbootxyz-1 2>&1 | wc -l
           register: _pxe_log_pre_parallel
           changed_when: false
-          delegate_to: "{{ netbootxyz_host }}"
+          delegate_to: "{{ groups[netbootxyz_host][0] }}"
           become: true
 
         - name: Capture pre log line count (parallel mode, shared)

--- a/docs/superpowers/plans/2026-05-09-test-netboot-pxe-headless.md
+++ b/docs/superpowers/plans/2026-05-09-test-netboot-pxe-headless.md
@@ -114,7 +114,6 @@ Write the file with this exact content:
     url: "{{ netbootxyz_self_url }}/"
     status_code: 200
     timeout: 10
-  register: _pxe_preflight_root
   delegate_to: localhost
   changed_when: false
 ```
@@ -1028,7 +1027,7 @@ EOF
 **Placeholder scan:** none.
 
 **Identifier consistency:**
-- Fact names: `_pxe_preflight_root`, `_pxe_pinned_macs`, `_pxe_preflight_pin_macs`, `_pxe_preflight_pin_results`, `_pxe_tftp_pre`, `_pxe_tftp_post`, `_pxe_hits_pre`, `_pxe_hits_post`, `_pxe_log_pre`, `_pre_log_line_count`, `_pxe_log_pre_parallel`, `_pre_log_line_count_parallel`, `_pxe_log_slice`, `_pxe_parsed_lines`, `_pxe_vm_lines`, `_pxe_expected_path`, `_pxe_matching_lines`, `_pxe_lease_query`, `_pxe_vmi_result`, `_pxe_parallel_addr_results`, `_pxe_parallel_addr_map`, `_vm_name`, `_vm_mac`, `_vm_ip`, `_wait`. All consistent across tasks.
+- Fact names: `_pxe_pinned_macs`, `_pxe_preflight_pin_macs`, `_pxe_preflight_pin_results`, `_pxe_tftp_pre`, `_pxe_tftp_post`, `_pxe_hits_pre`, `_pxe_hits_post`, `_pxe_log_pre`, `_pre_log_line_count`, `_pxe_log_pre_parallel`, `_pre_log_line_count_parallel`, `_pxe_log_slice`, `_pxe_parsed_lines`, `_pxe_vm_lines`, `_pxe_expected_path`, `_pxe_matching_lines`, `_pxe_lease_query`, `_pxe_vmi_result`, `_pxe_parallel_addr_results`, `_pxe_parallel_addr_map`, `_vm_name`, `_vm_mac`, `_vm_ip`, `_wait`. All consistent across tasks.
 - `_dhcp_lease_lookup.yml` outputs `_vm_mac` and `_vm_ip` as facts; both serial (Task 6) and parallel (Task 7) consume identically.
 - `_verify_http.yml` inputs: `vm_name`, `vm_mac`, `vm_ip`, `expected_status`, `pre_log_line_count`. Used identically in serial and parallel call sites.
 - Path constant: `/menus/host/MAC-<hexraw>.ipxe` — produced identically in Tasks 3 (URL fetch), 5 (computed expectation).

--- a/docs/superpowers/plans/2026-05-09-test-netboot-pxe-headless.md
+++ b/docs/superpowers/plans/2026-05-09-test-netboot-pxe-headless.md
@@ -2,38 +2,52 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Extend `playbooks/kubevirt/test_netboot_pxe/` so each smoke-test VM verifies — without console scraping — that the netbootxyz HTTP server served the *expected* file (per-host pin or main menu) to the VM's leased IP.
+**Goal:** Extend `playbooks/kubevirt/test_netboot_pxe/` so each smoke-test VM verifies — without console scraping — that the netbootxyz nginx access log shows the expected per-host HTTP request (200 if the MAC is pinned, 404 if it isn't).
 
-**Architecture:** Add a preflight stage that statically validates netbootxyz HTTP reachability and smoke-pin file content, plus computes per-case `expected_fetch_path` / `expected_substring` from inventory's `netboot_host_pins`. Add per-case HTTP-side verification that correlates the VM's leased IP (queried from rb5009 DHCP) against new lines in the netbootxyz container access log. Two new shared task files keep serial and parallel orchestration paths DRY.
+**Architecture:** Preflight stage validates netbootxyz HTTP reachability and pinned-MAC pin-file content (substring check). Per-case verification snapshots the nginx access log line count before the VM boots, reads the VMI to learn the actual MAC, queries rb5009 for the leased IP, and asserts that exactly one new access log line shows `GET /menus/host/MAC-<hexraw>.ipxe` with the expected status (200 or 404) from the VM's IP. Two new shared task files (`_dhcp_lease_lookup.yml`, `_verify_http.yml`) keep serial and parallel paths DRY.
 
-**Tech Stack:** Ansible (kubernetes.core, community.routeros, ansible.builtin.uri), `podman logs` over the existing TrueNAS SSH connection, RouterOS DHCP API.
+**Tech Stack:** Ansible (kubernetes.core, community.routeros, ansible.builtin.uri/command), `docker exec` over the existing TrueNAS SSH connection, RouterOS DHCP lease API.
 
 ---
 
 ## Reference material
 
-- **Spec:** `docs/superpowers/specs/2026-05-09-test-netboot-pxe-headless-design.md` — read this first; it explains every design decision.
+- **Spec:** `docs/superpowers/specs/2026-05-09-test-netboot-pxe-headless-design.md` — read this first.
 - **Existing playbook tree:** `playbooks/kubevirt/test_netboot_pxe/{test_netboot_pxe.yml,_arch_test.yml,vm.yaml.j2}`.
-- **Inventory:** `igou-inventory/group_vars/all/netboot.yml` defines `netboot_host_pins`, `netbootxyz_host`, `netbootxyz_self_url`. `netboot_host_pins` is **read-only** from this plan's perspective — do not modify it.
-- **Smoke pin fragments to assert against** (already in inventory):
+- **Inventory:** `igou-inventory/group_vars/all/netboot.yml` defines `netboot_host_pins`, `netbootxyz_host`, `netbootxyz_self_url`. **Read-only** from this plan's perspective.
+- **Smoke pin fragment substrings already in inventory:**
   - MAC `02:00:00:50:58:01` body contains literal `=== pxe-test smoke pin: bios`
   - MAC `02:00:00:50:58:02` body contains literal `=== pxe-test smoke pin: uefi-x64`
-- **Inventory file path:** `igou-inventory/inventory.yaml`. All commands assume CWD is the repo root.
+- **Inventory file path:** `igou-inventory/inventory.yaml`. All commands assume CWD is `/workspace/igou-ansible`.
+
+## Spike outcome (Task 1, completed 2026-05-09)
+
+These three values are the only outputs of the spike. They are referenced verbatim in Task 5.
+
+```
+runtime         = docker            (TrueNAS SCALE uses Docker, not podman)
+container_name  = ix-netbootxyz-netbootxyz-1   (TrueCharts naming)
+access_log_path = /config/log/nginx/access.log (inside the container)
+read_strategy   = wc -l snapshot before; tail -n +<N> after
+                  (nginx logs to a file, not stdout — `docker logs` only
+                  carries dnsmasq-tftp lines, not nginx access lines)
+http_root_probe = GET netbootxyz_self_url/ → 200 (asset root index;
+                  /menu.ipxe is NOT HTTP-served — that's TFTP)
+```
 
 ## Conventions
 
-- **Run commands from:** repository root `/workspace/igou-ansible`.
+- **Run from:** `/workspace/igou-ansible`.
 - **Run-the-playbook command:** `ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml -i igou-inventory/inventory.yaml`.
 - **Linters:** `ansible-lint --profile=production playbooks/kubevirt/test_netboot_pxe/` and `yamllint playbooks/kubevirt/test_netboot_pxe/`.
-- **YAML style** (matches the rest of the repo and the existing files in this tree):
+- **YAML style** (matches the rest of the repo):
   - `---` at file top, 2-space indent.
   - YAML 1.2 booleans (`true`/`false`).
-  - `gather_facts: false` on plays.
-  - Fact names prefixed `_pxe_…` to scope them; transient block-local vars use leading `_` plus a short name.
-  - Tasks named with imperative phrasing; per-loop labels via `loop_control: { label: "<name>" }`.
-- **Connection assumptions** (already configured by group_vars and used by the existing playbook):
-  - `rb5009.igou.systems` — RouterOS over the `community.routeros.*` collection. The existing TFTP-hits step works; reuse the same `delegate_to`.
-  - `truenas` — SSH with `become: true` available. Other playbooks in `playbooks/truenas/` use the same connection.
+  - Fact names prefixed `_pxe_…` to scope them.
+- **Connection assumptions** (already configured by group_vars):
+  - `rb5009.igou.systems` — `community.routeros.*` works (existing TFTP-hits step proves it).
+  - `truenas` — SSH with `become: true` works (existing `playbooks/truenas/*` use it).
+- **Each task ends with a commit.**
 
 ## Files Created/Modified/Deleted
 
@@ -48,95 +62,21 @@
 
 **Delete:** none.
 
-## Pre-flight assumptions (verify before Task 1)
+## Pre-flight assumptions
 
-- `KUBECONFIG` is set in the environment and points at the OpenShift cluster (the existing playbook already depends on this).
-- The user can connect to `rb5009.igou.systems` and `truenas` from the current shell using the existing inventory (validated by running the existing playbook end-to-end first).
-- Static DHCP leases on rb5009 already exist for MACs `02:00:00:50:58:01` and `02:00:00:50:58:02` (referenced in the existing playbook header comment as "matches static DHCP leases on rb5009"). Random-MAC test cases will get dynamic leases from the pool.
-- `playbooks/netboot/deploy_assets.yml` has been run recently enough that the rendered `host/MAC-020000505801.ipxe` and `host/MAC-020000505802.ipxe` files exist on the TrueNAS netbootxyz container with bodies containing the smoke pin substrings above.
+Verify before Task 2:
 
-If any of these are not true, stop and surface it before starting Task 1.
+- `KUBECONFIG` is set; `ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml -i igou-inventory/inventory.yaml` runs the existing playbook end-to-end successfully (4 cases pass on TFTP-hits assertions). If this is broken, fix it BEFORE adding new assertions.
+- `playbooks/netboot/deploy_assets.yml` has been run recently enough that the rendered `host/MAC-020000505801.ipxe` and `host/MAC-020000505802.ipxe` files exist on the TrueNAS netbootxyz container with bodies containing the smoke pin substrings.
+- Static DHCP leases on rb5009 already exist for MACs `02:00:00:50:58:01` and `02:00:00:50:58:02` (referenced in the existing playbook header).
+
+If any of these is not true, surface it before starting Task 2.
 
 ---
 
-## Task 1: Spike — confirm netbootxyz container name and log driver on truenas
+## Task 1: Spike — DONE
 
-This unblocks Task 5 (`_verify_http.yml`). The spec calls for documenting the spike outcome as a header comment in `_verify_http.yml`.
-
-**Files:**
-- Create: none yet.
-- Modify: none yet.
-- Output: a short note recorded in this plan's task body for downstream tasks to reference.
-
-- [ ] **Step 1: Identify the running netbootxyz container on truenas**
-
-Run:
-```bash
-ansible truenas -i igou-inventory/inventory.yaml -m ansible.builtin.command \
-  -a 'podman ps --format "{{ "{{" }}.Names{{ "}}" }}\t{{ "{{" }}.Image{{ "}}" }}"' \
-  -b
-```
-
-Expected: one row whose Image is something like `lscr.io/linuxserver/netbootxyz` (or the equivalent linuxserver image used in the TrueNAS app deployment). Capture the value from the Names column — call it `<NBXYZ_CTR>`. Common value: `netbootxyz`.
-
-If multiple matches or zero matches: stop and surface this — the deployment is not in the expected shape.
-
-- [ ] **Step 2: Inspect the log driver**
-
-Run:
-```bash
-ansible truenas -i igou-inventory/inventory.yaml -m ansible.builtin.command \
-  -a 'podman inspect <NBXYZ_CTR> --format "{{ "{{" }}.HostConfig.LogConfig.Type{{ "}}" }}"' \
-  -b
-```
-
-(Replace `<NBXYZ_CTR>` with the value from Step 1.)
-
-Expected output: `k8s-file` or `journald` or `json-file`. Any of these are fine — `podman logs` works against all three.
-
-If the output is `none`: stop. The container was started with logging disabled and `podman logs` cannot read access lines.
-
-- [ ] **Step 3: Confirm nginx access lines reach `podman logs`**
-
-Run:
-```bash
-ansible truenas -i igou-inventory/inventory.yaml -m ansible.builtin.command \
-  -a 'podman logs --tail=20 <NBXYZ_CTR>' \
-  -b
-```
-
-Expected: nginx access lines visible, format roughly:
-```
-<source_ip> - - [<timestamp>] "GET /menu.ipxe HTTP/1.1" 200 1234 "-" "iPXE/..."
-```
-
-If the output contains no nginx access lines (only s6-overlay startup messages): stop. The image is configured to log access to a file rather than stdout. Document the file path and switch the strategy in Task 5 to `cat <log_path>` over SSH; otherwise the rest of the plan stands.
-
-- [ ] **Step 4: Hit the HTTP root once and confirm a fresh access line appears**
-
-Run (from the test-runner shell):
-```bash
-curl -sf http://10.10.45.242/menu.ipxe > /dev/null && echo OK
-```
-
-Then re-run the `podman logs --tail=20` from Step 3. Expected: a new access line for the test-runner's source IP fetching `/menu.ipxe`.
-
-- [ ] **Step 5: Record findings**
-
-Add a single-line comment to the top of this task's local notes:
-
-```
-SPIKE OUTCOME (2026-05-09):
-  container_name = <NBXYZ_CTR>          # e.g. "netbootxyz"
-  log_driver     = <log_driver>          # k8s-file | journald | json-file
-  access_log_via = podman_logs           # confirmed nginx access lines appear in `podman logs`
-```
-
-These three values will be embedded as a comment block in `_verify_http.yml` in Task 5. Carry them forward.
-
-- [ ] **Step 6: No commit for this task**
-
-This is a read-only investigation. Nothing to commit yet.
+The spike completed on 2026-05-09. Outcomes are recorded in the "Spike outcome" section at the top of this plan and embedded into `_verify_http.yml` in Task 5. **No further action.**
 
 ---
 
@@ -158,47 +98,30 @@ Write the file with this exact content:
 # top of test_netboot_pxe.yml, before any VM is applied.
 #
 # Stages (each gated on the previous):
-#   1. HTTP-probe netbootxyz_self_url/menu.ipxe -- fail fast if down.
-#   2. (Task 3) Build the set of pinned MACs from netboot_host_pins,
+#   1. HTTP-probe netbootxyz_self_url/ (the asset root) -- fails fast
+#      if nginx is down. NB: /menu.ipxe is NOT HTTP-served in this
+#      deployment; iPXE TFTP-fetches it from the netbootxyz container's
+#      built-in dnsmasq.
+#   2. (Task 3) Build set of pinned MACs from netboot_host_pins,
 #      HTTP-fetch every smoke pin file referenced by pxe_test_arches,
-#      and assert each body contains the expected substring.
-#   3. (Task 4) Resolve expected_fetch_path / expected_substring per
-#      pxe_test_arches entry into _pxe_resolved_cases.
+#      assert each body contains its expected substring, cache bodies.
 #
-# All preflight tasks are delegate_to: localhost -- no TrueNAS or rb5009
+# All preflight tasks delegate_to: localhost -- no TrueNAS or rb5009
 # contact at this stage.
 
-- name: Preflight -- netbootxyz HTTP root is reachable and serving menu.ipxe
+- name: Preflight -- netbootxyz HTTP root is reachable
   ansible.builtin.uri:
-    url: "{{ netbootxyz_self_url }}/menu.ipxe"
-    return_content: true
+    url: "{{ netbootxyz_self_url }}/"
     status_code: 200
     timeout: 10
-  register: _pxe_preflight_menu
+  register: _pxe_preflight_root
   delegate_to: localhost
   changed_when: false
-
-- name: Preflight -- assert menu.ipxe body looks like an iPXE script
-  ansible.builtin.assert:
-    that:
-      - _pxe_preflight_menu.content is defined
-      - _pxe_preflight_menu.content.startswith('#!ipxe')
-    fail_msg: >-
-      {{ netbootxyz_self_url }}/menu.ipxe responded 200 but the body did
-      not start with '#!ipxe'. Either nginx is fronting a default page
-      because the netbootxyz container's /config/menus/ is empty, or
-      playbooks/netboot/deploy_assets.yml has never been run on this
-      host. First 200 chars of body: {{ _pxe_preflight_menu.content[:200] }}
-
-- name: Preflight -- cache menu.ipxe body for later substring checks
-  ansible.builtin.set_fact:
-    _pxe_preflight_bodies:
-      menu: "{{ _pxe_preflight_menu.content }}"
 ```
 
 - [ ] **Step 2: Wire `_preflight.yml` into `test_netboot_pxe.yml`**
 
-Modify `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`. Locate the `tasks:` block (after the `vars:` block, around the comment `# --- Pre-flight (idempotent, never destructive) -----`). Insert the new include as the **first** task in `tasks:`, before the existing CUDN read:
+Modify `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`. Locate the `tasks:` block. Insert the include as the **first** task in `tasks:`, before the existing CUDN read:
 
 ```yaml
   tasks:
@@ -211,21 +134,20 @@ Modify `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`. Locate the `t
       ...
 ```
 
-The existing CUDN-read block stays exactly where it is; only a new include is inserted above it.
+The existing CUDN-read block stays exactly where it is.
 
-- [ ] **Step 3: Run the playbook end-to-end and confirm the new preflight runs**
+- [ ] **Step 3: Run the playbook end-to-end and confirm preflight runs**
 
-Run:
 ```bash
 ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -i igou-inventory/inventory.yaml
 ```
 
-Expected: the first task to print is `Preflight -- netbootxyz HTTP root is reachable and serving menu.ipxe`. The full playbook should still pass end-to-end (TFTP-hits checks behave the same as before).
+Expected: the first task is `Preflight -- netbootxyz HTTP root is reachable`. The full playbook still passes end-to-end (TFTP-hits checks unchanged).
 
 - [ ] **Step 4: Demonstrate the failure mode**
 
-Run a one-off invocation with a deliberately broken `netbootxyz_self_url` to confirm the preflight catches a down service:
+Override `netbootxyz_self_url` to a known-bad URL:
 
 ```bash
 ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
@@ -233,7 +155,7 @@ ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -e 'netbootxyz_self_url=http://127.0.0.1:1'
 ```
 
-Expected: the `Preflight -- netbootxyz HTTP root is reachable...` task fails with a connection error. No VM is applied. The playbook exits with a non-zero return code.
+Expected: the preflight task fails with a connection error. No VMs applied. Non-zero return code.
 
 - [ ] **Step 5: Commit**
 
@@ -243,16 +165,19 @@ git add playbooks/kubevirt/test_netboot_pxe/_preflight.yml \
 git commit -m "$(cat <<'EOF'
 test_netboot_pxe: add preflight HTTP probe of netbootxyz_self_url
 
-Fails fast if netbootxyz is down before any VM is applied. First step
-of the headless verification design (see
+Fails fast if nginx is down before any VM is applied. First step of
+the headless verification design (see
 docs/superpowers/specs/2026-05-09-test-netboot-pxe-headless-design.md).
+
+The probe targets the asset root (/), not /menu.ipxe -- the latter is
+served via TFTP, not HTTP, in this deployment.
 EOF
 )"
 ```
 
 ---
 
-## Task 3: Preflight — pin lookup + smoke-pin substring assertions
+## Task 3: Preflight — pinned-MAC set + smoke-pin substring assertions
 
 **Files:**
 - Modify: `playbooks/kubevirt/test_netboot_pxe/_preflight.yml`
@@ -260,20 +185,22 @@ EOF
 
 - [ ] **Step 1: Add the substring defaults map to the playbook vars**
 
-Modify `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`. In the `vars:` block, just below `pxe_test_parallel: false` and above the `pxe_test_arches:` list comment, insert:
+In `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`, in the `vars:` block, just below `pxe_test_parallel: false` and above the `pxe_test_arches:` list comment, insert:
 
 ```yaml
     # Default substring to grep for in each smoke pin's served body,
-    # keyed by lowercase MAC. Per-entry expected_substring (Task 4)
-    # overrides; an unmapped MAC defaults to no substring check.
+    # keyed by lowercase MAC. Drives only the preflight static check;
+    # per-case substring assertion is dropped because preflight already
+    # validates the body. Adding a new pinned smoke entry?  Add the
+    # MAC -> substring pair here.
     pxe_test_substring_defaults:
       "02:00:00:50:58:01": "=== pxe-test smoke pin: bios"
       "02:00:00:50:58:02": "=== pxe-test smoke pin: uefi-x64"
 ```
 
-- [ ] **Step 2: Extend `_preflight.yml` with the pin lookup**
+- [ ] **Step 2: Extend `_preflight.yml` with pinned-MAC discovery**
 
-Append the following after the existing `_pxe_preflight_bodies` set_fact in `_preflight.yml`:
+Append to `_preflight.yml`:
 
 ```yaml
 - name: Preflight -- build set of pinned MACs (lowercase) from inventory
@@ -286,7 +213,7 @@ Append the following after the existing `_pxe_preflight_bodies` set_fact in `_pr
          | map('lower')
          | list }}
 
-- name: Preflight -- collect smoke-pin MACs referenced by pxe_test_arches that resolve to a pin
+- name: Preflight -- collect pinned MACs referenced by pxe_test_arches
   ansible.builtin.set_fact:
     _pxe_preflight_pin_macs: >-
       {{ pxe_test_arches
@@ -300,7 +227,7 @@ Append the following after the existing `_pxe_preflight_bodies` set_fact in `_pr
 
 - [ ] **Step 3: Append the per-pin HTTP fetch + substring assertion**
 
-Append (still in `_preflight.yml`) the loop that fetches each pin file and asserts its substring:
+Append to `_preflight.yml`:
 
 ```yaml
 - name: Preflight -- fetch each smoke pin file from netbootxyz
@@ -332,15 +259,6 @@ Append (still in `_preflight.yml`) the loop that fetches each pin file and asser
   loop: "{{ _pxe_preflight_pin_results.results }}"
   loop_control:
     label: "MAC-{{ item.item | regex_replace(':', '') }}.ipxe"
-
-- name: Preflight -- cache pin bodies keyed by lowercase MAC for per-case re-use
-  ansible.builtin.set_fact:
-    _pxe_preflight_bodies: >-
-      {{ _pxe_preflight_bodies
-         | combine({ ('pin:' ~ item.item): item.content }) }}
-  loop: "{{ _pxe_preflight_pin_results.results }}"
-  loop_control:
-    label: "MAC-{{ item.item | regex_replace(':', '') }}.ipxe"
 ```
 
 - [ ] **Step 4: Run the playbook and verify preflight passes**
@@ -350,11 +268,11 @@ ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -i igou-inventory/inventory.yaml
 ```
 
-Expected: the new preflight tasks run successfully, fetching two pin files and asserting their bodies contain the expected substrings. The rest of the playbook (TFTP-hits checks) still passes.
+Expected: the new preflight tasks fetch two pin files and assert their bodies contain the expected substrings. Rest of the playbook still passes.
 
 - [ ] **Step 5: Demonstrate the failure mode**
 
-Override the substring map to a value that won't appear in the pin body, to confirm the assertion fires:
+Override the substring defaults to values that won't appear:
 
 ```bash
 ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
@@ -362,7 +280,7 @@ ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -e '{"pxe_test_substring_defaults": {"02:00:00:50:58:01": "DEFINITELY-NOT-IN-THE-BODY", "02:00:00:50:58:02": "DEFINITELY-NOT-IN-THE-BODY"}}'
 ```
 
-Expected: the `Preflight -- assert each smoke pin body...` task fails for both pins. No VMs applied.
+Expected: the substring assertion fails for both pins. No VMs applied.
 
 - [ ] **Step 6: Commit**
 
@@ -374,141 +292,67 @@ test_netboot_pxe: preflight asserts smoke pin bodies on netbootxyz
 
 Per-MAC substring map catches inventory drift -- if netboot_host_pins
 is updated but deploy_assets.yml is not re-run, preflight fails before
-any VM is applied. Bodies are cached for per-case re-use (Task 5).
+any VM is applied. Pinned-MAC set is also derived here for the per-
+case 200-vs-404 classifier (Task 6).
 EOF
 )"
 ```
 
 ---
 
-## Task 4: Preflight — resolve `expected_fetch_path` / `expected_substring` per case
-
-**Files:**
-- Modify: `playbooks/kubevirt/test_netboot_pxe/_preflight.yml`
-
-- [ ] **Step 1: Append the per-case resolution to `_preflight.yml`**
-
-Append at the end of `_preflight.yml`:
-
-```yaml
-- name: Preflight -- resolve expected_fetch_path and expected_substring per pxe_test_arches entry
-  ansible.builtin.set_fact:
-    _pxe_resolved_cases: "{{ _pxe_resolved_cases | default([]) + [_resolved] }}"
-  vars:
-    _name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
-    _mac_raw: "{{ item.mac | default('') }}"
-    _mac: "{{ _mac_raw | lower }}"
-    _has_mac: "{{ _mac_raw | length > 0 }}"
-    _is_pinned: "{{ _has_mac and _mac in _pxe_pinned_macs }}"
-    _hexraw: "{{ _mac | regex_replace(':', '') }}"
-    _pin_path: "/menus/host/MAC-{{ _hexraw }}.ipxe"
-    _mode: "{{ item.expected_fetch | default('auto') }}"
-    _expected_fetch_path: >-
-      {%- if _mode == 'auto' -%}
-      {{ _pin_path if _is_pinned else '/menu.ipxe' }}
-      {%- elif _mode == 'host_pin' -%}
-      {{ _pin_path }}
-      {%- elif _mode == 'menu' -%}
-      /menu.ipxe
-      {%- else -%}
-      {{ _mode }}
-      {%- endif -%}
-    _default_substring: "{{ pxe_test_substring_defaults[_mac] | default('') if _is_pinned else '' }}"
-    _resolved:
-      name: "{{ _name }}"
-      arch: "{{ item.arch }}"
-      binary: "{{ item.binary }}"
-      mac: "{{ _mac }}"
-      has_mac: "{{ _has_mac }}"
-      is_pinned: "{{ _is_pinned }}"
-      expected_fetch_path: "{{ _expected_fetch_path | trim }}"
-      expected_substring: "{{ item.expected_substring | default(_default_substring) }}"
-  loop: "{{ pxe_test_arches }}"
-  loop_control:
-    label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
-
-- name: Preflight -- assert host_pin mode entries declare a MAC
-  ansible.builtin.assert:
-    that:
-      - item.has_mac
-    fail_msg: >-
-      pxe_test_arches entry '{{ item.name }}' specifies expected_fetch:
-      host_pin but no mac. host_pin mode requires a MAC so the per-host
-      pin path can be computed.
-  loop: "{{ _pxe_resolved_cases }}"
-  loop_control:
-    label: "{{ item.name }}"
-  when: item.expected_fetch_path is search('/menus/host/MAC-')
-
-- name: Preflight -- print resolved test cases (for visibility)
-  ansible.builtin.debug:
-    msg: "{{ item.name }}: fetch={{ item.expected_fetch_path }} substring='{{ item.expected_substring }}'"
-  loop: "{{ _pxe_resolved_cases }}"
-  loop_control:
-    label: "{{ item.name }}"
-```
-
-- [ ] **Step 2: Run the playbook; verify resolution**
-
-```bash
-ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
-  -i igou-inventory/inventory.yaml
-```
-
-Expected `debug` output (exact paths, hexraw lowercase, no separators):
-
-```
-pxe-test-bios-random:        fetch=/menu.ipxe                                      substring=''
-pxe-test-bios-pinned:        fetch=/menus/host/MAC-020000505801.ipxe                substring='=== pxe-test smoke pin: bios'
-pxe-test-uefi-x64-random:    fetch=/menu.ipxe                                      substring=''
-pxe-test-uefi-x64-pinned:    fetch=/menus/host/MAC-020000505802.ipxe                substring='=== pxe-test smoke pin: uefi-x64'
-```
-
-Whitespace alignment doesn't matter; the values do. If any value is wrong, the resolution logic is broken — fix and re-run before commit.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add playbooks/kubevirt/test_netboot_pxe/_preflight.yml
-git commit -m "$(cat <<'EOF'
-test_netboot_pxe: preflight resolves expected fetch path per case
-
-Each pxe_test_arches entry resolves to {expected_fetch_path,
-expected_substring} from its mac + inventory's netboot_host_pins, with
-mode override (auto|host_pin|menu|<literal>). Resolution is the input
-to the per-case HTTP assertion added in later tasks.
-EOF
-)"
-```
-
----
-
-## Task 5: Add `_dhcp_lease_lookup.yml` — VM IP from rb5009
+## Task 4: Add `_dhcp_lease_lookup.yml` — VMI MAC + rb5009 DHCP lease IP
 
 **Files:**
 - Create: `playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml`
 
 - [ ] **Step 1: Create the file**
 
-Write the file with this exact content:
+Write with this exact content:
 
 ```yaml
 ---
-# Look up a VM's leased IP from rb5009's DHCP server, given its MAC.
-# Polls up to 30s (5s interval) -- iPXE's DHCP exchange can lag VMI
-# Ready by a few seconds, especially in parallel mode where multiple
-# discovers race the rb5009 DHCP daemon.
+# Resolve a VM's MAC and IP for the headless smoke test.
+#
+# Step A reads the VirtualMachineInstance to learn the MAC. KubeVirt
+# fills .spec.domain.devices.interfaces[].macAddress in regardless of
+# whether the test fixture pinned a MAC or asked KubeVirt to generate
+# one -- so this works for both pinned and random cases.
+#
+# Step B queries rb5009 for the DHCP lease for that MAC. Up to 30s of
+# retry budget because iPXE's DHCP exchange can lag VMI Ready by a few
+# seconds, especially in parallel mode.
 #
 # Inputs (task vars expected on caller):
-#   _vm_name   for the loop label / failure message
-#   _vm_mac    MAC to query, any case, with-or-without separators
+#   _vm_name   for messages and loop labels
+#   pxe_test_namespace -- already a play-level var
 #
-# Outputs:
-#   _vm_ip     populated with the IP string (e.g. "10.10.9.42")
+# Outputs (set as facts):
+#   _vm_mac    lowercase, with colons (e.g. "02:00:00:50:58:01")
+#   _vm_ip     dotted-quad string (e.g. "10.10.9.42")
 #
-# Failure mode: if no lease appears within 30s, fails with a network-
-# layer-flavoured message that does NOT confuse the failure with a
+# Failure modes are distinct: an unreadable VMI fails on Step A with a
+# k8s-flavoured message; a missing DHCP lease fails on Step C with a
+# network-layer-flavoured message. Neither is confused with a
 # netbootxyz problem.
+
+- name: "Read VirtualMachineInstance for {{ _vm_name }} to learn its MAC"
+  kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
+    kind: VirtualMachineInstance
+    namespace: "{{ pxe_test_namespace }}"
+    name: "{{ _vm_name }}"
+    validate_certs: false
+  register: _pxe_vmi_result
+  retries: 6
+  delay: 5
+  until:
+    - _pxe_vmi_result.resources | length == 1
+    - _pxe_vmi_result.resources[0].spec.domain.devices.interfaces | default([]) | length > 0
+    - _pxe_vmi_result.resources[0].spec.domain.devices.interfaces[0].macAddress is defined
+
+- name: "Set _vm_mac fact for {{ _vm_name }}"
+  ansible.builtin.set_fact:
+    _vm_mac: "{{ _pxe_vmi_result.resources[0].spec.domain.devices.interfaces[0].macAddress | lower }}"
 
 - name: "Wait for {{ _vm_name }} DHCP lease (MAC {{ _vm_mac }})"
   community.routeros.command:
@@ -533,14 +377,12 @@ Write the file with this exact content:
       - _vm_ip is defined
       - _vm_ip | length > 0
     fail_msg: >-
-      VM {{ _vm_name }} (MAC {{ _vm_mac }}) appears to have a lease entry
-      on rb5009 but no address= field could be parsed. Raw output:
+      VM {{ _vm_name }} (MAC {{ _vm_mac }}) appears to have a lease
+      entry on rb5009 but no address= field could be parsed. Raw:
       {{ _pxe_lease_query.stdout[0] }}
 ```
 
-- [ ] **Step 2: Stand-alone smoke test by running the existing playbook tasks once**
-
-This file has no callers yet (those come in Tasks 7-8). The smoke check is just `yamllint` for now:
+- [ ] **Step 2: yamllint**
 
 ```bash
 yamllint playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
@@ -555,29 +397,23 @@ git add playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
 git commit -m "$(cat <<'EOF'
 test_netboot_pxe: add _dhcp_lease_lookup helper
 
-Polls rb5009 for the VM's DHCP lease (MAC -> IP), 30s budget. Wired
-in by Task 7 (serial) and Task 8 (parallel) of the headless plan.
+Reads the VMI to learn the MAC (works for both pinned and KubeVirt-
+generated cases), then polls rb5009 for the DHCP lease IP. 30s budget.
+Wired in by Tasks 6 (serial) and 7 (parallel).
 EOF
 )"
 ```
 
 ---
 
-## Task 6: Add `_verify_http.yml` — log grep + per-case HTTP assertions
+## Task 5: Add `_verify_http.yml` — nginx access-log slice + status-code assertion
 
 **Files:**
 - Create: `playbooks/kubevirt/test_netboot_pxe/_verify_http.yml`
 
-This file uses three values from the Task 1 spike:
-- `<NBXYZ_CTR>` — the netbootxyz container name on truenas. Substitute literally; do not parametrise unless other playbooks already vary it.
-- `<log_driver>` — recorded in a comment block.
-- `access_log_via=podman_logs` — confirmed.
-
-If the spike found that `podman logs` does NOT carry nginx access lines (Step 3 of Task 1), replace the `podman logs` invocation in Step 1 below with `cat <log_path>` over the same `delegate_to`, and adjust the `--since` filtering accordingly (drop `--since`, do client-side line counting instead).
-
 - [ ] **Step 1: Create the file**
 
-Write the file with this exact content (substitute `<NBXYZ_CTR>` with the literal container name from the spike — typically `netbootxyz`):
+Write with this exact content:
 
 ```yaml
 ---
@@ -586,97 +422,100 @@ Write the file with this exact content (substitute `<NBXYZ_CTR>` with the litera
 # block in test_netboot_pxe.yml.
 #
 # SPIKE OUTCOME (2026-05-09):
-#   container_name = <NBXYZ_CTR>
-#   log_driver     = <log_driver from Task 1, e.g. k8s-file>
-#   access_log_via = podman_logs   # nginx access lines reach `podman logs`
+#   runtime         = docker (TrueNAS SCALE uses Docker, not podman)
+#   container_name  = ix-netbootxyz-netbootxyz-1   (TrueCharts naming)
+#   access_log_path = /config/log/nginx/access.log (inside the container;
+#                     nginx is configured to log to a file, not stdout --
+#                     `docker logs` only carries dnsmasq-tftp lines)
+#   read_strategy   = wc -l snapshot before, tail -n +<N> after
+#                     (slice-by-line-count survives clock skew and is
+#                     robust regardless of log driver)
 #
 # Inputs (task vars expected on caller):
-#   vm_name              VM name, used in messages and loop labels
-#   vm_mac               lowercase MAC of the VM (already normalised)
-#   vm_ip                IP the VM was leased by rb5009
-#   expected_fetch_path  path the netbootxyz access log should show GET'd
-#   expected_substring   substring the served body must contain (or '')
-#   case_start_seconds   integer seconds elapsed since the case began
-#                          (used as `--since=<N>s` for `podman logs`)
+#   vm_name              VM name, used in messages
+#   vm_mac               lowercase MAC (with colons)
+#   vm_ip                dotted-quad IP from DHCP lease
+#   expected_status      200 (pinned) or 404 (random) -- the per-case
+#                          discriminator. Pinned MAC has a host file;
+#                          random MAC's GET hits 404 then iPXE falls
+#                          through to the in-binary :main_menu.
+#   pre_log_line_count   line count of access.log captured BEFORE the
+#                          VM was applied (snapshot in caller).
 #
-# Side effect: emits two assertions per case (positive fetch + optional
-# negative menu assertion + optional substring check).
+# Output: assertions only; no facts set.
 
-- name: "Fetch netbootxyz access log lines since case start ({{ vm_name }})"
+- name: "Read post-boot nginx access log slice for {{ vm_name }}"
   ansible.builtin.command:
-    cmd: "podman logs --since={{ case_start_seconds }}s <NBXYZ_CTR>"
-  register: _pxe_nbxyz_logs
+    cmd: >-
+      docker exec ix-netbootxyz-netbootxyz-1
+      sh -c "tail -n +{{ pre_log_line_count | int + 1 }} /config/log/nginx/access.log"
+  register: _pxe_log_slice
   changed_when: false
   delegate_to: "{{ netbootxyz_host }}"
   become: true
 
-- name: "Extract fetched paths for {{ vm_name }} (IP {{ vm_ip }})"
+- name: "Parse access lines into [ip, method, path, status] for {{ vm_name }}"
   ansible.builtin.set_fact:
-    _pxe_fetched_paths: >-
-      {{ _pxe_nbxyz_logs.stdout_lines
-         | select('search', '^' ~ vm_ip ~ ' ')
-         | map('regex_search', '\"GET ([^ ]+) HTTP', '\\1')
+    _pxe_parsed_lines: >-
+      {{ _pxe_log_slice.stdout_lines
+         | map('regex_search',
+               '^(\S+) - \S+ \[[^\]]+\] \"(\S+) (\S+) [^\"]+\" (\d+) ',
+               '\\1', '\\2', '\\3', '\\4')
          | select('truthy')
-         | map('first')
          | list }}
 
-- name: "Assert {{ vm_name }} fetched {{ expected_fetch_path }} from netbootxyz"
+- name: "Filter access lines to those from {{ vm_name }}'s IP ({{ vm_ip }})"
+  ansible.builtin.set_fact:
+    _pxe_vm_lines: "{{ _pxe_parsed_lines | selectattr('0', 'equalto', vm_ip) | list }}"
+
+- name: "Compute expected per-host path for {{ vm_name }}"
+  ansible.builtin.set_fact:
+    _pxe_expected_path: "/menus/host/MAC-{{ vm_mac | regex_replace(':', '') | lower }}.ipxe"
+
+- name: "Find access lines matching the expected GET for {{ vm_name }}"
+  ansible.builtin.set_fact:
+    _pxe_matching_lines: >-
+      {{ _pxe_vm_lines
+         | selectattr('1', 'equalto', 'GET')
+         | selectattr('2', 'equalto', _pxe_expected_path)
+         | list }}
+
+- name: "Assert {{ vm_name }} made at least one request to netbootxyz"
   ansible.builtin.assert:
     that:
-      - expected_fetch_path in _pxe_fetched_paths
+      - _pxe_vm_lines | length > 0
     fail_msg: >-
-      VM {{ vm_name }} (IP {{ vm_ip }}) was expected to fetch
-      {{ expected_fetch_path }} from netbootxyz, but the access log
-      shows: {{ _pxe_fetched_paths }}. Either iPXE never reached the
-      netbootxyz HTTP root (check the chain to {{ netbootxyz_self_url }}
-      from the binary, or the rb5009 DHCP option-67 setting), or the
-      matcher table is wrong.
+      VM {{ vm_name }} (IP {{ vm_ip }}) made NO HTTP requests to
+      netbootxyz. iPXE never reached the chainload step. Check the
+      rb5009 TFTP server, the chain target inside the iPXE binary, or
+      VLAN reachability between the VM CUDN and {{ netbootxyz_host }}.
 
-- name: "Assert {{ vm_name }} did NOT fetch any host/MAC-* file (menu fall-through case)"
+- name: "Assert {{ vm_name }} fetched {{ _pxe_expected_path }} exactly once"
   ansible.builtin.assert:
     that:
-      - _pxe_fetched_paths | select('match', '^/menus/host/MAC-') | list | length == 0
+      - _pxe_matching_lines | length == 1
     fail_msg: >-
-      Random-MAC VM {{ vm_name }} unexpectedly fetched a per-host file:
-      {{ _pxe_fetched_paths | select('match', '^/menus/host/MAC-') | list }}.
-      Either the menu fall-through is broken, or a stale per-host file
-      is being served for this MAC. The pinned MAC's hexraw appears in
-      the fetched path; cross-check against netboot_host_pins.
-  when: expected_fetch_path == '/menu.ipxe'
+      VM {{ vm_name }} (IP {{ vm_ip }}) -- expected exactly one GET
+      {{ _pxe_expected_path }}, but the access log slice shows
+      {{ _pxe_matching_lines | length }} matches. All lines from this
+      VM: {{ _pxe_vm_lines }}.
 
-- name: "Assert served body for {{ vm_name }} contains expected substring"
-  when: expected_substring | length > 0
-  block:
-    - name: "Re-use cached body for {{ vm_name }} if available, else fetch fresh"
-      ansible.builtin.set_fact:
-        _pxe_served_body: >-
-          {{ _pxe_preflight_bodies['pin:' ~ vm_mac]
-             | default(_pxe_preflight_bodies['menu'])
-             if (expected_fetch_path == '/menu.ipxe'
-                 or ('pin:' ~ vm_mac) in _pxe_preflight_bodies)
-             else '' }}
-
-    - name: "Fetch served body for {{ vm_name }} (cache miss)"
-      ansible.builtin.uri:
-        url: "{{ netbootxyz_self_url }}{{ expected_fetch_path }}"
-        return_content: true
-        status_code: 200
-        timeout: 10
-      register: _pxe_fresh_body
-      delegate_to: localhost
-      changed_when: false
-      when: _pxe_served_body | length == 0
-
-    - name: "Substring assert for {{ vm_name }}"
-      ansible.builtin.assert:
-        that:
-          - expected_substring in (_pxe_served_body if _pxe_served_body | length > 0 else _pxe_fresh_body.content)
-        fail_msg: >-
-          Served body for {{ vm_name }} at {{ expected_fetch_path }}
-          does not contain '{{ expected_substring }}'.
+- name: "Assert {{ vm_name }} got HTTP {{ expected_status }} on {{ _pxe_expected_path }}"
+  ansible.builtin.assert:
+    that:
+      - _pxe_matching_lines[0][3] | int == expected_status | int
+    fail_msg: >-
+      VM {{ vm_name }} (IP {{ vm_ip }}) hit {{ _pxe_expected_path }} but
+      got HTTP {{ _pxe_matching_lines[0][3] }} (expected
+      {{ expected_status }}). For a pinned MAC, this means the host
+      file is missing or stale -- run playbooks/netboot/deploy_assets.yml
+      and check inventory's netboot_host_pins. For a random MAC, this
+      means a per-host file exists for what should be an unpinned MAC
+      -- check whether that MAC was added to netboot_host_pins by
+      mistake, or whether deploy_assets.yml left a stale file behind.
 ```
 
-- [ ] **Step 2: yamllint the file**
+- [ ] **Step 2: yamllint**
 
 ```bash
 yamllint playbooks/kubevirt/test_netboot_pxe/_verify_http.yml
@@ -691,18 +530,18 @@ git add playbooks/kubevirt/test_netboot_pxe/_verify_http.yml
 git commit -m "$(cat <<'EOF'
 test_netboot_pxe: add _verify_http helper
 
-Per-case HTTP-side assertion: greps the netbootxyz container access
-log (since case start) for GETs from the VM's leased IP, asserts the
-expected path was fetched, and (for menu cases) asserts no per-host
-file was fetched. Substring check re-uses the body cached at preflight
-when available, otherwise fetches fresh.
+Slices the netbootxyz nginx access log via docker exec tail (since
+nginx logs to a file, not stdout). Asserts exactly one GET on the
+per-host path with the expected status (200 for pinned, 404 for
+random). Status code is the per-case discriminator -- it captures
+both classes of regression with a single observable.
 EOF
 )"
 ```
 
 ---
 
-## Task 7: Wire HTTP verification into serial mode (`_arch_test.yml`)
+## Task 6: Wire HTTP verification into serial mode (`_arch_test.yml`)
 
 **Files:**
 - Modify: `playbooks/kubevirt/test_netboot_pxe/_arch_test.yml`
@@ -710,20 +549,21 @@ EOF
 The existing per-arch flow becomes:
 
 ```
-capture _case_start_seconds (now)
+snapshot pre log line count (docker exec wc -l)
 TFTP hits BEFORE
 apply VM, wait Ready
-DHCP lease lookup -> _vm_ip
+include _dhcp_lease_lookup.yml -> _vm_mac, _vm_ip
 pause for boot
 TFTP hits AFTER
 assert TFTP hits incremented (existing)
-HTTP verify (new)
+compute expected_status from _vm_mac in _pxe_pinned_macs
+include _verify_http.yml
 always: delete VM
 ```
 
 - [ ] **Step 1: Replace `_arch_test.yml` with the augmented version**
 
-Open `playbooks/kubevirt/test_netboot_pxe/_arch_test.yml` and replace its entire contents with:
+Open `_arch_test.yml` and replace its entire contents with:
 
 ```yaml
 ---
@@ -739,20 +579,28 @@ Open `playbooks/kubevirt/test_netboot_pxe/_arch_test.yml` and replace its entire
 #
 # Per-case assertions:
 #   1. rb5009 TFTP hit counter for `item.binary` incremented (existing).
-#   2. netbootxyz access log shows the VM's leased IP fetched the
-#      expected path (host/MAC-<hexraw>.ipxe for pinned cases, /menu.ipxe
-#      for random-MAC cases). See _verify_http.yml.
+#   2. netbootxyz access log shows the VM's leased IP fetched
+#      /menus/host/MAC-<hexraw>.ipxe with HTTP 200 (pinned MAC) or 404
+#      (random MAC). See _verify_http.yml.
 
 - name: "Smoke-test {{ _vm_name }}"
   vars:
     _vm_name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
-    _vm_mac: "{{ item.mac | default('') | lower }}"
     _wait: "{{ item.boot_wait_seconds | default(pxe_test_boot_wait_seconds) }}"
-    _resolved: "{{ _pxe_resolved_cases | selectattr('name', 'equalto', _vm_name) | first }}"
   block:
-    - name: "Capture case-start timestamp for {{ _vm_name }}"
+    - name: "Snapshot nginx access log line count BEFORE {{ _vm_name }}"
+      ansible.builtin.command:
+        cmd: >-
+          docker exec ix-netbootxyz-netbootxyz-1
+          wc -l /config/log/nginx/access.log
+      register: _pxe_log_pre
+      changed_when: false
+      delegate_to: "{{ netbootxyz_host }}"
+      become: true
+
+    - name: "Capture pre log line count for {{ _vm_name }}"
       ansible.builtin.set_fact:
-        _case_start_epoch: "{{ ansible_date_time.epoch | default(lookup('pipe','date -u +%s')) | int }}"
+        _pre_log_line_count: "{{ _pxe_log_pre.stdout.split() | first | int }}"
 
     - name: "Snapshot rb5009 TFTP hits BEFORE boot for {{ item.binary }}"
       community.routeros.command:
@@ -780,7 +628,7 @@ Open `playbooks/kubevirt/test_netboot_pxe/_arch_test.yml` and replace its entire
           status: "True"
         wait_timeout: 180
 
-    - name: "Look up DHCP lease IP for {{ _vm_name }}"
+    - name: "Resolve VM addressing for {{ _vm_name }}"
       ansible.builtin.include_tasks: _dhcp_lease_lookup.yml
 
     - name: "Pause to let iPXE complete its boot attempt ({{ _vm_name }})"
@@ -809,8 +657,9 @@ Open `playbooks/kubevirt/test_netboot_pxe/_arch_test.yml` and replace its entire
           VM {{ _vm_name }} did not fetch {{ item.binary }} from rb5009
           within {{ _wait }}s. hits {{ _pxe_hits_pre }} ->
           {{ _pxe_hits_post }}. Check the VMI status, the DHCP offer to
-          its MAC (`/log print where topics~"dhcp"` on rb5009), and that
-          the matcher table still routes option-93 to the right binary.
+          its MAC (`/log print where topics~"dhcp"` on rb5009), and
+          that the matcher table still routes option-93 to the right
+          binary.
 
     - name: "Verify HTTP fetch for {{ _vm_name }}"
       ansible.builtin.include_tasks: _verify_http.yml
@@ -818,9 +667,8 @@ Open `playbooks/kubevirt/test_netboot_pxe/_arch_test.yml` and replace its entire
         vm_name: "{{ _vm_name }}"
         vm_mac: "{{ _vm_mac }}"
         vm_ip: "{{ _vm_ip }}"
-        expected_fetch_path: "{{ _resolved.expected_fetch_path }}"
-        expected_substring: "{{ _resolved.expected_substring }}"
-        case_start_seconds: "{{ ((lookup('pipe','date -u +%s') | int) - (_case_start_epoch | int)) + 5 }}"
+        expected_status: "{{ 200 if (_vm_mac in _pxe_pinned_macs) else 404 }}"
+        pre_log_line_count: "{{ _pre_log_line_count }}"
 
   always:
     - name: "Delete test VM ({{ _vm_name }})"
@@ -835,42 +683,39 @@ Open `playbooks/kubevirt/test_netboot_pxe/_arch_test.yml` and replace its entire
         wait_timeout: 120
 ```
 
-- [ ] **Step 2: Run the playbook in serial mode and verify all 4 cases pass**
+- [ ] **Step 2: Run the playbook in serial mode**
 
 ```bash
 ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -i igou-inventory/inventory.yaml
 ```
 
-Default mode is `pxe_test_parallel: false` so this exercises the serial path.
+Expected: 4 cases run sequentially. Each: TFTP-hits assertion (existing) + HTTP-verify assertion (new). Pinned cases see status 200; random cases see status 404. All pass; `failed=0`.
 
-Expected: 4 cases run, each with a TFTP-hits assertion (existing) AND an HTTP-verify assertion (new). All pass. The playbook completes with `failed=0`.
+If a case fails on HTTP-verify: read the failure message — it differentiates between (a) no HTTP at all from the VM, (b) wrong path, (c) right path wrong status.
 
-If a case fails on the HTTP-verify assertion: read the failure message — it tells you whether the access log saw the wrong path, didn't see the IP at all, or the substring check tripped.
-
-- [ ] **Step 3: Demonstrate the HTTP-verify failure mode**
-
-To prove the new assertion can detect a regression, temporarily corrupt the smoke pin (or rename the file on truenas):
+- [ ] **Step 3: Demonstrate the failure mode (pin file missing)**
 
 ```bash
+# Rename the pin file on truenas to simulate stale deployment.
 ansible truenas -i igou-inventory/inventory.yaml -m ansible.builtin.command \
-  -a 'mv /mnt/ssd/containers/netbootxyz/config/menus/host/MAC-020000505801.ipxe /mnt/ssd/containers/netbootxyz/config/menus/host/MAC-020000505801.ipxe.bak' \
+  -a 'docker exec ix-netbootxyz-netbootxyz-1 mv /config/menus/host/MAC-020000505801.ipxe /config/menus/host/MAC-020000505801.ipxe.bak' \
   -b
 ```
 
-Then run only the BIOS-pinned case:
+Run only the BIOS-pinned case:
 ```bash
 ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -i igou-inventory/inventory.yaml \
   -e '{"pxe_test_arches": [{"name": "pxe-test-bios-pinned", "arch": "bios", "binary": "netboot.xyz.kpxe", "mac": "02:00:00:50:58:01"}]}'
 ```
 
-Expected: the new "Preflight -- assert each smoke pin body..." catches it BEFORE any VM boots — the pin file is missing, preflight fails with a 404. (This is the design intent: cheap static check fails fast.)
+Expected: preflight catches it (404 on the pre-fetch) BEFORE any VM boots. The static check fails fast.
 
-Restore the file:
+Restore:
 ```bash
 ansible truenas -i igou-inventory/inventory.yaml -m ansible.builtin.command \
-  -a 'mv /mnt/ssd/containers/netbootxyz/config/menus/host/MAC-020000505801.ipxe.bak /mnt/ssd/containers/netbootxyz/config/menus/host/MAC-020000505801.ipxe' \
+  -a 'docker exec ix-netbootxyz-netbootxyz-1 mv /config/menus/host/MAC-020000505801.ipxe.bak /config/menus/host/MAC-020000505801.ipxe' \
   -b
 ```
 
@@ -883,31 +728,42 @@ git add playbooks/kubevirt/test_netboot_pxe/_arch_test.yml
 git commit -m "$(cat <<'EOF'
 test_netboot_pxe: serial mode asserts HTTP-side fetch per case
 
-Each case now also verifies that the netbootxyz access log shows the
-VM's leased IP fetching the expected path -- catches the iPXE -> nbxyz
-chain regression that the existing TFTP-hits check cannot see.
+Snapshots the nginx access log line count, applies the VM, resolves
+its MAC and DHCP IP, then asserts exactly one GET on
+/menus/host/MAC-<hex>.ipxe from the VM's IP with status 200 (pinned)
+or 404 (random). Status is the per-case discriminator.
 EOF
 )"
 ```
 
 ---
 
-## Task 8: Wire HTTP verification into parallel mode (`test_netboot_pxe.yml`)
+## Task 7: Wire HTTP verification into parallel mode (`test_netboot_pxe.yml`)
 
 **Files:**
 - Modify: `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`
 
 - [ ] **Step 1: Replace the parallel block**
 
-In `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`, locate the block named `Smoke-test architectures in parallel` (the `when: pxe_test_parallel` block, around line ~150 in the existing file). Replace the entire block (from `- name: Smoke-test architectures in parallel` through the matching `always:` block, inclusive) with:
+Locate the block named `Smoke-test architectures in parallel` (`when: pxe_test_parallel`) and replace it (entire block, including `always:`) with:
 
 ```yaml
     - name: Smoke-test architectures in parallel
       when: pxe_test_parallel
       block:
-        - name: Capture case-start epoch (parallel mode, shared)
+        - name: Snapshot nginx access log line count BEFORE the parallel batch
+          ansible.builtin.command:
+            cmd: >-
+              docker exec ix-netbootxyz-netbootxyz-1
+              wc -l /config/log/nginx/access.log
+          register: _pxe_log_pre_parallel
+          changed_when: false
+          delegate_to: "{{ netbootxyz_host }}"
+          become: true
+
+        - name: Capture pre log line count (parallel mode, shared)
           ansible.builtin.set_fact:
-            _pxe_parallel_start_epoch: "{{ lookup('pipe','date -u +%s') | int }}"
+            _pre_log_line_count_parallel: "{{ _pxe_log_pre_parallel.stdout.split() | first | int }}"
 
         - name: Snapshot rb5009 TFTP hits BEFORE boot (all)
           community.routeros.command:
@@ -949,23 +805,23 @@ In `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`, locate the block 
           loop_control:
             label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
 
-        - name: Look up DHCP lease IP for every VM (parallel)
+        - name: Resolve VM addressing for every VM (parallel)
           ansible.builtin.include_tasks: _dhcp_lease_lookup.yml
           vars:
             _vm_name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
-            _vm_mac: "{{ item.mac | default('') | lower }}"
           loop: "{{ pxe_test_arches }}"
           loop_control:
             label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
-          register: _pxe_parallel_ip_results
+          register: _pxe_parallel_addr_results
 
-        - name: Build {vm_name -> ip} map for the parallel batch
+        - name: Build {vm_name -> {mac, ip}} map for the parallel batch
           ansible.builtin.set_fact:
-            _pxe_parallel_ip_map: >-
-              {{ _pxe_parallel_ip_map | default({})
+            _pxe_parallel_addr_map: >-
+              {{ _pxe_parallel_addr_map | default({})
                  | combine({ (item.item.name | default('pxe-test-' ~ item.item.arch)):
-                             item.ansible_facts._vm_ip }) }}
-          loop: "{{ _pxe_parallel_ip_results.results }}"
+                             {'mac': item.ansible_facts._vm_mac,
+                              'ip':  item.ansible_facts._vm_ip} }) }}
+          loop: "{{ _pxe_parallel_addr_results.results }}"
           loop_control:
             label: "{{ item.item.name | default('pxe-test-' ~ item.item.arch) }}"
 
@@ -1011,13 +867,11 @@ In `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`, locate the block 
           ansible.builtin.include_tasks: _verify_http.yml
           vars:
             _vm_name_inner: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
-            _resolved: "{{ _pxe_resolved_cases | selectattr('name', 'equalto', _vm_name_inner) | first }}"
             vm_name: "{{ _vm_name_inner }}"
-            vm_mac: "{{ item.mac | default('') | lower }}"
-            vm_ip: "{{ _pxe_parallel_ip_map[_vm_name_inner] }}"
-            expected_fetch_path: "{{ _resolved.expected_fetch_path }}"
-            expected_substring: "{{ _resolved.expected_substring }}"
-            case_start_seconds: "{{ ((lookup('pipe','date -u +%s') | int) - (_pxe_parallel_start_epoch | int)) + 5 }}"
+            vm_mac: "{{ _pxe_parallel_addr_map[_vm_name_inner].mac }}"
+            vm_ip: "{{ _pxe_parallel_addr_map[_vm_name_inner].ip }}"
+            expected_status: "{{ 200 if (_pxe_parallel_addr_map[_vm_name_inner].mac in _pxe_pinned_macs) else 404 }}"
+            pre_log_line_count: "{{ _pre_log_line_count_parallel }}"
           loop: "{{ pxe_test_arches }}"
           loop_control:
             label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
@@ -1038,9 +892,7 @@ In `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml`, locate the block 
             label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
 ```
 
-Note: the existing parallel block also has a `delegate_to: "{{ pxe_test_router }}"` on the routeros tasks. The default for `pxe_test_router` is `rb5009.igou.systems`. To match the serial-mode style being introduced (literal hostname), use `delegate_to: rb5009.igou.systems` directly. If preserving the var-driven delegate is preferred, swap the literal back — both work.
-
-- [ ] **Step 2: Run the playbook in parallel mode**
+- [ ] **Step 2: Run in parallel mode**
 
 ```bash
 ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
@@ -1048,16 +900,16 @@ ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -e 'pxe_test_parallel=true'
 ```
 
-Expected: 4 VMs apply concurrently, all reach Ready, all leases looked up, single 180s pause, both TFTP-hits AND HTTP-verify assertions run for each. All pass. Playbook reports `failed=0`.
+Expected: 4 VMs apply concurrently, all reach Ready, addressing resolved per-VM, single shared pause, TFTP-hits AND HTTP-verify assertions for each. All pass.
 
-- [ ] **Step 3: Re-run in serial mode to confirm no regression**
+- [ ] **Step 3: Re-run in serial mode (no regression)**
 
 ```bash
 ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -i igou-inventory/inventory.yaml
 ```
 
-Expected: same end state, sequential per-case execution, all assertions pass.
+Expected: same end state, sequential execution, all assertions pass.
 
 - [ ] **Step 4: Commit**
 
@@ -1066,19 +918,20 @@ git add playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
 git commit -m "$(cat <<'EOF'
 test_netboot_pxe: parallel mode asserts HTTP-side fetch per case
 
-Lease lookups happen once per VM after batch Ready, before the long
-pause. The shared --since marker captures the whole window; per-VM-IP
-grep narrows the access log to each case. Same assertions as serial.
+Shared pre-snapshot of the nginx access log line count covers the
+whole batch; per-VM-IP filtering inside _verify_http.yml keeps cases
+independent. Same per-case discriminator as serial mode (200 pinned /
+404 random).
 EOF
 )"
 ```
 
 ---
 
-## Task 9: Lint, end-to-end verification, header-comment update
+## Task 8: Lint, end-to-end verification, header-comment update
 
 **Files:**
-- Modify: `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml` (header comment)
+- Modify: `playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml` (header comment only)
 
 - [ ] **Step 1: ansible-lint**
 
@@ -1112,17 +965,16 @@ Replace this paragraph with:
 # Verification (two layers):
 #   * TFTP hit counter on rb5009 increments for the expected binary
 #     (catches DHCP / matcher / TFTP regressions).
-#   * netbootxyz HTTP access log shows the VM's leased IP GET'd the
-#     expected path: /menus/host/MAC-<hexraw>.ipxe for pinned MACs,
-#     /menu.ipxe for random-MAC fall-through cases (catches the
-#     iPXE -> netbootxyz chain regression). Substring assertions on
-#     pinned bodies catch deploy_assets.yml drift.
-#   Per-entry expected_fetch / expected_substring overrides are
-#   honoured when set; otherwise resolved from inventory's
-#   netboot_host_pins (see the vars block + _preflight.yml).
+#   * netbootxyz nginx access log shows the VM's leased IP made
+#     exactly one GET /menus/host/MAC-<hexraw>.ipxe -- with status 200
+#     for pinned MACs (host file served) or 404 for random MACs (file
+#     absent, iPXE falls through to in-binary :main_menu). Single
+#     observable, two interpretations; status code is the per-case
+#     discriminator. Substring assertions on pinned bodies catch
+#     deploy_assets.yml drift at preflight.
+#   No per-entry override fields; expectations are fully derived from
+#   inventory's netboot_host_pins (see _preflight.yml + _verify_http.yml).
 ```
-
-The "Namespace selector label" paragraph and the example-invocation paragraph below it are unchanged.
 
 - [ ] **Step 4: Final end-to-end runs (both modes)**
 
@@ -1135,7 +987,7 @@ ansible-playbook playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
   -e 'pxe_test_parallel=true'
 ```
 
-Expected: both runs report `failed=0` and `unreachable=0`. The serial run takes ~12 minutes (4 cases × ~3 min each); the parallel run takes ~5 minutes (single 180s pause + setup + assertion phase).
+Expected: both runs report `failed=0`, `unreachable=0`. Serial: ~12 minutes; parallel: ~5 minutes.
 
 - [ ] **Step 5: Commit**
 
@@ -1145,7 +997,8 @@ git commit -m "$(cat <<'EOF'
 test_netboot_pxe: refresh header comment for headless verification
 
 The 'console scraping intentionally deferred' caveat no longer applies:
-the HTTP access-log assertion replaces it with a headless equivalent.
+the nginx access-log status-code assertion replaces it with a headless
+equivalent.
 EOF
 )"
 ```
@@ -1154,30 +1007,29 @@ EOF
 
 ## Self-review summary (against the spec)
 
-**Spec coverage check** (each item in the spec maps to one or more tasks):
+**Spec coverage check:**
 
-- Goal: assert per-host pin / main-menu fetch headlessly → **Tasks 6, 7, 8**.
-- Goal: detect three regression classes (stale pin, no chain, wrong fall-through) → **Task 3** (stale pin via preflight substring), **Task 6** (no chain via positive log assertion), **Task 6** (wrong fall-through via negative `host/MAC-*` assertion).
-- Goal: leave reusable primitives → **Tasks 5 (DHCP lookup), 6 (log grep + uri assertion)**. `mac_to_pin_path` is a pure jinja expression embedded where used (no separate file justified for a one-line transform).
-- Goal: honour block/always cleanup contract → **Task 7** keeps the existing `block:`/`always:` shape; the new HTTP-verify step lives inside `block:` so a failure still tears down via `always:`.
-- Goal: serial AND parallel mode → **Tasks 7 and 8** respectively.
-- Non-goal: boot-flip helper → not implemented; spec is explicit and the plan honours that.
+- Goal: assert per-host pin / main-menu fetch headlessly via status code → Tasks 5, 6, 7.
+- Goal: detect three regression classes → preflight substring (Task 3), positive log slice + status assertion (Task 5), 404-vs-200 discriminator (Task 5).
+- Goal: leave reusable primitives → Tasks 4 (DHCP+VMI), 5 (log slice + parser).
+- Goal: block/always cleanup → preserved in Task 6's serial block and Task 7's parallel block.
+- Goal: serial AND parallel → Tasks 6 and 7.
+- Non-goal: boot-flip helper → not implemented.
 - Non-goal: fragment-execution proof → not implemented (no virtctl, no probe URL).
-- Non-goal: real-host pin booting → `pxe_test_arches` default unchanged (still only the two smoke pins).
+- Non-goal: real-host pin booting → `pxe_test_arches` default unchanged.
 - Non-goal: inventory schema changes → no edits to `igou-inventory/`.
-- Architecture: preflight + per-case + always-cleanup → reflected in Tasks 2-4 (preflight) + 5-8 (per-case).
-- Test-case schema two new optional fields → introduced in **Task 4** with default + override semantics; substring map default in **Task 3**.
-- Verification primitives 1-4 → primitive 1 (mac→pin path) is inlined as Jinja in Tasks 3 & 4 & 6; primitive 2 (assert_pin_file_served) is the preflight URI step (Task 3) reused by Task 6 substring branch; primitive 3 (DHCP lease lookup) is Task 5; primitive 4 (log grep) is Task 6.
-- Edge cases (container name spike, lease retry budget, log lookback collisions, time skew, 200-but-wrong-body, never-fetched) → Task 1 spike; Task 5 retry config; relative-seconds `--since` in Task 6; preflight substring check in Task 3; negative log assertion in Task 6.
-- Risks (container name unknown, time skew, log rotation, 200-on-default-page, drift) → Task 1, Task 6 (relative since), bounded `pause` (already in playbook), Task 3, Task 3 substring.
-- Testing strategy (4 default cases pass, rename-pin-file, corrupt body, stop nbxyz, idempotent re-runs, lints) → Tasks 7 step 3 (rename), Task 3 step 5 (corrupt-body via substring override), Task 2 step 4 (down service), Tasks 7 step 2 + 8 step 3 (re-runs), Task 9 (lints).
+- Architecture: preflight + per-case + always-cleanup → Tasks 2-3 (preflight), 4-7 (per-case).
+- Test-case schema (no override fields) → no schema changes; substring map default added in Task 3.
+- Verification primitives → primitive 1 (mac→pin path) inlined in Tasks 3, 5; primitive 2 (assert_pin_file_served) in Task 3 preflight; primitive 3 (DHCP lease + VMI MAC) in Task 4; primitive 4 (read_nbxyz_access_lines_since) in Task 5.
+- Edge cases: container name baked from spike (Task 5); DHCP retry (Task 4); slice-by-line-count survives skew (Task 5); 200-but-wrong-path (Task 5 negative arms); never-fetched (Task 5 first assertion).
+- Risks → all mitigated in tasks above.
+- Testing strategy → Task 6 step 3 (rename pin), Task 3 step 5 (corrupt body via substring override), Task 2 step 4 (down service), Tasks 6-7 (re-runs), Task 8 (lints).
 
-**Placeholder scan:** none. Each step has the actual file content, the actual command, and the expected output.
+**Placeholder scan:** none.
 
-**Type/identifier consistency check:**
-- Fact names: `_pxe_preflight_menu`, `_pxe_preflight_bodies`, `_pxe_pinned_macs`, `_pxe_preflight_pin_macs`, `_pxe_preflight_pin_results`, `_pxe_resolved_cases`, `_pxe_tftp_pre`, `_pxe_tftp_post`, `_pxe_hits_pre`, `_pxe_hits_post`, `_case_start_epoch`, `_pxe_parallel_start_epoch`, `_pxe_parallel_ip_map`, `_pxe_parallel_ip_results`, `_pxe_lease_query`, `_pxe_nbxyz_logs`, `_pxe_fetched_paths`, `_pxe_served_body`, `_pxe_fresh_body`, `_vm_name`, `_vm_mac`, `_vm_ip`, `_resolved`, `_wait`. Cross-referenced across tasks; all consistent.
-- Resolved-case fields: `name`, `arch`, `binary`, `mac`, `has_mac`, `is_pinned`, `expected_fetch_path`, `expected_substring`. Used identically in Tasks 4, 7, 8.
-- Body cache key scheme: `'menu'` for menu.ipxe; `'pin:' ~ vm_mac` (lowercase MAC with colons) for per-host pins. Consistent across Tasks 2, 3, 6.
-- Path constant: `/menus/host/MAC-<hexraw>.ipxe` — produced identically in Tasks 3 (URL fetch), 4 (resolution), 6 (negative assert regex anchor).
-
-If any inconsistency surfaces during execution, fix it inline rather than mid-stream restructuring the plan.
+**Identifier consistency:**
+- Fact names: `_pxe_preflight_root`, `_pxe_pinned_macs`, `_pxe_preflight_pin_macs`, `_pxe_preflight_pin_results`, `_pxe_tftp_pre`, `_pxe_tftp_post`, `_pxe_hits_pre`, `_pxe_hits_post`, `_pxe_log_pre`, `_pre_log_line_count`, `_pxe_log_pre_parallel`, `_pre_log_line_count_parallel`, `_pxe_log_slice`, `_pxe_parsed_lines`, `_pxe_vm_lines`, `_pxe_expected_path`, `_pxe_matching_lines`, `_pxe_lease_query`, `_pxe_vmi_result`, `_pxe_parallel_addr_results`, `_pxe_parallel_addr_map`, `_vm_name`, `_vm_mac`, `_vm_ip`, `_wait`. All consistent across tasks.
+- `_dhcp_lease_lookup.yml` outputs `_vm_mac` and `_vm_ip` as facts; both serial (Task 6) and parallel (Task 7) consume identically.
+- `_verify_http.yml` inputs: `vm_name`, `vm_mac`, `vm_ip`, `expected_status`, `pre_log_line_count`. Used identically in serial and parallel call sites.
+- Path constant: `/menus/host/MAC-<hexraw>.ipxe` — produced identically in Tasks 3 (URL fetch), 5 (computed expectation).
+- Container literal: `ix-netbootxyz-netbootxyz-1` appears in Tasks 5, 6, 7. Identical spelling.

--- a/docs/superpowers/specs/2026-05-08-netboot-asset-management-design.md
+++ b/docs/superpowers/specs/2026-05-08-netboot-asset-management-design.md
@@ -1,0 +1,374 @@
+# netboot.xyz asset management — design
+
+**Date:** 2026-05-08
+**Status:** approved (brainstorming complete)
+**Scope:** one new playbook tree at `playbooks/netboot/` that replaces `playbooks/truenas/configure_netbootxyz.yml` and folds in `playbooks/truenas/sync_boot_files.yml`. Drives the menu, per-host pins, kickstart/cloud-init seeds, and binary asset fetches for the TrueNAS-hosted netbootxyz container from inventory and from in-repo source content. Eliminates the hardcoded `/home/igou/igou-node-bootstrap/netbootxyz-menus` reference.
+
+## Goals
+
+- Move all custom iPXE menu content, kickstart configs, cloud-init seeds, and per-host overrides from the external `igou-node-bootstrap` checkout into this repo, so the same review/lint/CI flow applies and the playbook can run from any control node (laptop, AAP, AWX).
+- Drive the menu declaratively via a `netboot_entries` inventory list — adding an entry is a YAML edit plus optionally a small file in `playbooks/netboot/files/`.
+- Support per-host PXE pins by MAC and/or hostname, auto-served from the netbootxyz HTTP root with no manual chainload wiring on the client.
+- Provide an escape hatch (`fragments/`) for hand-written `.ipxe` content the declarative schema can't express.
+- Idempotent: re-running with no input change reports `changed=0`. Tag-driven so a menu touch-up doesn't re-fetch ISOs.
+- Abstract the netbootxyz host via inventory (`netbootxyz_host`, `netbootxyz_root`, `netbootxyz_self_url`) so a future move (e.g. back to rb5009) is a one-line edit.
+
+## Non-goals
+
+- Refactoring the OpenShift add-node and agent-install flows. They keep writing per-cluster files directly to `/mnt/ssd/containers/netbootxyz/config/menus/` outside this playbook's purview. A later refactor can fold them in.
+- Touching the iPXE binary build (`playbooks/routeros/deploy_netboot_binaries.yml`). That stays as-is.
+- Migrating the `igou-node-bootstrap` repo. The user manually translates its current content into `netboot_entries` / `fragments/` during the cutover; the playbook doesn't import legacy content.
+- Multi-host netbootxyz. One TrueNAS container is the only consumer. The host abstraction is forward-looking, not a parallel deployment today.
+- Molecule scenarios. Consistent with the rest of `playbooks/truenas/` and `playbooks/routeros/`.
+
+## Inventory & connection
+
+No connection changes. TrueNAS already in `igou-inventory/inventory.yaml`; `igou-inventory/group_vars/truenas.yml` already configures the connection.
+
+New inventory variables live in `igou-inventory/group_vars/all/netboot.yml` (split-dir style — converts existing `all.yml` to `all/main.yml`, new file sits beside).
+
+```yaml
+netbootxyz_host: truenas
+netbootxyz_root: /mnt/ssd/containers/netbootxyz
+netbootxyz_self_url: http://10.10.45.242
+
+netboot_entries: []
+netboot_host_pins: []
+```
+
+`netbootxyz_self_url` is the externally-reachable URL the menu uses for `chain` calls back to itself (per-host hooks, kickstart references). `netbootxyz_root` is the TrueNAS-side filesystem path that maps to the container's `/config` and `/assets` mounts.
+
+## File layout
+
+```
+playbooks/netboot/
+  deploy_assets.yml                     # new — orchestrator, tagged stages
+  tasks/
+    preflight.yml                       # new — schema validation (always runs)
+    render_menu.yml                     # new — generate menu.ipxe + entries/ + host/ to .cache/
+    push_text.yml                       # new — sync menus, kickstart, cloud-init to TrueNAS
+    fetch_binaries.yml                  # new — idempotent download of upstream URLs into /assets
+    push_local_artifacts.yml            # new — copy local-built kernels/initrds into /assets
+    verify.yml                          # new — HTTP probes for menu.ipxe, host files, ISOs
+  templates/
+    menu.ipxe.j2                        # new — top-level menu, per-host header + entry list + fragments
+    entry-kernel.ipxe.j2                # new — per-entry boot of kernel/initrd
+    entry-iso.ipxe.j2                   # new — per-entry sanboot of ISO
+    host-mac.ipxe.j2                    # new — per-host pinned recipe
+  files/
+    fragments/                          # new — hand-written .ipxe escape hatch (auto-listed)
+    kickstart/                          # new — text kickstart configs
+    cloud-init/                         # new — text cloud-init seeds (user-data, meta-data)
+```
+
+`.cache/netboot-menus/` (gitignored) holds the rendered menu artifacts before push.
+
+Per-stage task files exist because each maps 1:1 to a tag and the stages are meaningfully independent. Matches the pattern set by `deploy_netbootxyz.yml` and `deploy_netboot_binaries.yml`.
+
+Conventions (consistent with the rest of `playbooks/`):
+
+- `hosts: "{{ netbootxyz_host | default('truenas') }}"`
+- `gather_facts: false`
+- `become: true` only on push/fetch tasks that touch the container's filesystem
+- `delegate_to: localhost` on render and validation
+- File-on-disk owner/group `1000:1000`, mode `0644` files / `0755` dirs
+
+## Inventory schema
+
+### `netboot_entries`
+
+Each entry is a dict. `id` is the slug used as a filename (`entries/<id>.ipxe`); `kind` discriminates the template.
+
+```yaml
+netboot_entries:
+
+  # --- kind: kernel — netbootxyz proxies the upstream URLs at boot time ---
+  - id: debian-12-preseed
+    name: "Debian 12 (preseed)"
+    kind: kernel
+    kernel: https://deb.debian.org/debian/dists/bookworm/main/installer-amd64/current/images/netboot/debian-installer/amd64/linux
+    initrd: https://deb.debian.org/debian/dists/bookworm/main/installer-amd64/current/images/netboot/debian-installer/amd64/initrd.gz
+    cmdline: "auto=true url=${netboot_self}/assets/kickstart/debian.preseed"
+    kickstart: debian.preseed             # path under playbooks/netboot/files/kickstart/
+    cache: false                          # opt-in: download to /assets and serve locally
+
+  # --- kind: iso — sanboot a pre-staged ISO; sha256 required ---
+  - id: talos-1.9
+    name: "Talos 1.9"
+    kind: iso
+    url: https://github.com/siderolabs/talos/releases/download/v1.9.0/metal-amd64.iso
+    sha256: 1234abcd...
+
+  # --- kind: chainload — chain to another .ipxe URL ---
+  - id: rocky-9-ks
+    name: "Rocky 9 (kickstart)"
+    kind: chainload
+    url: ${netboot_self}/assets/kickstart/rocky9.ipxe
+
+  # --- kind: local — ship a locally-built kernel/initrd from the control node ---
+  - id: custom-rescue
+    name: "Custom rescue kernel"
+    kind: local
+    kernel_src: "{{ playbook_dir }}/../../.cache/rescue/vmlinuz"
+    initrd_src: "{{ playbook_dir }}/../../.cache/rescue/initrd.img"
+    cmdline: "console=ttyS0 rescue"
+```
+
+Behavior per kind:
+
+| kind | Menu content | /assets fetch | Required fields |
+|---|---|---|---|
+| `kernel` | `kernel ${k}` + `initrd ${i}` + `imgargs ${cmdline}` + `boot` | none unless `cache: true`, then download both into `/assets/cache/<id>/` and rewrite URLs | `kernel`, `initrd` |
+| `iso` | `kernel ${memdisk} raw iso` + `initrd /assets/iso/<id>.iso` + `boot` | `get_url` upstream into `/assets/iso/<id>.iso` with `checksum: "sha256:<sha>"` | `url`, `sha256` |
+| `chainload` | `chain ${url}` | none | `url` |
+| `local` | `kernel /assets/local/<id>/vmlinuz` + `initrd /assets/local/<id>/initrd` + `imgargs ${cmdline}` + `boot` | `copy` from control node into `/assets/local/<id>/` | `kernel_src`, `initrd_src` |
+
+`${netboot_self}` is rendered to `{{ netbootxyz_self_url }}` at template time so kickstart/cloud-init URLs always resolve regardless of where netbootxyz lives.
+
+### `netboot_host_pins`
+
+Each pin binds a MAC and/or hostname to a boot recipe. Pinned hosts short-circuit the menu UI at the top of `menu.ipxe`.
+
+```yaml
+netboot_host_pins:
+
+  # --- form 1: pin to an existing entry by id ---
+  - mac: aa:bb:cc:dd:ee:ff
+    hostname: worker-01.igou.systems    # optional; both can match
+    entry: talos-1.9
+
+  # --- form 2: inline kernel/initrd ---
+  - mac: 11:22:33:44:55:66
+    kernel: https://...
+    initrd: https://...
+    cmdline: "..."
+
+  # --- form 3: free-form .ipxe escape hatch ---
+  - mac: 22:33:44:55:66:77
+    fragment: |
+      #!ipxe
+      kernel ...
+      initrd ...
+      boot
+```
+
+Generated:
+- `host/MAC-<hexraw>.ipxe` — one per pin (MAC lowercase, no separators).
+- `host/HOSTNAME-<name>.ipxe` — one per pin with `hostname` set, chains to the MAC file if both are present (avoids duplication).
+
+Validation enforced by the `preflight` stage:
+
+- MAC regex: `^([0-9a-f]{2}:){5}[0-9a-f]{2}$` (case-insensitive). Rendered filename uses lowercase hexraw.
+- `id` slugs: `^[a-z0-9][a-z0-9._-]*$`.
+- For `kind: iso`, `sha256` is required.
+- Each pin must specify exactly one of `entry` / inline `kernel`+`initrd` / `fragment`. Mixing fails preflight.
+- `entry: <id>` references must resolve to an `id` in `netboot_entries`.
+- `kickstart:` / `cloud-init:` references must resolve to a file under `playbooks/netboot/files/{kickstart,cloud-init}/`.
+
+## Generated layout on TrueNAS
+
+```
+/mnt/ssd/containers/netbootxyz/
+  config/menus/
+    menu.ipxe                           # rendered from menu.ipxe.j2
+    entries/<id>.ipxe                   # one per netboot_entries item (per kind)
+    host/MAC-<hexraw>.ipxe              # one per host pin
+    host/HOSTNAME-<name>.ipxe           # one per host pin with hostname
+    fragments/<filename>.ipxe           # copied verbatim from playbooks/netboot/files/fragments/
+    local/                              # mirror of menu.ipxe + entries/ + host/ + fragments/ (netbootxyz workaround)
+    <existing-openshift-files>.ipxe     # untouched — flat-named files written by other playbooks
+  assets/
+    kickstart/                          # synced from playbooks/netboot/files/kickstart/
+    cloud-init/                         # synced from playbooks/netboot/files/cloud-init/
+    iso/<id>.iso                        # one per kind: iso entry
+    local/<id>/{vmlinuz,initrd}         # one dir per kind: local entry
+    cache/<id>/{vmlinuz,initrd}         # opt-in cache for kind: kernel
+```
+
+The `local/` mirror under `config/menus/` exists because netbootxyz overwrites `config/menus/` on container start unless a `local/` mirror is present — same workaround the existing playbook applies.
+
+## Generated `menu.ipxe` header
+
+```
+#!ipxe
+:per_host
+isset ${hostname} && chain {{ netbootxyz_self_url }}/menus/host/HOSTNAME-${hostname}.ipxe || goto check_mac
+:check_mac
+isset ${mac} && chain {{ netbootxyz_self_url }}/menus/host/MAC-${mac:hexraw}.ipxe || goto main_menu
+:main_menu
+... menu UI listing each entries/<id>.ipxe + a "Custom" submenu listing fragments/*.ipxe ...
+```
+
+The `||` falls through silently when no per-host file exists. A pinned host short-circuits before ever rendering the menu UI; everything else gets the normal menu.
+
+`${mac:hexraw}` is the canonical iPXE syntax for the booted NIC's MAC with no separators (confirmed against `roles/netbootxyz/templates/disks/netboot.xyz.j2:101` in the upstream netboot.xyz Ansible build).
+
+## Playbook stages
+
+Top-level orchestration. Each `import_tasks` is wrapped in a tag so any subset can be run with `--tags`.
+
+```yaml
+- import_tasks: tasks/preflight.yml             # tags: [render, push, fetch, local, verify]
+- import_tasks: tasks/render_menu.yml           # tags: [render]
+- import_tasks: tasks/push_text.yml             # tags: [push]
+- import_tasks: tasks/fetch_binaries.yml        # tags: [fetch]
+- import_tasks: tasks/push_local_artifacts.yml  # tags: [local]
+- import_tasks: tasks/verify.yml                # tags: [verify]
+```
+
+Preflight runs under every tag — every other stage depends on validated input.
+
+### Stage `preflight`
+
+`delegate_to: localhost`. Schema validation only; doesn't touch TrueNAS.
+
+1. Assert `netboot_entries` is a list of dicts. For each entry: validate `id` slug, `kind` membership, kind-specific required fields.
+2. Assert `netboot_host_pins` MACs match regex. Each pin must specify exactly one of `entry` / inline `kernel`+`initrd` / `fragment`.
+3. Assert `entry: <id>` references in pins resolve to a real entry id.
+4. Assert `kickstart:` / `cloud-init:` references resolve to files under `playbooks/netboot/files/`.
+5. `find` `playbooks/netboot/files/fragments/*.ipxe` → register list of fragment filenames for the `render` stage to consume.
+
+Fails with one error per offending entry, naming the offending field.
+
+### Stage `render` — `tasks/render_menu.yml`
+
+`delegate_to: localhost`. Output written to `.cache/netboot-menus/`.
+
+1. `template menu.ipxe.j2 → .cache/netboot-menus/menu.ipxe`. Inputs: `netboot_entries`, `netboot_host_pins`, fragment list from preflight, `netbootxyz_self_url`.
+2. For each entry, render the appropriate per-kind template:
+   - `entry-kernel.ipxe.j2` for `kind: kernel` and `kind: local`
+   - `entry-iso.ipxe.j2` for `kind: iso`
+   - `chainload` entries embed inline in `menu.ipxe`, no separate file
+3. For each host pin, render `host/MAC-<hexraw>.ipxe`. If `hostname:` set, render `host/HOSTNAME-<name>.ipxe` chaining to the MAC file.
+
+### Stage `push` — `tasks/push_text.yml`
+
+Runs against `netbootxyz_host`.
+
+- `synchronize` (or `copy` with `directory_mode` for podman EE compatibility — final choice during implementation) the cache dir + `playbooks/netboot/files/{fragments,kickstart,cloud-init}/` into:
+  - `{{ netbootxyz_root }}/config/menus/` (menu.ipxe, entries/, host/, fragments/)
+  - `{{ netbootxyz_root }}/config/menus/local/` (mirror)
+  - `{{ netbootxyz_root }}/assets/kickstart/`
+  - `{{ netbootxyz_root }}/assets/cloud-init/`
+- Owner/group `1000:1000`, mode `0644` files / `0755` dirs.
+- `delete=true` scoped to `menus/entries/`, `menus/host/`, `menus/fragments/` only — never `menus/` itself, so the OpenShift add-node files survive.
+
+### Stage `fetch` — `tasks/fetch_binaries.yml`
+
+Runs against `netbootxyz_host`.
+
+For every `kind: iso` entry:
+
+1. `stat` `{{ netbootxyz_root }}/assets/iso/<id>.iso`.
+2. If absent, or size mismatches, or sha256 mismatches: `get_url` with `checksum: "sha256:{{ entry.sha256 }}"`, `force: false`. Re-runs are no-ops once the file is correct.
+
+For every `kind: kernel` entry with `cache: true`:
+
+3. Same pattern, target `{{ netbootxyz_root }}/assets/cache/<id>/{vmlinuz,initrd}`. Default `cache: false` — netbootxyz proxies on demand.
+
+### Stage `local` — `tasks/push_local_artifacts.yml`
+
+For every `kind: local` entry:
+
+1. `stat` `kernel_src` / `initrd_src` on the control node → register size + checksum.
+2. Compare to `{{ netbootxyz_root }}/assets/local/<id>/{vmlinuz,initrd}` via `stat`.
+3. `copy` only if missing or size mismatch. Owner/group `1000:1000`.
+
+### Stage `verify` — `tasks/verify.yml`
+
+`delegate_to: localhost`.
+
+1. HTTP GET `{{ netbootxyz_self_url }}/menu.ipxe` → 200, body starts with `#!ipxe`, body contains every entry's `name`.
+2. For each `kind: iso` (and each `kind: kernel` with `cache: true`): HTTP HEAD `{{ netbootxyz_self_url }}/iso/<id>.iso` (or `/cache/<id>/vmlinuz`) → 200, content-length matches local sha-checked size.
+3. For each host pin: HTTP GET `{{ netbootxyz_self_url }}/menus/host/MAC-<hexraw>.ipxe` → 200.
+
+## Idempotency model
+
+Every "did it change?" check is gated on an explicit pre-read.
+
+| Resource | Idempotency check |
+|---|---|
+| Rendered `menu.ipxe` | Local content hash vs. remote `stat` checksum |
+| Per-entry `entries/<id>.ipxe` | Local content hash vs. remote |
+| Per-host `host/MAC-*.ipxe` / `HOSTNAME-*.ipxe` | Local content hash vs. remote |
+| Static fragments / kickstart / cloud-init | `synchronize` (or copy with checksum) — diff-based |
+| `kind: iso` asset on disk | sha256 from inventory vs. remote sha256 (or size if no checksum) |
+| `kind: local` artifact | Source size + mtime vs. remote |
+| Cached `kind: kernel` asset | sha256 if provided, else size |
+
+`changed_when` is explicit per task. Read-only stats are `changed_when: false`. A re-run with no input changes reports `changed=0`.
+
+## Migration plan
+
+A single PR cuts over. No phased migration:
+
+1. New playbook tree at `playbooks/netboot/`.
+2. New inventory file `igou-inventory/group_vars/all/netboot.yml` (split-dir style — `all.yml` becomes `all/main.yml`, new file sits beside) with initial `netboot_entries` and `netboot_host_pins`. Initial content: whatever currently lives in `~/igou-node-bootstrap/netbootxyz-menus/` translated by hand into the schema.
+3. Custom `.ipxe` content from `~/igou-node-bootstrap/netbootxyz-menus/` that doesn't fit the declarative schema is dropped into `playbooks/netboot/files/fragments/` verbatim.
+4. `playbooks/truenas/configure_netbootxyz.yml` deleted.
+5. `playbooks/truenas/sync_boot_files.yml` deleted; `truenas_boot_files_*` vars removed from `igou-inventory/group_vars/truenas.yml`.
+6. `.gitignore` adds `.cache/netboot-menus/`.
+7. Header comment block at the top of `playbooks/netboot/deploy_assets.yml` covering: how to add an entry, how to add a per-host pin, how to add a fragment, tag invocation patterns, and the manual translation step from `igou-node-bootstrap` content.
+
+`igou-node-bootstrap` is left alone in this PR. The user can archive it after the cutover lands and is verified.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Per-host `chain` URL hits 404 → user sees a transient connection error before the menu | `||` fall-through to `:main_menu` makes 404 silent; `verify` HTTP GETs every host file at deploy time and catches a misconfigured pin |
+| `synchronize delete=true` in wrong scope wipes OpenShift add-node files | Scoped to `menus/entries/`, `menus/host/`, `menus/fragments/` only — never `menus/` itself |
+| Large ISO download blocks the playbook for minutes | `kind: iso` only fetches when sha256 mismatches; `--tags fetch` separates the slow stage |
+| User edits a generated file directly on TrueNAS | Header comment in every rendered file: `# Managed by playbooks/netboot/deploy_assets.yml — do not edit manually` |
+| Inventory typo (e.g. wrong MAC in `netboot_host_pins`) silently produces a host file no one references | `verify` does a positive HTTP GET on every host file; doesn't catch typos but ensures every generated file is reachable |
+| MAC variable syntax wrong for the booted NIC | `${mac:hexraw}` (the auto-aliased MAC of the booted NIC); confirmed against `roles/netbootxyz/templates/disks/netboot.xyz.j2:101` in the upstream netboot.xyz Ansible build |
+| File ownership drift if the netbootxyz container is redeployed under a different UID | Locked at `1000:1000` in `truenas_docker_containers`; flagged here, not designed around |
+| Two writers (this playbook + OpenShift add-node) into the same `config/menus/` directory | Different filename namespaces (`entries/`, `host/`, `fragments/` vs. flat `<hexmac>-add-node-<cluster>.ipxe`) and a scoped `delete=true` keep them isolated |
+
+## Testing strategy
+
+No molecule (consistent with the rest of `playbooks/truenas/`).
+
+Manual ladder:
+
+1. `--tags render -e netbootxyz_host=localhost --check` — local-only render, no TrueNAS contact. Eyeball generated `menu.ipxe` + per-host files in `.cache/netboot-menus/`.
+2. Full deploy with `--check --diff` first.
+3. Real run; verify HTTP probes pass.
+4. Re-run; every stage reports `changed=0`.
+5. Touch one entry's `cmdline:` in inventory; re-run with `--tags render,push,verify`; only that entry file changes.
+6. Add a `netboot_host_pins` entry for a known MAC; PXE-boot that host; confirm it boots the pinned recipe instead of seeing the menu. PXE-boot a different host; confirm it sees the menu.
+7. `ansible-lint --profile=production` and `yamllint` clean before commit.
+
+## Repo-level changes outside the playbook
+
+- `.gitignore`: add `.cache/netboot-menus/`.
+- `igou-inventory/group_vars/all.yml` → `all/main.yml` (split-dir conversion).
+- `igou-inventory/group_vars/all/netboot.yml`: new file with `netbootxyz_host`, `netbootxyz_root`, `netbootxyz_self_url`, `netboot_entries`, `netboot_host_pins`.
+- `igou-inventory/group_vars/truenas.yml`: remove `truenas_boot_files_*` block.
+
+## Documentation
+
+Header comment block at the top of `playbooks/netboot/deploy_assets.yml` covering:
+
+- The TrueNAS netbootxyz container as the only consumer.
+- How to add a `netboot_entries` item (per kind), with a one-line example for each.
+- How to add a `netboot_host_pins` item (all three forms).
+- How to add a fragment (drop a file in `files/fragments/`).
+- `--tags render,push,fetch,local,verify` invocation patterns.
+- The manual translation step from `igou-node-bootstrap` content (one-time cutover).
+
+Matches the comment-header convention in `playbooks/truenas/configure_docker_containers.yml` and `playbooks/routeros/deploy_netboot_binaries.yml`.
+
+## Open items resolved during brainstorming
+
+- Scope: custom .ipxe menus + boot media (kernels/initrds/ISOs/rootfs) + per-host iPXE scripts. iPXE binaries (.kpxe/.efi) stay in their own playbook.
+- Pain points addressed: hardcoded laptop path, separate-repo review/CI gap, manual workflow when adding a new menu/asset.
+- Source-of-truth: in-repo (`playbooks/netboot/files/` + inventory). `igou-node-bootstrap` is archived after cutover.
+- Add-entry workflow: hybrid declarative (`netboot_entries` list) + fragment escape hatch.
+- Deployment target: TrueNAS only; host abstracted via inventory for future portability.
+- Per-host pins: served via HTTP from TrueNAS at `menus/host/`, hooked from a header at the top of `menu.ipxe`. The TFTP-on-rb5009 alternative (which would require switching to the `disks/` binary variant) is out of scope.
+- OpenShift add-node and agent-install playbooks: left unchanged. Filename namespace separation prevents collision. Folding them in is a later refactor.
+- ISO sha256: required for `kind: iso`. Catches corrupted downloads at fetch time.
+- `kind: kernel` cache: opt-in (`cache: true`), defaults off (netbootxyz proxies upstream).
+- `synchronize delete=true`: scoped to subdirs we own; flat `menus/` is never deleted from.
+- Migration: single PR, manual translation of `igou-node-bootstrap` content into the new schema, deletion of the two legacy playbooks.

--- a/docs/superpowers/specs/2026-05-09-test-netboot-pxe-headless-design.md
+++ b/docs/superpowers/specs/2026-05-09-test-netboot-pxe-headless-design.md
@@ -6,8 +6,8 @@
 
 ## Goals
 
-- Headlessly assert that a pinned-MAC VM causes netbootxyz to serve `/menus/host/MAC-<hexraw>.ipxe` with HTTP 200, and that a random-MAC VM causes the same path to be requested but answered with HTTP 404 (which is the proof-of-fall-through to the in-binary main menu).
-- Detect three regression classes the current playbook misses: (a) the deployed pin file is stale or wrong, (b) iPXE fetched the binary but never chained to netbootxyz, (c) a stale per-host file is being served for what should be an unpinned MAC.
+- Headlessly assert that a pinned-MAC VM causes the netbootxyz container's TFTP server (dnsmasq) to **send** `/config/menus/host/MAC-<hexraw>.ipxe`, and that a random-MAC VM causes the **same path to be requested but answered with `file ... not found`** — that "not found" is the proof of fall-through to the in-binary main menu in the current iPXE chain.
+- Detect three regression classes the current playbook misses: (a) the deployed pin file is stale or wrong, (b) iPXE fetched the boot binary from rb5009 but never reached the netbootxyz chainload step, (c) a stale per-host file is being served for what should be an unpinned MAC.
 - Leave behind reusable verification primitives (HTTP fetch a pin file, look up a DHCP lease IP, grep the netbootxyz access log) that a future operator-facing "set/clear default boot" playbook can consume — without designing or building that playbook here.
 - Honour the existing block/always cleanup contract: a failed assertion still tears down its VM.
 - Stay compatible with both serial and parallel modes already in `test_netboot_pxe.yml`.
@@ -36,45 +36,47 @@ The new check adds two more snapshot points and one more assertion to the same s
 
 ```
 pre  = TFTP hits on rb5009                                                ┐
-pre  = nginx access log line count (snapshot for slice-after diff)        │
+pre  = `docker logs` line count for ix-netbootxyz-netbootxyz-1            │
 apply VM, wait for Ready                                                  │
-vm_ip, vm_mac = lookup rb5009 DHCP lease by MAC (poll up to 30s)          │
+vm_ip, vm_mac = lookup rb5009 DHCP lease (via VMI MAC, poll up to 30s)    │
 pause for boot wait window                                                │
 post = TFTP hits on rb5009                                                │
-post = new nginx access log lines from netbootxyz                         ┘
+post = new `docker logs` lines for the container                          ┘
 assert TFTP hits incremented (existing)
-classify case: vm_mac in netboot_host_pins → expected_status = 200
-                                       else → expected_status = 404
-assert exactly one nginx access line shows
-  GET /menus/host/MAC-<vm_mac_hexraw>.ipxe  status=<expected_status>  src=vm_ip
+classify case: vm_mac in netboot_host_pins → expected = "sent"
+                                       else → expected = "not_found"
+assert exactly one dnsmasq-tftp log line for /config/menus/host/MAC-<hex>.ipxe
+  with the expected outcome and the VM's leased IP.
 ```
 
-The crucial deployment fact (verified by the Task 1 spike): netbootxyz's `menu.ipxe` is served via **TFTP** (port 69, by the container's built-in dnsmasq), not HTTP. The HTTP root only hosts `/assets/` and `/menus/`. So when iPXE fetches the boot binary from rb5009 and chains into menu.ipxe via TFTP, the only HTTP request a smoke VM makes is the per-host `chain http://<self>/menus/host/MAC-<hexraw>.ipxe`. That single request is what we assert on:
+The crucial deployment fact (verified by the Task 1 spike + post-Task-3 inspection): the netbootxyz container's nginx serves only `/assets/`. **All chainload — including per-host pins — goes via TFTP**, served by the container's built-in dnsmasq. The current `menu.ipxe` (TFTP-served) chains to `host/MAC-${mac:hexraw}.ipxe` via `chain` over TFTP, falling through to `stock-menu.ipxe` when the per-host file is absent. So when an iPXE binary fetches from rb5009 and chains into netbootxyz, the dispatch sequence visible in dnsmasq-tftp logs is:
 
-- pinned MAC → file exists → nginx returns 200 → iPXE follows the pin fragment.
-- random MAC → file does not exist → nginx returns 404 → iPXE falls through to the in-binary `:main_menu` (no further HTTP request).
+- pinned MAC → `dnsmasq-tftp[…]: sent /config/menus/host/MAC-<hex>.ipxe to <ip>` (file existed and was served).
+- random MAC → `dnsmasq-tftp[…]: file /config/menus/host/MAC-<hex>.ipxe not found for <ip>` (the existence-of-fall-through proof).
 
-The status code IS the discriminator; we don't need a separate "did anything else get fetched" assertion.
+The "sent" vs "not found" outcome IS the discriminator. Both messages contain the full `/config/menus/host/MAC-<hex>.ipxe` path and the requesting IP — easy to filter and assert on.
 
-Preflight (once per playbook run, before any VM is applied) does a separate static check:
+Preflight (once per playbook run, before any VM is applied) does a separate setup + static check:
 
 1. Build a set of pinned MACs from `netboot_host_pins`.
-2. HTTP GET `{{ netbootxyz_self_url }}/` → 200. Catches netbootxyz HTTP server being down before any VM is wasted. (`/menu.ipxe` is NOT HTTP-served — see the deployment-fact note above.)
-3. For every pinned MAC referenced by `pxe_test_arches`, HTTP GET `{{ netbootxyz_self_url }}/menus/host/MAC-<hexraw>.ipxe` → 200 + body contains the pin-specific substring (default `=== pxe-test smoke pin:`). Catches `deploy_assets.yml` being stale, separately from the per-VM dynamic check.
+2. HTTP GET `{{ netbootxyz_self_url }}/` → 200. Catches the netbootxyz container's nginx being down before any VM is wasted.
+3. For every pinned MAC referenced by `pxe_test_arches`, **deploy** the pin file from inventory's `netboot_host_pins[…].fragment` to `/config/menus/host/MAC-<hex>.ipxe` on TrueNAS (via `ansible.builtin.copy` to the bind-mount path `/mnt/ssd/containers/netbootxyz/config/menus/host/`). Then `docker exec cat` the deployed file back and assert its body contains the pin-specific substring (default `=== pxe-test smoke pin:`). Catches drift between inventory and what's actually on disk.
+
+The deploy step is normally `playbooks/netboot/deploy_assets.yml`'s job (per `docs/superpowers/specs/2026-05-08-netboot-asset-management-design.md`). Until that playbook is implemented, this preflight inlines the minimum needed for the smoke pins. When `deploy_assets.yml` lands, this preflight may be simplified (or even reduced to a read-back check).
 
 ## File layout
 
 ```
 playbooks/kubevirt/test_netboot_pxe/
-  test_netboot_pxe.yml      # extended: include _preflight.yml, lease lookups + log slicing in parallel mode
-  _arch_test.yml            # extended: include lease lookup + _verify_http.yml inside the per-case block
-  _preflight.yml            # NEW: build pinned-MAC set, http-probe netbootxyz root, pin-content substring check
+  test_netboot_pxe.yml      # extended: include _preflight.yml, log slicing + lease lookups in parallel mode
+  _arch_test.yml            # extended: include lease lookup + _verify_tftp.yml inside the per-case block
+  _preflight.yml            # NEW: pinned-MAC set, http-probe nginx root, deploy + verify smoke pin files
   _dhcp_lease_lookup.yml    # NEW: poll rb5009 DHCP, set _vm_ip + _vm_mac (used by serial AND parallel)
-  _verify_http.yml          # NEW: nginx access log slice + per-case status assertion
+  _verify_tftp.yml          # NEW: docker-logs slice + per-case dnsmasq-tftp outcome assertion
   vm.yaml.j2                # unchanged
 ```
 
-`_verify_http.yml` and `_dhcp_lease_lookup.yml` are each their own file because both the serial path (`_arch_test.yml`) and the parallel path (the inline block in `test_netboot_pxe.yml`) call the same logic. Splitting them is the only way to avoid a copy-paste fork.
+`_verify_tftp.yml` and `_dhcp_lease_lookup.yml` are each their own file because both the serial path (`_arch_test.yml`) and the parallel path (the inline block in `test_netboot_pxe.yml`) call the same logic. Splitting them is the only way to avoid a copy-paste fork.
 
 ## Test-case schema (`pxe_test_arches`) — no new required fields
 
@@ -138,52 +140,56 @@ Wrapped in `until` retry — up to 30 seconds, 5-second interval — because the
 
 Outputs (set as facts on the caller): `_vm_ip`, `_vm_mac` (lowercase, with colons).
 
-### 4. `read_nbxyz_access_lines_since(pre_line_count)`
+### 4. `read_dnsmasq_tftp_lines_since(pre_line_count)`
 
-`delegate_to: {{ netbootxyz_host }}` (truenas). Two-shot: snapshot the access-log line count before the case starts, then read everything appended after.
+`delegate_to: {{ netbootxyz_host }}` (truenas). Two-shot: snapshot the docker-log line count before the case starts, then read everything appended after.
 
 Pre-snapshot:
 ```
-docker exec ix-netbootxyz-netbootxyz-1 wc -l /config/log/nginx/access.log
+docker logs ix-netbootxyz-netbootxyz-1 2>&1 | wc -l
 ```
 
-Post-read (returns only lines after the snapshot index):
+Post-read (returns only lines after the snapshot index, filtered to dnsmasq-tftp):
 ```
-docker exec ix-netbootxyz-netbootxyz-1 sh -c 'tail -n +<pre_count+1> /config/log/nginx/access.log'
-```
-
-Each line is then parsed with a regex into `{src_ip, method, path, status}`. Filtering and assertion happens in `_verify_http.yml`.
-
-Spike findings (recorded as a header comment in `_verify_http.yml`):
-
-```
-runtime         = docker (TrueNAS SCALE uses Docker, not podman)
-container_name  = ix-netbootxyz-netbootxyz-1   (TrueCharts naming)
-access_log_path = /config/log/nginx/access.log (inside the container; nginx
-                  is configured to write to a file, not stdout — `docker logs`
-                  only carries the dnsmasq-tftp output)
-read_strategy   = wc -l snapshot before, tail -n +<N> after
+docker logs ix-netbootxyz-netbootxyz-1 2>&1 | tail -n +<pre_count+1> | grep dnsmasq-tftp
 ```
 
-Slice-by-line-count (instead of `--since=<seconds>`) survives clock skew and is robust regardless of log driver.
+Each line is then parsed with a regex into `{outcome, path, ip}` where `outcome ∈ {sent, not_found}`. Filtering and assertion happen in `_verify_tftp.yml`.
 
-## Per-case assertion logic (`_verify_http.yml`)
+Sample lines (verified empirically):
 
-Inputs (as task vars): `vm_name`, `vm_mac`, `vm_ip`, `expected_status`, `pre_log_line_count`. Path is derived inline from `vm_mac`.
+```
+dnsmasq-tftp[23]: sent /config/menus/host/MAC-020000505801.ipxe to 10.10.9.40
+dnsmasq-tftp[23]: file /config/menus/host/MAC-525400deadbe.ipxe not found for 10.10.9.41
+```
+
+Regex (single capture per line, two patterns):
+
+```
+^dnsmasq-tftp\[\d+\]: sent (\S+) to ([\d.]+)$         → outcome=sent
+^dnsmasq-tftp\[\d+\]: file (\S+) not found for ([\d.]+)$  → outcome=not_found
+```
+
+Slice-by-line-count (instead of `--since=<seconds>`) survives clock skew and is robust regardless of log driver. Note: nginx access lines do NOT appear in `docker logs` (nginx in this image writes to a file at `/config/log/nginx/access.log`); the only log content reachable via `docker logs` is the dnsmasq-tftp output, which is exactly what we want.
+
+## Per-case assertion logic (`_verify_tftp.yml`)
+
+Inputs (as task vars): `vm_name`, `vm_mac`, `vm_ip`, `expected_outcome` (literal string `"sent"` or `"not_found"`), `pre_log_line_count`. Path is derived inline from `vm_mac`.
 
 Steps:
 
-1. Read access lines appended after `pre_log_line_count` (primitive 4 above).
-2. Parse each line into `{src_ip, method, path, status}` via regex.
-3. Filter to lines where `src_ip == vm_ip`.
-4. Compute `expected_path = '/menus/host/MAC-' + (vm_mac | regex_replace(':', '') | lower) + '.ipxe'`.
-5. Assert exactly one filtered line has `method == 'GET'`, `path == expected_path`, `status | int == expected_status | int`.
+1. Read docker-log lines appended after `pre_log_line_count`, filtered to `dnsmasq-tftp` (primitive 4 above).
+2. Parse each line into `{outcome, path, ip}` via the two regex patterns.
+3. Filter to lines where `ip == vm_ip`.
+4. Compute `expected_path = '/config/menus/host/MAC-' + (vm_mac | regex_replace(':', '') | lower) + '.ipxe'`.
+5. Filter to lines where `path == expected_path`.
+6. Assert: `length == 1` and `outcome == expected_outcome`.
 
 Failure messages:
 
-- No line at all from `vm_ip` → `VM {{ vm_name }} (IP {{ vm_ip }}) made no HTTP requests to netbootxyz. iPXE never reached the chainload step. Check the rb5009 TFTP server, the chain target inside the iPXE binary, or VLAN reachability between the VM CUDN and {{ netbootxyz_host }}.`
-- Line for `vm_ip` exists but on a different path → `VM {{ vm_name }} fetched {{ <observed path> }} instead of {{ expected_path }}. The chain inside the menu.ipxe served by netbootxyz may be wrong.`
-- Right path but wrong status → `VM {{ vm_name }} hit {{ expected_path }} but got {{ <observed status> }} (expected {{ expected_status }}). Pinned-MAC case = stale or missing host file; random-MAC case = a per-host file exists for what should be an unpinned MAC.`
+- No dnsmasq-tftp lines at all from `vm_ip` → `VM {{ vm_name }} (IP {{ vm_ip }}) made no TFTP requests to netbootxyz. iPXE never reached the chainload step. Check the rb5009 TFTP server, the chain target inside the iPXE binary, or VLAN reachability between the VM CUDN and {{ netbootxyz_host }}.`
+- Lines for `vm_ip` exist but none on the expected path → `VM {{ vm_name }} requested {{ <observed paths> }} instead of {{ expected_path }}. The chain inside the menu.ipxe served by netbootxyz may be wrong.`
+- Right path but wrong outcome → `VM {{ vm_name }} hit {{ expected_path }} but dnsmasq returned {{ <observed outcome> }} (expected {{ expected_outcome }}). Pinned-MAC case where outcome=not_found means the deploy step in preflight failed silently or the file was removed; random-MAC case where outcome=sent means a per-host file exists for what should be an unpinned MAC.`
 
 ## Orchestration changes
 
@@ -191,19 +197,19 @@ Failure messages:
 
 Per-case flow:
 
-1. Snapshot pre log line count (primitive 4 pre-shot).
+1. Snapshot pre `docker logs` line count (primitive 4 pre-shot).
 2. Snapshot pre TFTP hits (existing).
 3. Apply VM, wait Ready (existing).
 4. Lookup DHCP lease → `_vm_ip` AND `_vm_mac` (primitive 3, augmented to extract both).
 5. Pause (existing).
 6. Snapshot post TFTP hits (existing).
 7. TFTP-hits assert (existing).
-8. Compute `_expected_status = 200 if _vm_mac in _pxe_pinned_macs else 404`.
-9. `include_tasks: _verify_http.yml` with `{vm_name, vm_mac, vm_ip, expected_status, pre_log_line_count}`.
+8. Compute `_expected_outcome = 'sent' if _vm_mac in _pxe_pinned_macs else 'not_found'`.
+9. `include_tasks: _verify_tftp.yml` with `{vm_name, vm_mac, vm_ip, expected_outcome, pre_log_line_count}`.
 
 ### Parallel mode (`test_netboot_pxe.yml`)
 
-Same flow but batched: the pre log line count is captured once (shared); each VM's lease lookup yields its own `vm_ip`/`vm_mac`; the verify step is looped per case. Per-VM-IP filtering inside `_verify_http.yml` keeps the cases independent inside the shared log slice.
+Same flow but batched: the pre log line count is captured once (shared); each VM's lease lookup yields its own `vm_ip`/`vm_mac`; the verify step is looped per case. Per-VM-IP filtering inside `_verify_tftp.yml` keeps the cases independent inside the shared log slice.
 
 ## Idempotency, retries, timing
 
@@ -219,37 +225,40 @@ Same flow but batched: the pre log line count is captured once (shared); each VM
 
 | Risk | Mitigation |
 |---|---|
-| netbootxyz container name or log layout differs from what this design assumes | Captured by Task 1 spike (recorded above). Container name `ix-netbootxyz-netbootxyz-1`, log at `/config/log/nginx/access.log`, runtime `docker`. |
+| netbootxyz container name or log layout differs from what this design assumes | Captured by Task 1 spike + post-Task-3 inspection. Container `ix-netbootxyz-netbootxyz-1`, dnsmasq-tftp lines visible in `docker logs`, runtime `docker`. |
 | Clock skew | Line-count slicing, no timestamps. |
-| Log rotation drops lines mid-test | Bounded by ≤180s pause; nginx rotates on size, not by minute; flagged in code comment. |
-| nginx returns 200 for a wrong path (e.g. directory listing instead of the per-host file) | Preflight static pin-content substring check fails fast before any VM boots. |
-| Smoke pin fragment in inventory drifts from what's served | Same preflight check — substring match catches drift. |
+| Log rotation drops lines mid-test | Bounded by ≤180s pause; `docker logs` retains tens of thousands of lines on default log driver; flagged in code comment. |
+| dnsmasq-tftp message format changes between netbootxyz image versions | Two stable formats are matched by regex (`sent ... to <ip>` and `file ... not found for <ip>`). Image is pinned in the TrueCharts deployment; format change would surface as zero-match assertion failures with diagnostic line content. |
+| Smoke pin file deployed but mode/owner is wrong → dnsmasq refuses to serve | Preflight `docker exec cat` reads the file back and asserts substring; if dnsmasq can't read it the read-back also fails or returns empty. |
+| Smoke pin fragment in inventory drifts from what's deployed | Preflight read-back substring check catches drift. |
 | iPXE retains the IP into a kernel that DHCPs again later (would generate extra log lines) | Smoke VMs are diskless; iPXE never hands off to a kernel. The pin fragments `exit 0` after the echo. Not a concern for the smoke cases. |
 | Test runner can't reach `netbootxyz_self_url` (e.g. wrong VLAN) | Preflight HTTP probe of `/` fails fast with the relevant URL in the error. |
-| `docker exec` requires elevated privileges on truenas | The truenas connection is already root for other playbooks (`playbooks/truenas/*`); verified at plan time. |
+| `docker exec`/`docker logs` requires elevated privileges on truenas | The truenas connection is already root for other playbooks (`playbooks/truenas/*`); verified at plan time. |
+| Smoke pin files deployed by this preflight collide with `playbooks/netboot/deploy_assets.yml` | `deploy_assets.yml` doesn't yet exist. When it lands, this preflight's deploy step is reviewed: either reduced to a read-back check, or kept (idempotent overwrite) — to be decided when that plan executes. |
 
 ## Testing strategy
 
 Manual ladder, run from the existing AWX EE / ansible-navigator container:
 
-1. Run with current default `pxe_test_arches`. Confirm: 4 cases pass — 2 pinned MACs see `/menus/host/MAC-…` returning 200 (and the substring check at preflight passes), 2 random MACs see the same path returning 404.
-2. Negative: temporarily rename `host/MAC-020000505801.ipxe` on truenas. Re-run. Expect: preflight catches it first (404 on the pre-fetch) before any VM boots. Restore the file.
-3. Negative: temporarily corrupt the smoke pin fragment body (edit inventory, run `playbooks/netboot/deploy_assets.yml --tags render,push`). Re-run smoke test. Expect: preflight fails on the substring check before any VM boots.
+1. Run with current default `pxe_test_arches`. Confirm: 4 cases pass — preflight deploys 2 smoke pins; 2 pinned-MAC cases see `dnsmasq-tftp ... sent .../host/MAC-…` for their IP, 2 random-MAC cases see `dnsmasq-tftp ... file .../host/MAC-… not found for ...` for their IP.
+2. Negative: temporarily delete `/mnt/ssd/containers/netbootxyz/config/menus/host/MAC-020000505801.ipxe` and edit the inventory fragment so preflight redeploys with a different substring. Re-run. Expect: preflight read-back substring check fails fast before any VM boots.
+3. Negative: temporarily corrupt the smoke pin fragment body in inventory (different substring). Re-run smoke test. Expect: preflight redeploys + read-back substring assertion fails before any VM boots.
 4. Negative: stop the netbootxyz container. Re-run smoke test. Expect: preflight fails on the HTTP `/` probe.
-5. Re-run twice in succession with no changes — both runs report identical pass/fail (no per-run state).
+5. Re-run twice in succession with no changes — both runs report identical pass/fail. Pin file deployment is idempotent.
 6. `ansible-lint --profile=production` and `yamllint` clean before commit.
 
 No molecule scenario (consistent with the rest of `playbooks/kubevirt/`).
 
 ## Open items resolved during brainstorming
 
-- Cases verified headlessly: pin-fetch (per-host short-circuit, expect 200 on the per-host path), menu-fetch (unpinned fall-through, expect 404 on the per-host path — the 404 IS the proof of fall-through). NOT pin-fragment-executed (rejected as "needs serial console scraping or phone-home — out of scope here").
-- Verification mechanism: HTTP fetch by test runner at preflight (catches static config drift) + nginx access log slice via `docker exec ... tail` (catches dynamic dispatch breakage). No virtctl console; no probe URL.
-- Test fixture location: `pxe_test_arches` stays in the playbook (test concern). Inventory `netboot_host_pins` is read-only from the test's perspective.
+- Cases verified headlessly: pin-fetch (per-host short-circuit, expect dnsmasq `sent` for the per-host path), menu-fetch (unpinned fall-through, expect dnsmasq `not found` for the per-host path — the not-found IS the proof of fall-through to `stock-menu.ipxe`). NOT pin-fragment-executed (rejected as "needs serial console scraping or phone-home — out of scope here").
+- Verification mechanism: HTTP probe of nginx root at preflight (liveness only) + ansible.builtin.copy of smoke pin files into the container's `/config/menus/host/` mount + `docker exec cat` read-back substring check + `docker logs` slice for dnsmasq-tftp lines (catches dynamic dispatch breakage). No virtctl console; no probe URL.
+- Test fixture location: `pxe_test_arches` stays in the playbook (test concern). Inventory `netboot_host_pins` is read-only from the test's perspective; the smoke pin file BODY comes from inventory's `netboot_host_pins[…].fragment` field — the test playbook copies that text into the container's menus directory.
 - Inventory schema: unchanged. No `smoke_test:` flag added.
 - Real-host pins (helpernode/p330/hpg5/etc.): NOT booted by the test. Only the two `02:00:00:50:58:0*` smoke pins.
-- Per-case discriminator: nginx HTTP **status code** on the per-host path (200 vs 404). Single observable, two interpretations. Replaces the original "menu.ipxe vs host/MAC-* path" framing — `menu.ipxe` is served via TFTP, not HTTP, in the actual deployment (Task 1 spike).
-- Substring check on served pin body: preflight only (test-side default substring map keyed by MAC). Per-case substring assertion dropped because preflight already validates the body.
+- Per-case discriminator: dnsmasq-tftp **outcome** (`sent` vs `not found`) on the per-host path. Single observable, two interpretations. Replaces the original "menu.ipxe vs host/MAC-* path" framing — the actual deployment serves nothing through HTTP except `/assets/`; all chainload is TFTP.
+- Substring check on deployed pin body: preflight only (test-side default substring map keyed by MAC). Per-case substring assertion dropped because preflight already validates the body via `docker exec cat` after deploy.
 - Boot-flip helper playbook: out of scope; deferred to a follow-up brainstorm. The four primitives this design produces are the foundation it will reuse.
-- IP **and MAC** source for log correlation: rb5009 DHCP lease table — query yields both the IP and the MAC (so KubeVirt-generated random MACs are observable without reading VMI status).
-- Container name / log layout: confirmed by Task 1 spike. Container `ix-netbootxyz-netbootxyz-1` (TrueCharts naming on TrueNAS SCALE), runtime `docker`, nginx access log at `/config/log/nginx/access.log` inside the container, read via `docker exec ... tail` since nginx is configured to log to a file rather than stdout.
+- IP **and MAC** source for log correlation: rb5009 DHCP lease table — query yields both the IP and the MAC (so KubeVirt-generated random MACs are observable). MAC is also read from the VirtualMachineInstance for the input to the rb5009 query.
+- Container / log layout: confirmed empirically. Container `ix-netbootxyz-netbootxyz-1` (TrueCharts naming on TrueNAS SCALE), runtime `docker`, dnsmasq-tftp logs visible in `docker logs` (nginx access logs are NOT — they go to a file, but we don't need them in this pivoted design). Per-host pin files live at `/config/menus/host/MAC-<hex>.ipxe` inside the container; the bind mount on TrueNAS is at `/mnt/ssd/containers/netbootxyz/config/menus/host/`.
+- Pivot note: an earlier iteration of this spec assumed an HTTP-served `/menus/` layout (per `docs/superpowers/specs/2026-05-08-netboot-asset-management-design.md`). That asset-management plan exists but is not yet implemented; the current deployment uses TFTP-only chaining. The smoke test deploys its own pin files into the live deployment until `deploy_assets.yml` lands.

--- a/docs/superpowers/specs/2026-05-09-test-netboot-pxe-headless-design.md
+++ b/docs/superpowers/specs/2026-05-09-test-netboot-pxe-headless-design.md
@@ -6,8 +6,8 @@
 
 ## Goals
 
-- Headlessly assert that a pinned-MAC VM causes netbootxyz to serve `/menus/host/MAC-<hexraw>.ipxe`, and that an unpinned VM causes it to serve `/menu.ipxe` and *not* any per-host file.
-- Detect three regression classes the current playbook misses: (a) the deployed pin file is stale or wrong, (b) iPXE fetched the binary but never chained to netbootxyz, (c) the menu fall-through is silently chaining to a leftover per-host file.
+- Headlessly assert that a pinned-MAC VM causes netbootxyz to serve `/menus/host/MAC-<hexraw>.ipxe` with HTTP 200, and that a random-MAC VM causes the same path to be requested but answered with HTTP 404 (which is the proof-of-fall-through to the in-binary main menu).
+- Detect three regression classes the current playbook misses: (a) the deployed pin file is stale or wrong, (b) iPXE fetched the binary but never chained to netbootxyz, (c) a stale per-host file is being served for what should be an unpinned MAC.
 - Leave behind reusable verification primitives (HTTP fetch a pin file, look up a DHCP lease IP, grep the netbootxyz access log) that a future operator-facing "set/clear default boot" playbook can consume — without designing or building that playbook here.
 - Honour the existing block/always cleanup contract: a failed assertion still tears down its VM.
 - Stay compatible with both serial and parallel modes already in `test_netboot_pxe.yml`.
@@ -35,38 +35,50 @@ always: delete VM
 The new check adds two more snapshot points and one more assertion to the same skeleton:
 
 ```
-pre  = TFTP hits on rb5009                                    ┐
-pre  = wall-clock marker for the netbootxyz log lookback      │
-apply VM, wait for Ready                                      │
-vm_ip = lookup rb5009 DHCP lease by MAC (poll up to 30s)      │
-pause for boot wait window                                    │
-post = TFTP hits on rb5009                                    │
-post = netbootxyz container log lines since pre marker        ┘
+pre  = TFTP hits on rb5009                                                ┐
+pre  = nginx access log line count (snapshot for slice-after diff)        │
+apply VM, wait for Ready                                                  │
+vm_ip, vm_mac = lookup rb5009 DHCP lease by MAC (poll up to 30s)          │
+pause for boot wait window                                                │
+post = TFTP hits on rb5009                                                │
+post = new nginx access log lines from netbootxyz                         ┘
 assert TFTP hits incremented (existing)
-assert exactly one HTTP GET for the expected path from vm_ip
-if expected = menu: assert NO GET /menus/host/MAC-* from vm_ip
+classify case: vm_mac in netboot_host_pins → expected_status = 200
+                                       else → expected_status = 404
+assert exactly one nginx access line shows
+  GET /menus/host/MAC-<vm_mac_hexraw>.ipxe  status=<expected_status>  src=vm_ip
 ```
+
+The crucial deployment fact (verified by the Task 1 spike): netbootxyz's `menu.ipxe` is served via **TFTP** (port 69, by the container's built-in dnsmasq), not HTTP. The HTTP root only hosts `/assets/` and `/menus/`. So when iPXE fetches the boot binary from rb5009 and chains into menu.ipxe via TFTP, the only HTTP request a smoke VM makes is the per-host `chain http://<self>/menus/host/MAC-<hexraw>.ipxe`. That single request is what we assert on:
+
+- pinned MAC → file exists → nginx returns 200 → iPXE follows the pin fragment.
+- random MAC → file does not exist → nginx returns 404 → iPXE falls through to the in-binary `:main_menu` (no further HTTP request).
+
+The status code IS the discriminator; we don't need a separate "did anything else get fetched" assertion.
 
 Preflight (once per playbook run, before any VM is applied) does a separate static check:
 
-1. Build a `{mac → pin}` lookup from `netboot_host_pins`.
-2. HTTP GET `{{ netbootxyz_self_url }}/menu.ipxe` → 200 + body starts with `#!ipxe`. Catches netbootxyz being down before any VM is wasted.
-3. For every smoke pin in inventory (the `02:00:00:50:58:0*` ones), HTTP GET `{{ netbootxyz_self_url }}/menus/host/MAC-<hexraw>.ipxe` → 200 + body contains the pin-specific substring (default `=== pxe-test smoke pin:`). Catches `deploy_assets.yml` being stale, separately from the per-VM dynamic check.
+1. Build a set of pinned MACs from `netboot_host_pins`.
+2. HTTP GET `{{ netbootxyz_self_url }}/` → 200. Catches netbootxyz HTTP server being down before any VM is wasted. (`/menu.ipxe` is NOT HTTP-served — see the deployment-fact note above.)
+3. For every pinned MAC referenced by `pxe_test_arches`, HTTP GET `{{ netbootxyz_self_url }}/menus/host/MAC-<hexraw>.ipxe` → 200 + body contains the pin-specific substring (default `=== pxe-test smoke pin:`). Catches `deploy_assets.yml` being stale, separately from the per-VM dynamic check.
 
 ## File layout
 
 ```
 playbooks/kubevirt/test_netboot_pxe/
-  test_netboot_pxe.yml      # extended: include _preflight.yml, snapshot/grep nbxyz log in parallel mode
-  _arch_test.yml            # extended: include _verify_http.yml inside the per-case block
-  _preflight.yml            # NEW: build pin lookup, http-probe netbootxyz root, static pin-content check
-  _verify_http.yml          # NEW: shared HTTP-fetch + access-log assertion, callable per case
+  test_netboot_pxe.yml      # extended: include _preflight.yml, lease lookups + log slicing in parallel mode
+  _arch_test.yml            # extended: include lease lookup + _verify_http.yml inside the per-case block
+  _preflight.yml            # NEW: build pinned-MAC set, http-probe netbootxyz root, pin-content substring check
+  _dhcp_lease_lookup.yml    # NEW: poll rb5009 DHCP, set _vm_ip + _vm_mac (used by serial AND parallel)
+  _verify_http.yml          # NEW: nginx access log slice + per-case status assertion
   vm.yaml.j2                # unchanged
 ```
 
-`_verify_http.yml` is its own file because both the serial path (`_arch_test.yml`) and the parallel path (the inline block in `test_netboot_pxe.yml`) call the same logic. Splitting it is the only way to avoid a copy-paste fork.
+`_verify_http.yml` and `_dhcp_lease_lookup.yml` are each their own file because both the serial path (`_arch_test.yml`) and the parallel path (the inline block in `test_netboot_pxe.yml`) call the same logic. Splitting them is the only way to avoid a copy-paste fork.
 
-## Test-case schema (`pxe_test_arches`) — two new optional fields
+## Test-case schema (`pxe_test_arches`) — no new required fields
+
+The existing entry shape is unchanged:
 
 ```yaml
 pxe_test_arches:
@@ -74,25 +86,15 @@ pxe_test_arches:
     arch: bios
     binary: netboot.xyz.kpxe
     mac: '02:00:00:50:58:01'
-    # NEW (both optional, defaulted at preflight):
-    expected_fetch: auto         # auto | host_pin | menu | <literal path under netbootxyz_self_url>
-    expected_substring: ''       # optional grep on the served file body; empty = skip body check
 ```
 
-`expected_fetch` resolution order:
+Per-case expected behaviour is fully derived at runtime, not declared per entry:
 
-| Value | Resolves to |
-|---|---|
-| `auto` (default, or unset) | If `mac` is set and is in `netboot_host_pins` → `/menus/host/MAC-<hexraw>.ipxe`. Otherwise → `/menu.ipxe`. |
-| `host_pin` | Force `/menus/host/MAC-<hexraw>.ipxe`. Fails preflight if `mac` not set. |
-| `menu` | Force `/menu.ipxe`. |
-| `<literal path>` | Used verbatim. Caller is responsible for it being a valid path under `netbootxyz_self_url`. |
+- **Path:** `/menus/host/MAC-<hexraw>.ipxe`, where `<hexraw>` comes from the VM's actual MAC observed in the rb5009 DHCP lease (the test fixture's declared `mac:` if pinned, or KubeVirt's auto-generated MAC if not).
+- **Expected status:** 200 if that MAC is in `netboot_host_pins`, otherwise 404.
+- **Expected substring (preflight only, pinned MACs):** the playbook ships a `pxe_test_substring_defaults` map keyed by lowercase MAC (default for both smoke pins: `=== pxe-test smoke pin:`). This drives only the preflight static check; per-case substring assertion is dropped because preflight already validated the body.
 
-`expected_substring`:
-
-- Empty (default) — substring check skipped.
-- For the two smoke pins, the playbook ships defaults at the playbook-vars level (a `pxe_test_substring_defaults` map keyed by MAC); a per-entry `expected_substring` overrides. Default for both smoke pins: `=== pxe-test smoke pin:`.
-- Body is fetched once by the preflight static check and re-used for the assertion (no second GET).
+YAGNI: no escape-hatch override fields. If a non-default case is needed later, add the field then.
 
 ## Inventory schema
 
@@ -120,101 +122,120 @@ iPXE's `${mac:hexraw}` produces the same form (lowercase, no separators), confir
 
 Used twice: once during preflight per smoke pin (static check), and once during per-case verification (re-uses the body cached from preflight when path matches; otherwise fetches fresh).
 
-### 3. `lookup_dhcp_lease_ip(mac)`
+### 3. `lookup_dhcp_lease(vm_name)`
 
 `community.routeros.command`, `delegate_to: rb5009`:
 
 ```
-/ip dhcp-server lease print detail without-paging where mac-address="<mac>"
+/ip dhcp-server lease print detail without-paging
+  where comment~"<vm_name>" or
+        mac-address="<vm_mac_if_known>"
 ```
 
-Wrapped in `until` retry — up to 30 seconds, 5-second interval — because the iPXE DHCP exchange can lag a few seconds behind VMI Ready. Fails the case if no lease appears with a distinct error: `VM <name> (MAC <mac>) never received a DHCP lease from rb5009 within 30s. Check OVN bridging on the CUDN.` This message intentionally points at the network layer, not at netbootxyz — the failure mode is independent.
+The lookup uses a pinned MAC if `pxe_test_arches` declared one, otherwise it queries by recently-seen MAC matching the VM's CUDN/IP range. In practice, the simplest approach is: read the VirtualMachineInstance's `.spec.domain.devices.interfaces[].macAddress` (KubeVirt fills this in even for auto-generated MACs by the time VMI is Ready), then query rb5009 by that MAC. The output line yields BOTH `address=<ip>` and `mac-address=<mac>` (uppercase from RouterOS; we lowercase it).
 
-### 4. `grep_nbxyz_log_since(host_ip, since_seconds)`
+Wrapped in `until` retry — up to 30 seconds, 5-second interval — because the iPXE DHCP exchange can lag a few seconds behind VMI Ready. Fails the case if no lease appears with: `VM <name> (MAC <mac>) never received a DHCP lease from rb5009 within 30s. Check OVN bridging on the CUDN.` This message intentionally points at the network layer, not at netbootxyz — the failure mode is independent.
 
-`delegate_to: {{ netbootxyz_host }}` (truenas), runs:
+Outputs (set as facts on the caller): `_vm_ip`, `_vm_mac` (lowercase, with colons).
+
+### 4. `read_nbxyz_access_lines_since(pre_line_count)`
+
+`delegate_to: {{ netbootxyz_host }}` (truenas). Two-shot: snapshot the access-log line count before the case starts, then read everything appended after.
+
+Pre-snapshot:
+```
+docker exec ix-netbootxyz-netbootxyz-1 wc -l /config/log/nginx/access.log
+```
+
+Post-read (returns only lines after the snapshot index):
+```
+docker exec ix-netbootxyz-netbootxyz-1 sh -c 'tail -n +<pre_count+1> /config/log/nginx/access.log'
+```
+
+Each line is then parsed with a regex into `{src_ip, method, path, status}`. Filtering and assertion happens in `_verify_http.yml`.
+
+Spike findings (recorded as a header comment in `_verify_http.yml`):
 
 ```
-podman logs --since={{ since_seconds }}s {{ netbootxyz_container_name }}
+runtime         = docker (TrueNAS SCALE uses Docker, not podman)
+container_name  = ix-netbootxyz-netbootxyz-1   (TrueCharts naming)
+access_log_path = /config/log/nginx/access.log (inside the container; nginx
+                  is configured to write to a file, not stdout — `docker logs`
+                  only carries the dnsmasq-tftp output)
+read_strategy   = wc -l snapshot before, tail -n +<N> after
 ```
 
-with the result piped through a regex filter for `host_ip`. Returns the list of fetched paths (one per nginx access-log line that matches the IP).
-
-`since_seconds` is captured at the start of each case as `(now() - case_start_ts) + 5` (small slop) — relative seconds rather than absolute timestamps, so we don't depend on truenas/test-runner clock alignment.
-
-`netbootxyz_container_name` defaults to `netbootxyz`. The existing TrueNAS deployment name needs to be confirmed in the implementation plan (Task 1 spike — `podman ps --filter name=netbootxyz` + `podman inspect` on the LogConfig). If the linuxserver image logs to a file rather than stdout, this primitive switches to `cat <log_path>` instead; same interface to the caller.
+Slice-by-line-count (instead of `--since=<seconds>`) survives clock skew and is robust regardless of log driver.
 
 ## Per-case assertion logic (`_verify_http.yml`)
 
-Inputs (as task vars): `vm_name`, `vm_mac`, `vm_ip`, `expected_fetch_path`, `expected_substring`, `case_start_ts`.
+Inputs (as task vars): `vm_name`, `vm_mac`, `vm_ip`, `expected_status`, `pre_log_line_count`. Path is derived inline from `vm_mac`.
 
 Steps:
 
-1. `fetched_paths = grep_nbxyz_log_since(vm_ip, now() - case_start_ts + 5)`.
-2. Assert `expected_fetch_path in fetched_paths`. Fail msg: `VM {{ vm_name }} (IP {{ vm_ip }}) was expected to fetch {{ expected_fetch_path }} from netbootxyz but the access log shows: {{ fetched_paths }}. Either iPXE never reached the netbootxyz HTTP root (check the chain to {{ netbootxyz_self_url }} from the binary), or the matcher table is wrong.`
-3. If `expected_fetch_path == '/menu.ipxe'`: assert no element of `fetched_paths` matches `^/menus/host/MAC-`. Fail msg: `Random-MAC VM {{ vm_name }} unexpectedly fetched a per-host file ({{ <matching path> }}). Either menu fall-through is broken or a stale host file is being served.`
-4. If `expected_substring` is non-empty:
-   - If `expected_fetch_path == /menu.ipxe` → skip; preflight already validated the body at startup.
-   - Else if `expected_fetch_path` is in the preflight body cache (a per-host pin path covered by the static check) → re-use the cached body, assert substring present.
-   - Else (literal path not pre-fetched) → fetch the URL fresh with `ansible.builtin.uri`, assert substring present.
+1. Read access lines appended after `pre_log_line_count` (primitive 4 above).
+2. Parse each line into `{src_ip, method, path, status}` via regex.
+3. Filter to lines where `src_ip == vm_ip`.
+4. Compute `expected_path = '/menus/host/MAC-' + (vm_mac | regex_replace(':', '') | lower) + '.ipxe'`.
+5. Assert exactly one filtered line has `method == 'GET'`, `path == expected_path`, `status | int == expected_status | int`.
+
+Failure messages:
+
+- No line at all from `vm_ip` → `VM {{ vm_name }} (IP {{ vm_ip }}) made no HTTP requests to netbootxyz. iPXE never reached the chainload step. Check the rb5009 TFTP server, the chain target inside the iPXE binary, or VLAN reachability between the VM CUDN and {{ netbootxyz_host }}.`
+- Line for `vm_ip` exists but on a different path → `VM {{ vm_name }} fetched {{ <observed path> }} instead of {{ expected_path }}. The chain inside the menu.ipxe served by netbootxyz may be wrong.`
+- Right path but wrong status → `VM {{ vm_name }} hit {{ expected_path }} but got {{ <observed status> }} (expected {{ expected_status }}). Pinned-MAC case = stale or missing host file; random-MAC case = a per-host file exists for what should be an unpinned MAC.`
 
 ## Orchestration changes
 
 ### Serial mode (`_arch_test.yml`)
 
-Per-case block, between "pause" and "Snapshot rb5009 TFTP hits AFTER":
+Per-case flow:
 
-```yaml
-- name: "Wait for {{ _vm_name }} DHCP lease (MAC {{ _vm_mac }})"
-  # primitive 3 — populates _vm_ip
-- name: "Verify HTTP fetch for {{ _vm_name }}"
-  ansible.builtin.include_tasks: _verify_http.yml
-  vars:
-    vm_name: "{{ _vm_name }}"
-    vm_mac: "{{ _vm_mac }}"
-    vm_ip: "{{ _vm_ip }}"
-    expected_fetch_path: "{{ _expected_fetch_path }}"
-    expected_substring: "{{ _expected_substring }}"
-    case_start_ts: "{{ _case_start_ts }}"
-```
-
-`_case_start_ts` is captured before the "Apply VM" step. `_expected_fetch_path` and `_expected_substring` come from preflight's per-case resolution table.
+1. Snapshot pre log line count (primitive 4 pre-shot).
+2. Snapshot pre TFTP hits (existing).
+3. Apply VM, wait Ready (existing).
+4. Lookup DHCP lease → `_vm_ip` AND `_vm_mac` (primitive 3, augmented to extract both).
+5. Pause (existing).
+6. Snapshot post TFTP hits (existing).
+7. TFTP-hits assert (existing).
+8. Compute `_expected_status = 200 if _vm_mac in _pxe_pinned_macs else 404`.
+9. `include_tasks: _verify_http.yml` with `{vm_name, vm_mac, vm_ip, expected_status, pre_log_line_count}`.
 
 ### Parallel mode (`test_netboot_pxe.yml`)
 
-The "Snapshot AFTER" block gains a sibling `include_tasks: _verify_http.yml` looped per case, after the existing TFTP-hits assertion. Each iteration uses its own `vm_ip` (resolved via primitive 3 once per VM, between "Wait for all VMs to reach Ready" and the long pause) and its own `case_start_ts` (the same shared `pre` timestamp captured before the batch apply works fine — the per-IP grep narrows correctly).
+Same flow but batched: the pre log line count is captured once (shared); each VM's lease lookup yields its own `vm_ip`/`vm_mac`; the verify step is looped per case. Per-VM-IP filtering inside `_verify_http.yml` keeps the cases independent inside the shared log slice.
 
 ## Idempotency, retries, timing
 
 | Concern | Handling |
 |---|---|
 | iPXE DHCP can lag VMI Ready by a few seconds | DHCP lease lookup retries for 30s, 5s interval. |
-| `podman logs --since=<rel>` survives clock skew | Use relative seconds, captured per-case. |
-| Log rotation between snapshots | Bounded by the `pause` window (≤180s default). nginx access logs at homelab volume rotate on size, not by minute — extremely unlikely to rotate inside a single case. Flagged, not designed-around. |
-| Parallel mode: log lines from N VMs interleave | Per-VM-IP grep handles it. Two VMs sharing a dynamic IP would alias — impossible in practice with the rb5009 DHCP pool. Flagged. |
+| Clock skew between test runner and TrueNAS | Slice-by-line-count (`wc -l` pre, `tail -n +<N>` post) — no timestamp arithmetic. |
+| Log rotation between snapshots | nginx access log inside `ix-netbootxyz-netbootxyz-1` rotates on size, not by minute, at homelab volume. The slice-by-line-count window is bounded by one `pause` (≤180s default) — rotation inside that window is extremely unlikely. Flagged, not designed-around. |
+| Parallel mode: log lines from N VMs interleave | Per-VM-IP filter inside the slice handles it. Two VMs sharing a dynamic IP would alias — impossible in practice with rb5009's DHCP pool. Flagged. |
 | Re-running the playbook | Preflight is read-only. Per-case work is unchanged in idempotency: VM applied → asserted → deleted. No state persists between runs. |
 
 ## Risks and mitigations
 
 | Risk | Mitigation |
 |---|---|
-| netbootxyz container name or log path differs from what this design assumes | Plan Task 1 spike confirms via `podman ps` / `podman inspect` on truenas. Outcome documented as a header comment in `_verify_http.yml`. |
-| Time skew test-runner ↔ truenas | Relative `--since=<seconds>` instead of absolute timestamp. |
-| Log rotation drops lines mid-test | `pause` capped at ≤180s; rotation by line count not seen at homelab volume; flagged in code comment. |
-| nginx returns 200 for a wrong path (e.g. `/host/MAC-…` falls through to `index.html`) | Preflight static pin-content substring check fails fast before any VM boots. |
+| netbootxyz container name or log layout differs from what this design assumes | Captured by Task 1 spike (recorded above). Container name `ix-netbootxyz-netbootxyz-1`, log at `/config/log/nginx/access.log`, runtime `docker`. |
+| Clock skew | Line-count slicing, no timestamps. |
+| Log rotation drops lines mid-test | Bounded by ≤180s pause; nginx rotates on size, not by minute; flagged in code comment. |
+| nginx returns 200 for a wrong path (e.g. directory listing instead of the per-host file) | Preflight static pin-content substring check fails fast before any VM boots. |
 | Smoke pin fragment in inventory drifts from what's served | Same preflight check — substring match catches drift. |
 | iPXE retains the IP into a kernel that DHCPs again later (would generate extra log lines) | Smoke VMs are diskless; iPXE never hands off to a kernel. The pin fragments `exit 0` after the echo. Not a concern for the smoke cases. |
-| Test runner can't reach `netbootxyz_self_url` (e.g. wrong VLAN) | Preflight HTTP probe of `/menu.ipxe` fails fast with the relevant URL in the error. |
-| `podman logs` requires elevated privileges on truenas | The truenas connection is already root for other playbooks; verified at plan time. |
+| Test runner can't reach `netbootxyz_self_url` (e.g. wrong VLAN) | Preflight HTTP probe of `/` fails fast with the relevant URL in the error. |
+| `docker exec` requires elevated privileges on truenas | The truenas connection is already root for other playbooks (`playbooks/truenas/*`); verified at plan time. |
 
 ## Testing strategy
 
 Manual ladder, run from the existing AWX EE / ansible-navigator container:
 
-1. Run with current default `pxe_test_arches`. Confirm: 4 cases pass — 2 pinned (BIOS + UEFI smoke pins) match per-host file fetched, 2 random match menu fetched and no host/MAC fetched.
-2. Negative: temporarily rename `host/MAC-020000505801.ipxe` on truenas. Re-run. Expect: that case fails with "expected to fetch /menus/host/MAC-020000505801.ipxe but the access log shows: [...menu.ipxe]". Restore the file.
+1. Run with current default `pxe_test_arches`. Confirm: 4 cases pass — 2 pinned MACs see `/menus/host/MAC-…` returning 200 (and the substring check at preflight passes), 2 random MACs see the same path returning 404.
+2. Negative: temporarily rename `host/MAC-020000505801.ipxe` on truenas. Re-run. Expect: preflight catches it first (404 on the pre-fetch) before any VM boots. Restore the file.
 3. Negative: temporarily corrupt the smoke pin fragment body (edit inventory, run `playbooks/netboot/deploy_assets.yml --tags render,push`). Re-run smoke test. Expect: preflight fails on the substring check before any VM boots.
-4. Negative: stop the netbootxyz container. Re-run smoke test. Expect: preflight fails on the `/menu.ipxe` HTTP probe.
+4. Negative: stop the netbootxyz container. Re-run smoke test. Expect: preflight fails on the HTTP `/` probe.
 5. Re-run twice in succession with no changes — both runs report identical pass/fail (no per-run state).
 6. `ansible-lint --profile=production` and `yamllint` clean before commit.
 
@@ -222,13 +243,13 @@ No molecule scenario (consistent with the rest of `playbooks/kubevirt/`).
 
 ## Open items resolved during brainstorming
 
-- Cases verified headlessly: pin-fetch (per-host short-circuit), menu-fetch (unpinned fall-through), pin fragment served-correctly. NOT pin-fragment-executed (rejected as "needs serial console scraping or phone-home — out of scope here").
-- Verification mechanism: hybrid HTTP fetch by test runner (catches static config drift) + container access log grep (catches dynamic dispatch breakage). No virtctl console; no probe URL.
+- Cases verified headlessly: pin-fetch (per-host short-circuit, expect 200 on the per-host path), menu-fetch (unpinned fall-through, expect 404 on the per-host path — the 404 IS the proof of fall-through). NOT pin-fragment-executed (rejected as "needs serial console scraping or phone-home — out of scope here").
+- Verification mechanism: HTTP fetch by test runner at preflight (catches static config drift) + nginx access log slice via `docker exec ... tail` (catches dynamic dispatch breakage). No virtctl console; no probe URL.
 - Test fixture location: `pxe_test_arches` stays in the playbook (test concern). Inventory `netboot_host_pins` is read-only from the test's perspective.
 - Inventory schema: unchanged. No `smoke_test:` flag added.
 - Real-host pins (helpernode/p330/hpg5/etc.): NOT booted by the test. Only the two `02:00:00:50:58:0*` smoke pins.
-- Negative menu assertion (no host/MAC-* fetched on random-MAC cases): YES, included.
-- Substring check on served pin body: test-side default substring map keyed by MAC, per-case override available. Inventory stays clean.
+- Per-case discriminator: nginx HTTP **status code** on the per-host path (200 vs 404). Single observable, two interpretations. Replaces the original "menu.ipxe vs host/MAC-* path" framing — `menu.ipxe` is served via TFTP, not HTTP, in the actual deployment (Task 1 spike).
+- Substring check on served pin body: preflight only (test-side default substring map keyed by MAC). Per-case substring assertion dropped because preflight already validates the body.
 - Boot-flip helper playbook: out of scope; deferred to a follow-up brainstorm. The four primitives this design produces are the foundation it will reuse.
-- IP source for grep correlation: rb5009 DHCP lease table (works whether or not qemu-guest-agent is in the boot image — and the diskless smoke VMs never run guest-agent anyway).
-- Container name / log driver assumptions: deferred to plan Task 1 spike on truenas; outcome captured as a header comment in `_verify_http.yml`.
+- IP **and MAC** source for log correlation: rb5009 DHCP lease table — query yields both the IP and the MAC (so KubeVirt-generated random MACs are observable without reading VMI status).
+- Container name / log layout: confirmed by Task 1 spike. Container `ix-netbootxyz-netbootxyz-1` (TrueCharts naming on TrueNAS SCALE), runtime `docker`, nginx access log at `/config/log/nginx/access.log` inside the container, read via `docker exec ... tail` since nginx is configured to log to a file rather than stdout.

--- a/docs/superpowers/specs/2026-05-09-test-netboot-pxe-headless-design.md
+++ b/docs/superpowers/specs/2026-05-09-test-netboot-pxe-headless-design.md
@@ -1,0 +1,234 @@
+# Headless verification for `test_netboot_pxe` — design
+
+**Date:** 2026-05-09
+**Status:** approved (brainstorming complete)
+**Scope:** extend `playbooks/kubevirt/test_netboot_pxe/` so each smoke-test VM verifies, without console scraping, that the netbootxyz HTTP server served the *expected* file (per-host pin or main menu) to the VM's leased IP. Today the playbook only confirms the iPXE binary fetched from rb5009 (TFTP hits) — the comment block at the top of `test_netboot_pxe.yml` explicitly defers the iPXE → TrueNAS chainload check because "that needs console scraping." This design closes that gap.
+
+## Goals
+
+- Headlessly assert that a pinned-MAC VM causes netbootxyz to serve `/menus/host/MAC-<hexraw>.ipxe`, and that an unpinned VM causes it to serve `/menu.ipxe` and *not* any per-host file.
+- Detect three regression classes the current playbook misses: (a) the deployed pin file is stale or wrong, (b) iPXE fetched the binary but never chained to netbootxyz, (c) the menu fall-through is silently chaining to a leftover per-host file.
+- Leave behind reusable verification primitives (HTTP fetch a pin file, look up a DHCP lease IP, grep the netbootxyz access log) that a future operator-facing "set/clear default boot" playbook can consume — without designing or building that playbook here.
+- Honour the existing block/always cleanup contract: a failed assertion still tears down its VM.
+- Stay compatible with both serial and parallel modes already in `test_netboot_pxe.yml`.
+
+## Non-goals
+
+- The operator-facing boot-flip playbook (`set_host_boot.yml` / `clear_host_boot.yml`). Out of scope; deferred to a follow-up brainstorm. The primitives this design produces are the foundation it will sit on.
+- Verifying that iPXE *executed* the fragment body (vs. merely fetched it). That still needs serial console scraping or a phone-home probe; both were explicitly rejected during brainstorming. The HTTP-side check covers the regressions the user actually hits.
+- Booting real-host pins (helpernode, p330, hpg5, 5847ca77098a, 998877664433, 02:9f:47:58:1b:f7). Their fragments would attempt real OS installs. Test fixtures stay limited to the two smoke pins (`02:00:00:50:58:01`, `02:00:00:50:58:02`).
+- Changing the inventory schema. `netboot_host_pins` is read-only from the test's perspective; no `smoke_test:` flag, no parallel test-case list in inventory.
+- Touching the iPXE binary build (`playbooks/routeros/deploy_netboot_binaries.yml`) or the asset-management playbook (`playbooks/netboot/deploy_assets.yml`).
+
+## Architecture
+
+Each test case already runs through this skeleton (block/always, with snapshots before/after the VM boot):
+
+```
+pre  = TFTP hits on rb5009
+apply VM, wait for Ready, pause for boot
+post = TFTP hits on rb5009
+assert post > pre
+always: delete VM
+```
+
+The new check adds two more snapshot points and one more assertion to the same skeleton:
+
+```
+pre  = TFTP hits on rb5009                                    ┐
+pre  = wall-clock marker for the netbootxyz log lookback      │
+apply VM, wait for Ready                                      │
+vm_ip = lookup rb5009 DHCP lease by MAC (poll up to 30s)      │
+pause for boot wait window                                    │
+post = TFTP hits on rb5009                                    │
+post = netbootxyz container log lines since pre marker        ┘
+assert TFTP hits incremented (existing)
+assert exactly one HTTP GET for the expected path from vm_ip
+if expected = menu: assert NO GET /menus/host/MAC-* from vm_ip
+```
+
+Preflight (once per playbook run, before any VM is applied) does a separate static check:
+
+1. Build a `{mac → pin}` lookup from `netboot_host_pins`.
+2. HTTP GET `{{ netbootxyz_self_url }}/menu.ipxe` → 200 + body starts with `#!ipxe`. Catches netbootxyz being down before any VM is wasted.
+3. For every smoke pin in inventory (the `02:00:00:50:58:0*` ones), HTTP GET `{{ netbootxyz_self_url }}/menus/host/MAC-<hexraw>.ipxe` → 200 + body contains the pin-specific substring (default `=== pxe-test smoke pin:`). Catches `deploy_assets.yml` being stale, separately from the per-VM dynamic check.
+
+## File layout
+
+```
+playbooks/kubevirt/test_netboot_pxe/
+  test_netboot_pxe.yml      # extended: include _preflight.yml, snapshot/grep nbxyz log in parallel mode
+  _arch_test.yml            # extended: include _verify_http.yml inside the per-case block
+  _preflight.yml            # NEW: build pin lookup, http-probe netbootxyz root, static pin-content check
+  _verify_http.yml          # NEW: shared HTTP-fetch + access-log assertion, callable per case
+  vm.yaml.j2                # unchanged
+```
+
+`_verify_http.yml` is its own file because both the serial path (`_arch_test.yml`) and the parallel path (the inline block in `test_netboot_pxe.yml`) call the same logic. Splitting it is the only way to avoid a copy-paste fork.
+
+## Test-case schema (`pxe_test_arches`) — two new optional fields
+
+```yaml
+pxe_test_arches:
+  - name: pxe-test-bios-pinned
+    arch: bios
+    binary: netboot.xyz.kpxe
+    mac: '02:00:00:50:58:01'
+    # NEW (both optional, defaulted at preflight):
+    expected_fetch: auto         # auto | host_pin | menu | <literal path under netbootxyz_self_url>
+    expected_substring: ''       # optional grep on the served file body; empty = skip body check
+```
+
+`expected_fetch` resolution order:
+
+| Value | Resolves to |
+|---|---|
+| `auto` (default, or unset) | If `mac` is set and is in `netboot_host_pins` → `/menus/host/MAC-<hexraw>.ipxe`. Otherwise → `/menu.ipxe`. |
+| `host_pin` | Force `/menus/host/MAC-<hexraw>.ipxe`. Fails preflight if `mac` not set. |
+| `menu` | Force `/menu.ipxe`. |
+| `<literal path>` | Used verbatim. Caller is responsible for it being a valid path under `netbootxyz_self_url`. |
+
+`expected_substring`:
+
+- Empty (default) — substring check skipped.
+- For the two smoke pins, the playbook ships defaults at the playbook-vars level (a `pxe_test_substring_defaults` map keyed by MAC); a per-entry `expected_substring` overrides. Default for both smoke pins: `=== pxe-test smoke pin:`.
+- Body is fetched once by the preflight static check and re-used for the assertion (no second GET).
+
+## Inventory schema
+
+**No changes.** `netboot_host_pins` is read-only. Test-side concerns stay on the test side.
+
+## Verification primitives
+
+These four operations are the building blocks. Each is implemented as a small reusable include or a `set_fact`-style task. None are coupled to KubeVirt; all are usable by future playbooks (operator-facing boot-flip, ad-hoc audit) without modification.
+
+### 1. `mac_to_pin_path(mac)` — pure jinja, no IO
+
+```jinja
+/menus/host/MAC-{{ mac | regex_replace(':', '') | lower }}.ipxe
+```
+
+iPXE's `${mac:hexraw}` produces the same form (lowercase, no separators), confirmed against `roles/netbootxyz/templates/disks/netboot.xyz.j2:101` in the upstream netboot.xyz Ansible build (already vetted in `2026-05-08-netboot-asset-management-design.md`).
+
+### 2. `assert_pin_file_served(path, expected_substring=None)`
+
+`ansible.builtin.uri` GET `{{ netbootxyz_self_url }}{{ path }}`:
+
+- `status_code: 200`
+- `return_content: true`
+- If `expected_substring` non-empty: assert it appears in `result.content`.
+
+Used twice: once during preflight per smoke pin (static check), and once during per-case verification (re-uses the body cached from preflight when path matches; otherwise fetches fresh).
+
+### 3. `lookup_dhcp_lease_ip(mac)`
+
+`community.routeros.command`, `delegate_to: rb5009`:
+
+```
+/ip dhcp-server lease print detail without-paging where mac-address="<mac>"
+```
+
+Wrapped in `until` retry — up to 30 seconds, 5-second interval — because the iPXE DHCP exchange can lag a few seconds behind VMI Ready. Fails the case if no lease appears with a distinct error: `VM <name> (MAC <mac>) never received a DHCP lease from rb5009 within 30s. Check OVN bridging on the CUDN.` This message intentionally points at the network layer, not at netbootxyz — the failure mode is independent.
+
+### 4. `grep_nbxyz_log_since(host_ip, since_seconds)`
+
+`delegate_to: {{ netbootxyz_host }}` (truenas), runs:
+
+```
+podman logs --since={{ since_seconds }}s {{ netbootxyz_container_name }}
+```
+
+with the result piped through a regex filter for `host_ip`. Returns the list of fetched paths (one per nginx access-log line that matches the IP).
+
+`since_seconds` is captured at the start of each case as `(now() - case_start_ts) + 5` (small slop) — relative seconds rather than absolute timestamps, so we don't depend on truenas/test-runner clock alignment.
+
+`netbootxyz_container_name` defaults to `netbootxyz`. The existing TrueNAS deployment name needs to be confirmed in the implementation plan (Task 1 spike — `podman ps --filter name=netbootxyz` + `podman inspect` on the LogConfig). If the linuxserver image logs to a file rather than stdout, this primitive switches to `cat <log_path>` instead; same interface to the caller.
+
+## Per-case assertion logic (`_verify_http.yml`)
+
+Inputs (as task vars): `vm_name`, `vm_mac`, `vm_ip`, `expected_fetch_path`, `expected_substring`, `case_start_ts`.
+
+Steps:
+
+1. `fetched_paths = grep_nbxyz_log_since(vm_ip, now() - case_start_ts + 5)`.
+2. Assert `expected_fetch_path in fetched_paths`. Fail msg: `VM {{ vm_name }} (IP {{ vm_ip }}) was expected to fetch {{ expected_fetch_path }} from netbootxyz but the access log shows: {{ fetched_paths }}. Either iPXE never reached the netbootxyz HTTP root (check the chain to {{ netbootxyz_self_url }} from the binary), or the matcher table is wrong.`
+3. If `expected_fetch_path == '/menu.ipxe'`: assert no element of `fetched_paths` matches `^/menus/host/MAC-`. Fail msg: `Random-MAC VM {{ vm_name }} unexpectedly fetched a per-host file ({{ <matching path> }}). Either menu fall-through is broken or a stale host file is being served.`
+4. If `expected_substring` is non-empty:
+   - If `expected_fetch_path == /menu.ipxe` → skip; preflight already validated the body at startup.
+   - Else if `expected_fetch_path` is in the preflight body cache (a per-host pin path covered by the static check) → re-use the cached body, assert substring present.
+   - Else (literal path not pre-fetched) → fetch the URL fresh with `ansible.builtin.uri`, assert substring present.
+
+## Orchestration changes
+
+### Serial mode (`_arch_test.yml`)
+
+Per-case block, between "pause" and "Snapshot rb5009 TFTP hits AFTER":
+
+```yaml
+- name: "Wait for {{ _vm_name }} DHCP lease (MAC {{ _vm_mac }})"
+  # primitive 3 — populates _vm_ip
+- name: "Verify HTTP fetch for {{ _vm_name }}"
+  ansible.builtin.include_tasks: _verify_http.yml
+  vars:
+    vm_name: "{{ _vm_name }}"
+    vm_mac: "{{ _vm_mac }}"
+    vm_ip: "{{ _vm_ip }}"
+    expected_fetch_path: "{{ _expected_fetch_path }}"
+    expected_substring: "{{ _expected_substring }}"
+    case_start_ts: "{{ _case_start_ts }}"
+```
+
+`_case_start_ts` is captured before the "Apply VM" step. `_expected_fetch_path` and `_expected_substring` come from preflight's per-case resolution table.
+
+### Parallel mode (`test_netboot_pxe.yml`)
+
+The "Snapshot AFTER" block gains a sibling `include_tasks: _verify_http.yml` looped per case, after the existing TFTP-hits assertion. Each iteration uses its own `vm_ip` (resolved via primitive 3 once per VM, between "Wait for all VMs to reach Ready" and the long pause) and its own `case_start_ts` (the same shared `pre` timestamp captured before the batch apply works fine — the per-IP grep narrows correctly).
+
+## Idempotency, retries, timing
+
+| Concern | Handling |
+|---|---|
+| iPXE DHCP can lag VMI Ready by a few seconds | DHCP lease lookup retries for 30s, 5s interval. |
+| `podman logs --since=<rel>` survives clock skew | Use relative seconds, captured per-case. |
+| Log rotation between snapshots | Bounded by the `pause` window (≤180s default). nginx access logs at homelab volume rotate on size, not by minute — extremely unlikely to rotate inside a single case. Flagged, not designed-around. |
+| Parallel mode: log lines from N VMs interleave | Per-VM-IP grep handles it. Two VMs sharing a dynamic IP would alias — impossible in practice with the rb5009 DHCP pool. Flagged. |
+| Re-running the playbook | Preflight is read-only. Per-case work is unchanged in idempotency: VM applied → asserted → deleted. No state persists between runs. |
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| netbootxyz container name or log path differs from what this design assumes | Plan Task 1 spike confirms via `podman ps` / `podman inspect` on truenas. Outcome documented as a header comment in `_verify_http.yml`. |
+| Time skew test-runner ↔ truenas | Relative `--since=<seconds>` instead of absolute timestamp. |
+| Log rotation drops lines mid-test | `pause` capped at ≤180s; rotation by line count not seen at homelab volume; flagged in code comment. |
+| nginx returns 200 for a wrong path (e.g. `/host/MAC-…` falls through to `index.html`) | Preflight static pin-content substring check fails fast before any VM boots. |
+| Smoke pin fragment in inventory drifts from what's served | Same preflight check — substring match catches drift. |
+| iPXE retains the IP into a kernel that DHCPs again later (would generate extra log lines) | Smoke VMs are diskless; iPXE never hands off to a kernel. The pin fragments `exit 0` after the echo. Not a concern for the smoke cases. |
+| Test runner can't reach `netbootxyz_self_url` (e.g. wrong VLAN) | Preflight HTTP probe of `/menu.ipxe` fails fast with the relevant URL in the error. |
+| `podman logs` requires elevated privileges on truenas | The truenas connection is already root for other playbooks; verified at plan time. |
+
+## Testing strategy
+
+Manual ladder, run from the existing AWX EE / ansible-navigator container:
+
+1. Run with current default `pxe_test_arches`. Confirm: 4 cases pass — 2 pinned (BIOS + UEFI smoke pins) match per-host file fetched, 2 random match menu fetched and no host/MAC fetched.
+2. Negative: temporarily rename `host/MAC-020000505801.ipxe` on truenas. Re-run. Expect: that case fails with "expected to fetch /menus/host/MAC-020000505801.ipxe but the access log shows: [...menu.ipxe]". Restore the file.
+3. Negative: temporarily corrupt the smoke pin fragment body (edit inventory, run `playbooks/netboot/deploy_assets.yml --tags render,push`). Re-run smoke test. Expect: preflight fails on the substring check before any VM boots.
+4. Negative: stop the netbootxyz container. Re-run smoke test. Expect: preflight fails on the `/menu.ipxe` HTTP probe.
+5. Re-run twice in succession with no changes — both runs report identical pass/fail (no per-run state).
+6. `ansible-lint --profile=production` and `yamllint` clean before commit.
+
+No molecule scenario (consistent with the rest of `playbooks/kubevirt/`).
+
+## Open items resolved during brainstorming
+
+- Cases verified headlessly: pin-fetch (per-host short-circuit), menu-fetch (unpinned fall-through), pin fragment served-correctly. NOT pin-fragment-executed (rejected as "needs serial console scraping or phone-home — out of scope here").
+- Verification mechanism: hybrid HTTP fetch by test runner (catches static config drift) + container access log grep (catches dynamic dispatch breakage). No virtctl console; no probe URL.
+- Test fixture location: `pxe_test_arches` stays in the playbook (test concern). Inventory `netboot_host_pins` is read-only from the test's perspective.
+- Inventory schema: unchanged. No `smoke_test:` flag added.
+- Real-host pins (helpernode/p330/hpg5/etc.): NOT booted by the test. Only the two `02:00:00:50:58:0*` smoke pins.
+- Negative menu assertion (no host/MAC-* fetched on random-MAC cases): YES, included.
+- Substring check on served pin body: test-side default substring map keyed by MAC, per-case override available. Inventory stays clean.
+- Boot-flip helper playbook: out of scope; deferred to a follow-up brainstorm. The four primitives this design produces are the foundation it will reuse.
+- IP source for grep correlation: rb5009 DHCP lease table (works whether or not qemu-guest-agent is in the boot image — and the diskless smoke VMs never run guest-agent anyway).
+- Container name / log driver assumptions: deferred to plan Task 1 spike on truenas; outcome captured as a header comment in `_verify_http.yml`.

--- a/playbooks/kubevirt/test_netboot_pxe/_arch_test.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_arch_test.yml
@@ -42,7 +42,7 @@
             req-filename="{{ item.binary }}"
       register: _pxe_tftp_pre
       changed_when: false
-      delegate_to: rb5009.igou.systems
+      delegate_to: "{{ pxe_test_router }}"
 
     - name: "Extract pre-boot hit count"
       ansible.builtin.set_fact:
@@ -75,7 +75,7 @@
             req-filename="{{ item.binary }}"
       register: _pxe_tftp_post
       changed_when: false
-      delegate_to: rb5009.igou.systems
+      delegate_to: "{{ pxe_test_router }}"
 
     - name: "Extract post-boot hit count"
       ansible.builtin.set_fact:

--- a/playbooks/kubevirt/test_netboot_pxe/_arch_test.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_arch_test.yml
@@ -1,32 +1,54 @@
 ---
-# Per-architecture smoke test, included once per entry in
-# pxe_test_arches by ../test_netboot_pxe.yml. Expects loop variables:
-#   item.arch    -- "bios" or "uefi-x64"
-#   item.binary  -- the corresponding netboot.xyz.* filename
+# Per-architecture smoke test, included once per entry in pxe_test_arches
+# by ../test_netboot_pxe.yml when pxe_test_parallel is false. Wrapped in
+# block/always so a failed assertion still tears down the VM before the
+# next entry attempts.
 #
-# Wrapped in block/always so a failed assertion still tears down the
-# VM before the next arch attempts.
+# Expects loop variables on `item`:
+#   item.arch    free-form arch label
+#   item.binary  TFTP filename to watch on rb5009
+# Optional per-entry overrides are documented in the parent playbook.
+#
+# Per-case assertions:
+#   1. rb5009 TFTP hit counter for `item.binary` incremented (existing).
+#   2. netbootxyz dnsmasq-tftp logs show the VM's leased IP requested
+#      /config/menus/host/MAC-<hexraw>.ipxe with outcome 'sent' (pinned
+#      MAC, file exists) or 'not_found' (random MAC, falls through to
+#      stock-menu.ipxe). See _verify_tftp.yml.
 
-- name: "Smoke-test {{ item.arch }}"
+- name: "Smoke-test {{ _vm_name }}"
   vars:
-    arch: "{{ item.arch }}"
-    binary: "{{ item.binary }}"
+    _vm_name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+    _wait: "{{ item.boot_wait_seconds | default(pxe_test_boot_wait_seconds) }}"
   block:
-    - name: Snapshot rb5009 TFTP hits BEFORE boot for {{ binary }}
+    - name: "Snapshot docker logs line count BEFORE {{ _vm_name }}"
+      ansible.builtin.shell:
+        cmd: set -o pipefail && docker logs ix-netbootxyz-netbootxyz-1 2>&1 | wc -l
+        executable: /bin/bash
+      register: _pxe_log_pre
+      changed_when: false
+      delegate_to: "{{ groups[netbootxyz_host][0] }}"
+      become: true
+
+    - name: "Capture pre log line count for {{ _vm_name }}"
+      ansible.builtin.set_fact:
+        _pre_log_line_count: "{{ _pxe_log_pre.stdout | int }}"
+
+    - name: "Snapshot rb5009 TFTP hits BEFORE boot for {{ item.binary }}"
       community.routeros.command:
         commands:
           - >-
             /ip tftp print detail without-paging where
-            req-filename="{{ binary }}"
+            req-filename="{{ item.binary }}"
       register: _pxe_tftp_pre
       changed_when: false
-      delegate_to: "{{ pxe_test_router }}"
+      delegate_to: rb5009.igou.systems
 
-    - name: Extract pre-boot hit count
+    - name: "Extract pre-boot hit count"
       ansible.builtin.set_fact:
         _pxe_hits_pre: "{{ _pxe_tftp_pre.stdout[0] | regex_search('hits=\\d+') | default('hits=0') | regex_replace('^hits=', '') | int }}"
 
-    - name: Apply diskless PXE-boot VM ({{ arch }})
+    - name: "Apply diskless PXE-boot VM ({{ _vm_name }})"
       kubernetes.core.k8s:
         state: present
         validate_certs: false
@@ -38,43 +60,56 @@
           status: "True"
         wait_timeout: 180
 
-    - name: Pause to let iPXE complete its boot attempt ({{ arch }})
-      ansible.builtin.pause:
-        seconds: "{{ pxe_test_boot_wait_seconds }}"
+    - name: "Resolve VM addressing for {{ _vm_name }}"
+      ansible.builtin.include_tasks: _dhcp_lease_lookup.yml
 
-    - name: Snapshot rb5009 TFTP hits AFTER boot for {{ binary }}
+    - name: "Pause to let iPXE complete its boot attempt ({{ _vm_name }})"
+      ansible.builtin.pause:
+        seconds: "{{ _wait }}"
+
+    - name: "Snapshot rb5009 TFTP hits AFTER boot for {{ item.binary }}"
       community.routeros.command:
         commands:
           - >-
             /ip tftp print detail without-paging where
-            req-filename="{{ binary }}"
+            req-filename="{{ item.binary }}"
       register: _pxe_tftp_post
       changed_when: false
-      delegate_to: "{{ pxe_test_router }}"
+      delegate_to: rb5009.igou.systems
 
-    - name: Extract post-boot hit count
+    - name: "Extract post-boot hit count"
       ansible.builtin.set_fact:
         _pxe_hits_post: "{{ _pxe_tftp_post.stdout[0] | regex_search('hits=\\d+') | default('hits=0') | regex_replace('^hits=', '') | int }}"
 
-    - name: Assert TFTP hits incremented for {{ binary }}
+    - name: "Assert TFTP hits incremented for {{ item.binary }}"
       ansible.builtin.assert:
         that:
           - (_pxe_hits_post | int) > (_pxe_hits_pre | int)
         fail_msg: >-
-          VM pxe-test-{{ arch }} did not fetch {{ binary }} from rb5009
-          within {{ pxe_test_boot_wait_seconds }}s. hits {{ _pxe_hits_pre }}
-          -> {{ _pxe_hits_post }}. Check the VMI status, the DHCP offer to
-          its MAC (`/log print where topics~"dhcp"` on rb5009), and that
-          the matcher table still routes option-93 to the right binary.
+          VM {{ _vm_name }} did not fetch {{ item.binary }} from rb5009
+          within {{ _wait }}s. hits {{ _pxe_hits_pre }} ->
+          {{ _pxe_hits_post }}. Check the VMI status, the DHCP offer to
+          its MAC (`/log print where topics~"dhcp"` on rb5009), and
+          that the matcher table still routes option-93 to the right
+          binary.
+
+    - name: "Verify TFTP dispatch for {{ _vm_name }}"
+      ansible.builtin.include_tasks: _verify_tftp.yml
+      vars:
+        vm_name: "{{ _vm_name }}"
+        vm_mac: "{{ _vm_mac }}"
+        vm_ip: "{{ _vm_ip }}"
+        expected_outcome: "{{ 'sent' if (_vm_mac in _pxe_pinned_macs) else 'not_found' }}"
+        pre_log_line_count: "{{ _pre_log_line_count }}"
 
   always:
-    - name: Delete test VM ({{ arch }})
+    - name: "Delete test VM ({{ _vm_name }})"
       kubernetes.core.k8s:
         state: absent
         validate_certs: false
         api_version: kubevirt.io/v1
         kind: VirtualMachine
         namespace: "{{ pxe_test_namespace }}"
-        name: "pxe-test-{{ arch }}"
+        name: "{{ _vm_name }}"
         wait: true
         wait_timeout: 120

--- a/playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
@@ -23,7 +23,7 @@
 # network-layer-flavoured message. Neither is confused with a
 # netbootxyz problem.
 
-- name: "Read VirtualMachineInstance for {{ _vm_name }} to learn its MAC"
+- name: "Read VirtualMachineInstance to learn its MAC -- {{ _vm_name }}"
   kubernetes.core.k8s_info:
     api_version: kubevirt.io/v1
     kind: VirtualMachineInstance
@@ -42,7 +42,7 @@
   ansible.builtin.set_fact:
     _vm_mac: "{{ _pxe_vmi_result.resources[0].spec.domain.devices.interfaces[0].macAddress | lower }}"
 
-- name: "Wait for {{ _vm_name }} DHCP lease (MAC {{ _vm_mac }})"
+- name: "Wait for DHCP lease -- {{ _vm_name }}"
   community.routeros.command:
     commands:
       - >-

--- a/playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
@@ -68,3 +68,9 @@
       VM {{ _vm_name }} (MAC {{ _vm_mac }}) appears to have a lease
       entry on rb5009 but no address= field could be parsed. Raw:
       {{ _pxe_lease_query.stdout[0] }}
+
+- name: "Append to address map (parallel caller) -- {{ _vm_name }}"
+  ansible.builtin.set_fact:
+    _pxe_vm_addr_map: >-
+      {{ (_pxe_vm_addr_map | default({}))
+         | combine({_vm_name: {'mac': _vm_mac, 'ip': _vm_ip}}) }}

--- a/playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
@@ -50,7 +50,7 @@
         where mac-address="{{ _vm_mac | upper }}"
   register: _pxe_lease_query
   changed_when: false
-  delegate_to: rb5009.igou.systems
+  delegate_to: "{{ pxe_test_router }}"
   retries: 6
   delay: 5
   until: _pxe_lease_query.stdout[0] is search('address=')

--- a/playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_dhcp_lease_lookup.yml
@@ -1,0 +1,70 @@
+---
+# Resolve a VM's MAC and IP for the headless smoke test.
+#
+# Step A reads the VirtualMachineInstance to learn the MAC. KubeVirt
+# fills .spec.domain.devices.interfaces[].macAddress in regardless of
+# whether the test fixture pinned a MAC or asked KubeVirt to generate
+# one -- so this works for both pinned and random cases.
+#
+# Step B queries rb5009 for the DHCP lease for that MAC. Up to 30s of
+# retry budget because iPXE's DHCP exchange can lag VMI Ready by a few
+# seconds, especially in parallel mode.
+#
+# Inputs (task vars expected on caller):
+#   _vm_name   for messages and loop labels
+#   pxe_test_namespace -- already a play-level var
+#
+# Outputs (set as facts):
+#   _vm_mac    lowercase, with colons (e.g. "02:00:00:50:58:01")
+#   _vm_ip     dotted-quad string (e.g. "10.10.9.42")
+#
+# Failure modes are distinct: an unreadable VMI fails on Step A with a
+# k8s-flavoured message; a missing DHCP lease fails on Step C with a
+# network-layer-flavoured message. Neither is confused with a
+# netbootxyz problem.
+
+- name: "Read VirtualMachineInstance for {{ _vm_name }} to learn its MAC"
+  kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
+    kind: VirtualMachineInstance
+    namespace: "{{ pxe_test_namespace }}"
+    name: "{{ _vm_name }}"
+    validate_certs: false
+  register: _pxe_vmi_result
+  retries: 6
+  delay: 5
+  until:
+    - _pxe_vmi_result.resources | length == 1
+    - _pxe_vmi_result.resources[0].spec.domain.devices.interfaces | default([]) | length > 0
+    - _pxe_vmi_result.resources[0].spec.domain.devices.interfaces[0].macAddress is defined
+
+- name: "Set _vm_mac fact for {{ _vm_name }}"
+  ansible.builtin.set_fact:
+    _vm_mac: "{{ _pxe_vmi_result.resources[0].spec.domain.devices.interfaces[0].macAddress | lower }}"
+
+- name: "Wait for {{ _vm_name }} DHCP lease (MAC {{ _vm_mac }})"
+  community.routeros.command:
+    commands:
+      - >-
+        /ip dhcp-server lease print detail without-paging
+        where mac-address="{{ _vm_mac | upper }}"
+  register: _pxe_lease_query
+  changed_when: false
+  delegate_to: rb5009.igou.systems
+  retries: 6
+  delay: 5
+  until: _pxe_lease_query.stdout[0] is search('address=')
+
+- name: "Extract IP from lease for {{ _vm_name }}"
+  ansible.builtin.set_fact:
+    _vm_ip: "{{ _pxe_lease_query.stdout[0] | regex_search('address=([0-9.]+)', '\\1') | first }}"
+
+- name: "Assert IP was extracted for {{ _vm_name }}"
+  ansible.builtin.assert:
+    that:
+      - _vm_ip is defined
+      - _vm_ip | length > 0
+    fail_msg: >-
+      VM {{ _vm_name }} (MAC {{ _vm_mac }}) appears to have a lease
+      entry on rb5009 but no address= field could be parsed. Raw:
+      {{ _pxe_lease_query.stdout[0] }}

--- a/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
@@ -44,7 +44,7 @@
 
 - name: Preflight -- ensure host pin directory exists on TrueNAS
   ansible.builtin.file:
-    path: "/mnt/ssd/containers/netbootxyz/config/menus/host"
+    path: "{{ netbootxyz_root }}/config/menus/host"
     state: directory
     mode: '0755'
   delegate_to: "{{ groups[netbootxyz_host][0] }}"
@@ -53,7 +53,7 @@
 - name: Preflight -- deploy each smoke pin from inventory to /config/menus/host/
   ansible.builtin.copy:
     content: "{{ (netboot_host_pins | selectattr('mac', 'equalto', item) | first).fragment }}"
-    dest: "/mnt/ssd/containers/netbootxyz/config/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe"
+    dest: "{{ netbootxyz_root }}/config/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe"
     mode: '0644'
     owner: "1000"
     group: "1000"

--- a/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
@@ -1,18 +1,17 @@
 ---
-# Preflight for the netboot.xyz HTTP-side smoke test. Runs once at the
-# top of test_netboot_pxe.yml, before any VM is applied.
+# Preflight for the netboot.xyz smoke test. Runs once at the top of
+# test_netboot_pxe.yml, before any VM is applied.
 #
 # Stages (each gated on the previous):
 #   1. HTTP-probe netbootxyz_self_url/ (the asset root) -- fails fast
 #      if nginx is down. NB: /menu.ipxe is NOT HTTP-served in this
 #      deployment; iPXE TFTP-fetches it from the netbootxyz container's
 #      built-in dnsmasq.
-#   2. (Task 3) Build set of pinned MACs from netboot_host_pins,
-#      HTTP-fetch every smoke pin file referenced by pxe_test_arches,
-#      assert each body contains its expected substring, cache bodies.
-#
-# All preflight tasks delegate_to: localhost -- no TrueNAS or rb5009
-# contact at this stage.
+#   2. Build set of pinned MACs from netboot_host_pins, then collect
+#      the subset referenced by pxe_test_arches.
+#   3. Deploy each smoke pin file into /config/menus/host/ on the
+#      netbootxyz container, then read it back via `docker exec cat`
+#      and assert substring.
 
 - name: Preflight -- netbootxyz HTTP root is reachable
   ansible.builtin.uri:
@@ -43,32 +42,51 @@
          | select('in', _pxe_pinned_macs)
          | list }}
 
-- name: Preflight -- fetch each smoke pin file from netbootxyz
-  ansible.builtin.uri:
-    url: "{{ netbootxyz_self_url }}/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe"
-    return_content: true
-    status_code: 200
-    timeout: 10
-  register: _pxe_preflight_pin_results
-  delegate_to: localhost
-  changed_when: false
+- name: Preflight -- ensure host pin directory exists on TrueNAS
+  ansible.builtin.file:
+    path: "/mnt/ssd/containers/netbootxyz/config/menus/host"
+    state: directory
+    mode: '0755'
+  delegate_to: "{{ groups[netbootxyz_host][0] }}"
+  become: true
+
+- name: Preflight -- deploy each smoke pin from inventory to /config/menus/host/
+  ansible.builtin.copy:
+    content: "{{ (netboot_host_pins | selectattr('mac', 'equalto', item) | first).fragment }}"
+    dest: "/mnt/ssd/containers/netbootxyz/config/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe"
+    mode: '0644'
+  delegate_to: "{{ groups[netbootxyz_host][0] }}"
+  become: true
   loop: "{{ _pxe_preflight_pin_macs }}"
   loop_control:
     label: "MAC-{{ item | regex_replace(':', '') }}.ipxe"
 
-- name: Preflight -- assert each smoke pin body contains its expected substring
+- name: Preflight -- read each deployed smoke pin back via docker exec
+  ansible.builtin.command:
+    cmd: >-
+      docker exec ix-netbootxyz-netbootxyz-1
+      cat /config/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe
+  register: _pxe_preflight_pin_readback
+  changed_when: false
+  delegate_to: "{{ groups[netbootxyz_host][0] }}"
+  become: true
+  loop: "{{ _pxe_preflight_pin_macs }}"
+  loop_control:
+    label: "MAC-{{ item | regex_replace(':', '') }}.ipxe"
+
+- name: Preflight -- assert each deployed smoke pin contains its expected substring
   ansible.builtin.assert:
     that:
-      - _expected_substring == '' or _expected_substring in item.content
+      - _expected_substring == '' or _expected_substring in item.stdout
     fail_msg: >-
-      Pin file MAC-{{ item.item | regex_replace(':', '') }}.ipxe at
-      {{ netbootxyz_self_url }} returned 200 but its body does not contain
-      the expected substring '{{ _expected_substring }}'. This usually
-      means inventory's netboot_host_pins was changed but
-      playbooks/netboot/deploy_assets.yml has not been re-run.
-      First 200 chars: {{ item.content[:200] }}
+      Pin file MAC-{{ item.item | regex_replace(':', '') }}.ipxe was
+      deployed to /config/menus/host/ but its body does not contain
+      the expected substring '{{ _expected_substring }}'. This means
+      inventory's netboot_host_pins[].fragment for that MAC has changed
+      and the substring map at pxe_test_substring_defaults is out of
+      sync. First 200 chars of deployed file: {{ item.stdout[:200] }}
   vars:
     _expected_substring: "{{ pxe_test_substring_defaults[item.item] | default('') }}"
-  loop: "{{ _pxe_preflight_pin_results.results }}"
+  loop: "{{ _pxe_preflight_pin_readback.results }}"
   loop_control:
     label: "{{ item.item | regex_replace(':', '') }}.ipxe"

--- a/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
@@ -19,6 +19,5 @@
     url: "{{ netbootxyz_self_url }}/"
     status_code: 200
     timeout: 10
-  register: _pxe_preflight_root
   delegate_to: localhost
   changed_when: false

--- a/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
@@ -1,0 +1,24 @@
+---
+# Preflight for the netboot.xyz HTTP-side smoke test. Runs once at the
+# top of test_netboot_pxe.yml, before any VM is applied.
+#
+# Stages (each gated on the previous):
+#   1. HTTP-probe netbootxyz_self_url/ (the asset root) -- fails fast
+#      if nginx is down. NB: /menu.ipxe is NOT HTTP-served in this
+#      deployment; iPXE TFTP-fetches it from the netbootxyz container's
+#      built-in dnsmasq.
+#   2. (Task 3) Build set of pinned MACs from netboot_host_pins,
+#      HTTP-fetch every smoke pin file referenced by pxe_test_arches,
+#      assert each body contains its expected substring, cache bodies.
+#
+# All preflight tasks delegate_to: localhost -- no TrueNAS or rb5009
+# contact at this stage.
+
+- name: Preflight -- netbootxyz HTTP root is reachable
+  ansible.builtin.uri:
+    url: "{{ netbootxyz_self_url }}/"
+    status_code: 200
+    timeout: 10
+  register: _pxe_preflight_root
+  delegate_to: localhost
+  changed_when: false

--- a/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
@@ -55,6 +55,8 @@
     content: "{{ (netboot_host_pins | selectattr('mac', 'equalto', item) | first).fragment }}"
     dest: "/mnt/ssd/containers/netbootxyz/config/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe"
     mode: '0644'
+    owner: "1000"
+    group: "1000"
   delegate_to: "{{ groups[netbootxyz_host][0] }}"
   become: true
   loop: "{{ _pxe_preflight_pin_macs }}"

--- a/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_preflight.yml
@@ -21,3 +21,54 @@
     timeout: 10
   delegate_to: localhost
   changed_when: false
+
+- name: Preflight -- build set of pinned MACs (lowercase) from inventory
+  ansible.builtin.set_fact:
+    _pxe_pinned_macs: >-
+      {{ netboot_host_pins
+         | default([])
+         | selectattr('mac', 'defined')
+         | map(attribute='mac')
+         | map('lower')
+         | list }}
+
+- name: Preflight -- collect pinned MACs referenced by pxe_test_arches
+  ansible.builtin.set_fact:
+    _pxe_preflight_pin_macs: >-
+      {{ pxe_test_arches
+         | selectattr('mac', 'defined')
+         | map(attribute='mac')
+         | map('lower')
+         | unique
+         | select('in', _pxe_pinned_macs)
+         | list }}
+
+- name: Preflight -- fetch each smoke pin file from netbootxyz
+  ansible.builtin.uri:
+    url: "{{ netbootxyz_self_url }}/menus/host/MAC-{{ item | regex_replace(':', '') }}.ipxe"
+    return_content: true
+    status_code: 200
+    timeout: 10
+  register: _pxe_preflight_pin_results
+  delegate_to: localhost
+  changed_when: false
+  loop: "{{ _pxe_preflight_pin_macs }}"
+  loop_control:
+    label: "MAC-{{ item | regex_replace(':', '') }}.ipxe"
+
+- name: Preflight -- assert each smoke pin body contains its expected substring
+  ansible.builtin.assert:
+    that:
+      - _expected_substring == '' or _expected_substring in item.content
+    fail_msg: >-
+      Pin file MAC-{{ item.item | regex_replace(':', '') }}.ipxe at
+      {{ netbootxyz_self_url }} returned 200 but its body does not contain
+      the expected substring '{{ _expected_substring }}'. This usually
+      means inventory's netboot_host_pins was changed but
+      playbooks/netboot/deploy_assets.yml has not been re-run.
+      First 200 chars: {{ item.content[:200] }}
+  vars:
+    _expected_substring: "{{ pxe_test_substring_defaults[item.item] | default('') }}"
+  loop: "{{ _pxe_preflight_pin_results.results }}"
+  loop_control:
+    label: "{{ item.item | regex_replace(':', '') }}.ipxe"

--- a/playbooks/kubevirt/test_netboot_pxe/_verify_tftp.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_verify_tftp.yml
@@ -1,0 +1,105 @@
+---
+# Per-case TFTP-side verification for the netboot.xyz smoke test.
+# Called from both _arch_test.yml (serial mode) and the inline parallel
+# block in test_netboot_pxe.yml.
+#
+# Spike outcome (2026-05-09, see plan section "Spike outcome"):
+#   runtime          = docker (TrueNAS SCALE uses Docker)
+#   container_name  = ix-netbootxyz-netbootxyz-1   (TrueCharts naming)
+#   docker_logs      = carries dnsmasq-tftp lines (NOT nginx access lines)
+#   read_strategy    = wc -l on `docker logs` before; tail -n +<N> after;
+#                      grep dnsmasq-tftp; parse two patterns.
+#
+# Sample lines:
+#   dnsmasq-tftp[23]: sent /config/menus/host/MAC-020000505801.ipxe to 10.10.9.40
+#   dnsmasq-tftp[23]: file /config/menus/host/MAC-525400deadbe.ipxe not found for 10.10.9.41
+#
+# Inputs (task vars expected on caller):
+#   vm_name              VM name, used in messages
+#   vm_mac               lowercase MAC (with colons)
+#   vm_ip                dotted-quad IP from DHCP lease
+#   expected_outcome     'sent' (pinned) or 'not_found' (random) --
+#                          the per-case discriminator. Pinned MAC has
+#                          a deployed host file -> dnsmasq sends it.
+#                          Random MAC -> dnsmasq returns "not found"
+#                          and iPXE falls through to stock-menu.ipxe.
+#   pre_log_line_count   line count of `docker logs` captured BEFORE
+#                          the VM was applied (snapshot in caller).
+#
+# Output: assertions only; no facts set.
+
+- name: "Read post-boot docker logs slice for {{ vm_name }}"
+  ansible.builtin.shell:
+    cmd: >-
+      docker logs ix-netbootxyz-netbootxyz-1 2>&1
+      | tail -n +{{ pre_log_line_count | int + 1 }}
+      | grep dnsmasq-tftp || true
+  register: _pxe_log_slice
+  changed_when: false
+  delegate_to: "{{ groups[netbootxyz_host][0] }}"
+  become: true
+
+- name: "Parse dnsmasq-tftp lines for {{ vm_name }} (sent pattern)"
+  ansible.builtin.set_fact:
+    _pxe_sent_lines: >-
+      {{ _pxe_log_slice.stdout_lines
+         | map('regex_search',
+               '^dnsmasq-tftp\[\d+\]: sent (\S+) to ([\d.]+)$',
+               '\\1', '\\2')
+         | select('truthy')
+         | list }}
+
+- name: "Parse dnsmasq-tftp lines for {{ vm_name }} (not_found pattern)"
+  ansible.builtin.set_fact:
+    _pxe_notfound_lines: >-
+      {{ _pxe_log_slice.stdout_lines
+         | map('regex_search',
+               '^dnsmasq-tftp\[\d+\]: file (\S+) not found for ([\d.]+)$',
+               '\\1', '\\2')
+         | select('truthy')
+         | list }}
+
+- name: "Compute expected per-host path for {{ vm_name }}"
+  ansible.builtin.set_fact:
+    _pxe_expected_path: "/config/menus/host/MAC-{{ vm_mac | regex_replace(':', '') | lower }}.ipxe"
+
+- name: "Filter sent/not_found lines to {{ vm_name }} (path + IP match)"
+  ansible.builtin.set_fact:
+    _pxe_match_sent: >-
+      {{ _pxe_sent_lines
+         | selectattr('0', 'equalto', _pxe_expected_path)
+         | selectattr('1', 'equalto', vm_ip)
+         | list }}
+    _pxe_match_notfound: >-
+      {{ _pxe_notfound_lines
+         | selectattr('0', 'equalto', _pxe_expected_path)
+         | selectattr('1', 'equalto', vm_ip)
+         | list }}
+
+- name: "Assert {{ vm_name }} produced exactly one matching dnsmasq-tftp line"
+  ansible.builtin.assert:
+    that:
+      - (_pxe_match_sent | length) + (_pxe_match_notfound | length) == 1
+    fail_msg: >-
+      VM {{ vm_name }} (IP {{ vm_ip }}) -- expected exactly one
+      dnsmasq-tftp line for {{ _pxe_expected_path }} from this IP.
+      Found {{ _pxe_match_sent | length }} 'sent' and
+      {{ _pxe_match_notfound | length }} 'not_found' matches. Either
+      iPXE never reached the netbootxyz chainload step (check the
+      rb5009 -> netbootxyz path), or the menu.ipxe served by netbootxyz
+      doesn't chain to host/MAC-<hex>.ipxe at all.
+
+- name: "Assert {{ vm_name }} got the expected outcome '{{ expected_outcome }}' on {{ _pxe_expected_path }}"
+  ansible.builtin.assert:
+    that:
+      - (expected_outcome == 'sent' and _pxe_match_sent | length == 1)
+        or
+        (expected_outcome == 'not_found' and _pxe_match_notfound | length == 1)
+    fail_msg: >-
+      VM {{ vm_name }} (IP {{ vm_ip }}) hit {{ _pxe_expected_path }} but
+      dnsmasq returned the wrong outcome (expected '{{ expected_outcome }}').
+      For a pinned MAC ('sent' expected), this means the deploy step
+      in preflight failed silently or the file was removed since.
+      For a random MAC ('not_found' expected), this means a per-host
+      file exists for what should be an unpinned MAC -- check
+      /config/menus/host/ on the netbootxyz container for stale files.

--- a/playbooks/kubevirt/test_netboot_pxe/_verify_tftp.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/_verify_tftp.yml
@@ -31,39 +31,33 @@
 - name: "Read post-boot docker logs slice for {{ vm_name }}"
   ansible.builtin.shell:
     cmd: >-
+      set -o pipefail &&
       docker logs ix-netbootxyz-netbootxyz-1 2>&1
       | tail -n +{{ pre_log_line_count | int + 1 }}
       | grep dnsmasq-tftp || true
+    executable: /bin/bash
   register: _pxe_log_slice
   changed_when: false
   delegate_to: "{{ groups[netbootxyz_host][0] }}"
   become: true
 
-- name: "Parse dnsmasq-tftp lines for {{ vm_name }} (sent pattern)"
+- name: "Parse dnsmasq-tftp sent lines -- {{ vm_name }}"
   ansible.builtin.set_fact:
     _pxe_sent_lines: >-
-      {{ _pxe_log_slice.stdout_lines
-         | map('regex_search',
-               '^dnsmasq-tftp\[\d+\]: sent (\S+) to ([\d.]+)$',
-               '\\1', '\\2')
-         | select('truthy')
-         | list }}
+      {{ _pxe_log_slice.stdout
+         | regex_findall('dnsmasq-tftp\[\d+\]: sent (\S+) to ([\d.]+)') }}
 
-- name: "Parse dnsmasq-tftp lines for {{ vm_name }} (not_found pattern)"
+- name: "Parse dnsmasq-tftp not_found lines -- {{ vm_name }}"
   ansible.builtin.set_fact:
     _pxe_notfound_lines: >-
-      {{ _pxe_log_slice.stdout_lines
-         | map('regex_search',
-               '^dnsmasq-tftp\[\d+\]: file (\S+) not found for ([\d.]+)$',
-               '\\1', '\\2')
-         | select('truthy')
-         | list }}
+      {{ _pxe_log_slice.stdout
+         | regex_findall('dnsmasq-tftp\[\d+\]: file (\S+) not found for ([\d.]+)') }}
 
 - name: "Compute expected per-host path for {{ vm_name }}"
   ansible.builtin.set_fact:
     _pxe_expected_path: "/config/menus/host/MAC-{{ vm_mac | regex_replace(':', '') | lower }}.ipxe"
 
-- name: "Filter sent/not_found lines to {{ vm_name }} (path + IP match)"
+- name: "Filter sent/not_found lines by path and IP -- {{ vm_name }}"
   ansible.builtin.set_fact:
     _pxe_match_sent: >-
       {{ _pxe_sent_lines
@@ -76,7 +70,7 @@
          | selectattr('1', 'equalto', vm_ip)
          | list }}
 
-- name: "Assert {{ vm_name }} produced exactly one matching dnsmasq-tftp line"
+- name: "Assert exactly one matching dnsmasq-tftp line -- {{ vm_name }}"
   ansible.builtin.assert:
     that:
       - (_pxe_match_sent | length) + (_pxe_match_notfound | length) == 1
@@ -89,7 +83,7 @@
       rb5009 -> netbootxyz path), or the menu.ipxe served by netbootxyz
       doesn't chain to host/MAC-<hex>.ipxe at all.
 
-- name: "Assert {{ vm_name }} got the expected outcome '{{ expected_outcome }}' on {{ _pxe_expected_path }}"
+- name: "Assert expected dnsmasq outcome on host path -- {{ vm_name }}"
   ansible.builtin.assert:
     that:
       - (expected_outcome == 'sent' and _pxe_match_sent | length == 1)

--- a/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
@@ -189,7 +189,7 @@
                 req-filename="{{ item.binary }}"
           register: _pxe_tftp_pre_all
           changed_when: false
-          delegate_to: rb5009.igou.systems
+          delegate_to: "{{ pxe_test_router }}"
           loop: "{{ pxe_test_arches }}"
           loop_control:
             label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
@@ -244,7 +244,7 @@
                 req-filename="{{ item.binary }}"
           register: _pxe_tftp_post_all
           changed_when: false
-          delegate_to: rb5009.igou.systems
+          delegate_to: "{{ pxe_test_router }}"
           loop: "{{ pxe_test_arches }}"
           loop_control:
             label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"

--- a/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
@@ -59,6 +59,14 @@
     # single pass, then torn down -- noticeably faster for >2 entries
     # but harder to attribute failures.
     pxe_test_parallel: false
+    # Default substring to grep for in each smoke pin's served body,
+    # keyed by lowercase MAC. Drives only the preflight static check;
+    # per-case substring assertion is dropped because preflight already
+    # validates the body. Adding a new pinned smoke entry?  Add the
+    # MAC -> substring pair here.
+    pxe_test_substring_defaults:
+      "02:00:00:50:58:01": "=== pxe-test smoke pin: bios"
+      "02:00:00:50:58:02": "=== pxe-test smoke pin: uefi-x64"
     # Each entry must set: arch (free-form label, used in resource
     # labels and the default name), binary (TFTP filename to watch on
     # rb5009). All other fields are optional overrides:

--- a/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
@@ -9,11 +9,19 @@
 # defaults, so a single run can mix architectures, firmware modes,
 # CUDNs, MACs, and per-VM wait windows.
 #
-# Iteration 1 scope:
-#   * Verifies the binary fetch via TFTP hit counter delta. Does NOT
-#     verify the iPXE -> TrueNAS chainload; that needs console
-#     scraping, which is intentionally deferred.
-#   * Namespace selector label is hardcoded to vlan9; testing CUDNs
+# Verification (two layers):
+#   * TFTP hit counter on rb5009 increments for the expected binary
+#     (catches DHCP / matcher / TFTP regressions on the rb5009 side).
+#   * netbootxyz dnsmasq-tftp logs show the VM's leased IP made
+#     exactly one TFTP RRQ for /config/menus/host/MAC-<hexraw>.ipxe --
+#     with outcome 'sent' for pinned MACs (host file served) or
+#     'not_found' for random MACs (file absent; iPXE falls through to
+#     stock-menu.ipxe). Single observable, two interpretations; the
+#     outcome is the per-case discriminator. Substring assertions on
+#     deployed pin bodies catch inventory drift at preflight.
+#   No per-entry override fields; expectations are fully derived from
+#   inventory's netboot_host_pins (see _preflight.yml + _verify_tftp.yml).
+#   Namespace selector label is hardcoded to vlan9; testing CUDNs
 #     in other VLANs requires the namespace to already carry the
 #     matching selector label.
 #
@@ -155,10 +163,10 @@
       loop: "{{ pxe_test_arches }}"
       loop_control:
         label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
-      when: not pxe_test_parallel
+      when: not (pxe_test_parallel | bool)
 
     - name: Smoke-test architectures in parallel
-      when: pxe_test_parallel
+      when: pxe_test_parallel | bool
       block:
         - name: Snapshot docker logs line count BEFORE the parallel batch
           ansible.builtin.shell:

--- a/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
@@ -160,6 +160,19 @@
     - name: Smoke-test architectures in parallel
       when: pxe_test_parallel
       block:
+        - name: Snapshot docker logs line count BEFORE the parallel batch
+          ansible.builtin.shell:
+            cmd: set -o pipefail && docker logs ix-netbootxyz-netbootxyz-1 2>&1 | wc -l
+            executable: /bin/bash
+          register: _pxe_log_pre_parallel
+          changed_when: false
+          delegate_to: "{{ groups[netbootxyz_host][0] }}"
+          become: true
+
+        - name: Capture pre log line count (parallel mode, shared)
+          ansible.builtin.set_fact:
+            _pre_log_line_count_parallel: "{{ _pxe_log_pre_parallel.stdout | int }}"
+
         - name: Snapshot rb5009 TFTP hits BEFORE boot (all)
           community.routeros.command:
             commands:
@@ -168,7 +181,7 @@
                 req-filename="{{ item.binary }}"
           register: _pxe_tftp_pre_all
           changed_when: false
-          delegate_to: "{{ pxe_test_router }}"
+          delegate_to: rb5009.igou.systems
           loop: "{{ pxe_test_arches }}"
           loop_control:
             label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
@@ -200,6 +213,14 @@
           loop_control:
             label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
 
+        - name: Resolve VM addressing for every VM (parallel)
+          ansible.builtin.include_tasks: _dhcp_lease_lookup.yml
+          vars:
+            _vm_name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+
         - name: Pause to let iPXE complete its boot attempts (longest effective wait)
           ansible.builtin.pause:
             seconds: >-
@@ -215,7 +236,7 @@
                 req-filename="{{ item.binary }}"
           register: _pxe_tftp_post_all
           changed_when: false
-          delegate_to: "{{ pxe_test_router }}"
+          delegate_to: rb5009.igou.systems
           loop: "{{ pxe_test_arches }}"
           loop_control:
             label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
@@ -237,6 +258,19 @@
           loop: "{{ _pxe_tftp_pre_all.results | zip(_pxe_tftp_post_all.results) | list }}"
           loop_control:
             label: "{{ item.0.item.name | default('pxe-test-' ~ item.0.item.arch) }}"
+
+        - name: Verify TFTP dispatch for every VM (parallel)
+          ansible.builtin.include_tasks: _verify_tftp.yml
+          vars:
+            _vm_name_inner: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+            vm_name: "{{ _vm_name_inner }}"
+            vm_mac: "{{ _pxe_vm_addr_map[_vm_name_inner].mac }}"
+            vm_ip: "{{ _pxe_vm_addr_map[_vm_name_inner].ip }}"
+            expected_outcome: "{{ 'sent' if (_pxe_vm_addr_map[_vm_name_inner].mac in _pxe_pinned_macs) else 'not_found' }}"
+            pre_log_line_count: "{{ _pre_log_line_count_parallel }}"
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
 
       always:
         - name: Delete all test VMs

--- a/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
@@ -73,8 +73,8 @@
     # validates the body. Adding a new pinned smoke entry?  Add the
     # MAC -> substring pair here.
     pxe_test_substring_defaults:
-      "02:00:00:50:58:01": "=== pxe-test smoke pin: bios"
-      "02:00:00:50:58:02": "=== pxe-test smoke pin: uefi-x64"
+      "02:00:00:50:58:01": "pxe-test pin: bios"
+      "02:00:00:50:58:02": "pxe-test pin: uefi-x64"
     # Each entry must set: arch (free-form label, used in resource
     # labels and the default name), binary (TFTP filename to watch on
     # rb5009). All other fields are optional overrides:

--- a/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
+++ b/playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml
@@ -1,22 +1,41 @@
 ---
-# Smoke-test the netboot.xyz custom binaries by spinning up a diskless
-# KubeVirt VM on vlan9 (DHCP from rb5009) for each x86 architecture
+# Smoke-test the netboot.xyz custom binaries by spinning up diskless
+# KubeVirt VMs (DHCP from rb5009) for each entry in pxe_test_arches
 # and asserting that the matching binary's TFTP hit counter on the
 # router increments. Catches regressions in the DHCP -> TFTP path that
 # deploy_netboot_binaries.yml wires up.
 #
+# Per-entry fields (see pxe_test_arches below) override the playbook
+# defaults, so a single run can mix architectures, firmware modes,
+# CUDNs, MACs, and per-VM wait windows.
+#
 # Iteration 1 scope:
-#   * vlan9 only (vlan45's CUDN is not yet synced into the cluster).
-#   * BIOS + UEFI x86_64 (arm64 would require qemu emulation).
 #   * Verifies the binary fetch via TFTP hit counter delta. Does NOT
 #     verify the iPXE -> TrueNAS chainload; that needs console
 #     scraping, which is intentionally deferred.
+#   * Namespace selector label is hardcoded to vlan9; testing CUDNs
+#     in other VLANs requires the namespace to already carry the
+#     matching selector label.
 #
 # Namespace handling: the test namespace is ensured (created with the
 # vlan9 CUDN selector label if missing) but never deleted -- removing
 # CUDN-attached namespaces is currently fragile, and the namespace is
 # safe to leave in place between runs. Each VM IS cleaned up via the
 # block's always: clause, even on assertion failure.
+#
+# Example: two BIOS VMs with pinned MACs, run in parallel
+# (matches static DHCP leases on rb5009):
+#
+#   ansible-navigator run \
+#     playbooks/kubevirt/test_netboot_pxe/test_netboot_pxe.yml \
+#     -i igou-inventory/inventory.yaml \
+#     -e '{"pxe_test_parallel": true,
+#          "pxe_test_arches": [
+#            {"name": "pxe-test-host-a", "arch": "bios",
+#             "binary": "netboot.xyz.kpxe", "mac": "52:54:00:de:ad:01"},
+#            {"name": "pxe-test-host-b", "arch": "bios",
+#             "binary": "netboot.xyz.kpxe", "mac": "52:54:00:de:ad:02"}
+#          ]}'
 
 - name: Test netboot.xyz custom binaries via KubeVirt VM PXE boot
   hosts: localhost
@@ -24,35 +43,85 @@
   vars:
     pxe_test_namespace: netboot-pxe-test
     pxe_test_router: rb5009.igou.systems
+    # Defaults applied to any pxe_test_arches entry that omits the
+    # corresponding key. Per-entry fields take precedence.
     pxe_test_cudn: vlan9-no-ipam
+    pxe_test_firmware: bios
+    pxe_test_cores: 1
+    pxe_test_memory: 1Gi
     # Time to wait between VM-Ready and the post-snapshot. SeaBIOS POST
     # plus the iPXE ROM's DHCP retry loop can run 60-90s on its own,
     # before TFTP even starts; 180s gives margin without dragging the
     # full per-arch cycle past 4 minutes.
     pxe_test_boot_wait_seconds: 180
+    # When false (default), each entry's create/assert/teardown runs
+    # serially. When true, all VMs are applied at once, asserted in a
+    # single pass, then torn down -- noticeably faster for >2 entries
+    # but harder to attribute failures.
+    pxe_test_parallel: false
+    # Each entry must set: arch (free-form label, used in resource
+    # labels and the default name), binary (TFTP filename to watch on
+    # rb5009). All other fields are optional overrides:
+    #   name              VM name (default: pxe-test-<arch>; required
+    #                     when multiple entries share an arch)
+    #   mac               pin the NIC MAC (else KubeVirt generates one)
+    #   cudn              ClusterUserDefinedNetwork (default: pxe_test_cudn)
+    #   firmware          'bios' or 'efi' (default: pxe_test_firmware)
+    #   cores             vCPU count (default: pxe_test_cores)
+    #   memory            guest memory (default: pxe_test_memory)
+    #   boot_wait_seconds wait between Ready and the post-snapshot
+    #                     (default: pxe_test_boot_wait_seconds; in
+    #                     parallel mode the max effective wait wins)
+    # Default mix: each arch is exercised twice -- once with a
+    # KubeVirt-generated MAC (random, exercises the un-pinned path
+    # through netboot.xyz's main menu) and once with a fixed MAC that
+    # has a matching netboot_host_pins entry in
+    # igou-inventory/group_vars/all/netboot.yml (exercises the per-host
+    # short-circuit in menu.ipxe).
     pxe_test_arches:
-      - { arch: bios, binary: netboot.xyz.kpxe }
-      - { arch: uefi-x64, binary: netboot.xyz.efi }
+      - name: pxe-test-bios-random
+        arch: bios
+        binary: netboot.xyz.kpxe
+      - name: pxe-test-bios-pinned
+        arch: bios
+        binary: netboot.xyz.kpxe
+        mac: '02:00:00:50:58:01'
+      - name: pxe-test-uefi-x64-random
+        arch: uefi-x64
+        binary: netboot.xyz.efi
+        firmware: efi
+      - name: pxe-test-uefi-x64-pinned
+        arch: uefi-x64
+        binary: netboot.xyz.efi
+        firmware: efi
+        mac: '02:00:00:50:58:02'
 
   tasks:
+    - name: Preflight -- netbootxyz HTTP-side checks
+      ansible.builtin.include_tasks: _preflight.yml
+
     # --- Pre-flight (idempotent, never destructive) --------------------------
 
-    - name: Read the vlan9 ClusterUserDefinedNetwork
+    - name: Read each ClusterUserDefinedNetwork referenced by pxe_test_arches
       kubernetes.core.k8s_info:
         api_version: k8s.ovn.org/v1
         kind: ClusterUserDefinedNetwork
-        name: "{{ pxe_test_cudn }}"
+        name: "{{ item }}"
         validate_certs: false
-      register: _pxe_cudn
+      register: _pxe_cudn_results
+      loop: "{{ pxe_test_arches | map(attribute='cudn', default=pxe_test_cudn) | list | unique }}"
 
-    - name: Assert the vlan9 CUDN is present
+    - name: Assert every referenced CUDN is present
       ansible.builtin.assert:
         that:
-          - _pxe_cudn.resources | length == 1
+          - item.resources | length == 1
         fail_msg: >-
-          ClusterUserDefinedNetwork {{ pxe_test_cudn }} is not present in
-          the current cluster. The test cannot attach VMs to vlan9 until
-          the CUDN is synced (see clusters/ocp/udn/ in igou-openshift).
+          ClusterUserDefinedNetwork {{ item.item }} is not present in the
+          current cluster. The test cannot attach VMs to it until the
+          CUDN is synced (see clusters/ocp/udn/ in igou-openshift).
+      loop: "{{ _pxe_cudn_results.results }}"
+      loop_control:
+        label: "{{ item.item }}"
 
     - name: Ensure test namespace exists with the vlan9 CUDN selector label
       kubernetes.core.k8s:
@@ -67,11 +136,111 @@
               network.igou.systems/vlan9: "true"
 
     # --- Per-arch smoke test -------------------------------------------------
-    # The block/always per-iteration cleanup is in _arch_test.yml because
-    # ansible does not allow `loop:` directly on a `block:`.
+    # Two execution modes: serial (default) iterates and tears down
+    # each VM in turn; parallel applies all VMs, asserts in one pass,
+    # then tears them all down. Both honour the per-entry block/always
+    # cleanup contract -- in parallel mode a single block wraps the
+    # whole batch, so a mid-run failure still cleans up every VM.
 
-    - name: Smoke-test each architecture
+    - name: Smoke-test architectures serially
       ansible.builtin.include_tasks: _arch_test.yml
       loop: "{{ pxe_test_arches }}"
       loop_control:
-        label: "{{ item.arch }}"
+        label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+      when: not pxe_test_parallel
+
+    - name: Smoke-test architectures in parallel
+      when: pxe_test_parallel
+      block:
+        - name: Snapshot rb5009 TFTP hits BEFORE boot (all)
+          community.routeros.command:
+            commands:
+              - >-
+                /ip tftp print detail without-paging where
+                req-filename="{{ item.binary }}"
+          register: _pxe_tftp_pre_all
+          changed_when: false
+          delegate_to: "{{ pxe_test_router }}"
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+
+        - name: Apply all diskless PXE-boot VMs (no per-VM wait)
+          kubernetes.core.k8s:
+            state: present
+            validate_certs: false
+            namespace: "{{ pxe_test_namespace }}"
+            definition: "{{ lookup('ansible.builtin.template', 'vm.yaml.j2') | from_yaml }}"
+            wait: false
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+
+        - name: Wait for all VMs to reach Ready
+          kubernetes.core.k8s_info:
+            api_version: kubevirt.io/v1
+            kind: VirtualMachine
+            namespace: "{{ pxe_test_namespace }}"
+            name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+            validate_certs: false
+            wait: true
+            wait_condition:
+              type: Ready
+              status: "True"
+            wait_timeout: 180
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+
+        - name: Pause to let iPXE complete its boot attempts (longest effective wait)
+          ansible.builtin.pause:
+            seconds: >-
+              {{ pxe_test_arches
+                 | map(attribute='boot_wait_seconds', default=pxe_test_boot_wait_seconds)
+                 | map('int') | max }}
+
+        - name: Snapshot rb5009 TFTP hits AFTER boot (all)
+          community.routeros.command:
+            commands:
+              - >-
+                /ip tftp print detail without-paging where
+                req-filename="{{ item.binary }}"
+          register: _pxe_tftp_post_all
+          changed_when: false
+          delegate_to: "{{ pxe_test_router }}"
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+
+        - name: Assert TFTP hits incremented for each binary
+          ansible.builtin.assert:
+            that:
+              - (_pxe_post_hits | int) > (_pxe_pre_hits | int)
+            fail_msg: >-
+              VM {{ item.0.item.name | default('pxe-test-' ~ item.0.item.arch) }}
+              did not fetch {{ item.0.item.binary }} from rb5009. hits
+              {{ _pxe_pre_hits }} -> {{ _pxe_post_hits }}. Check the VMI
+              status, the DHCP offer to its MAC (`/log print where
+              topics~"dhcp"` on rb5009), and that the matcher table
+              still routes option-93 to the right binary.
+          vars:
+            _pxe_pre_hits: "{{ item.0.stdout[0] | regex_search('hits=\\d+') | default('hits=0') | regex_replace('^hits=', '') | int }}"
+            _pxe_post_hits: "{{ item.1.stdout[0] | regex_search('hits=\\d+') | default('hits=0') | regex_replace('^hits=', '') | int }}"
+          loop: "{{ _pxe_tftp_pre_all.results | zip(_pxe_tftp_post_all.results) | list }}"
+          loop_control:
+            label: "{{ item.0.item.name | default('pxe-test-' ~ item.0.item.arch) }}"
+
+      always:
+        - name: Delete all test VMs
+          kubernetes.core.k8s:
+            state: absent
+            api_version: kubevirt.io/v1
+            kind: VirtualMachine
+            namespace: "{{ pxe_test_namespace }}"
+            name: "{{ item.name | default('pxe-test-' ~ item.arch) }}"
+            validate_certs: false
+            wait: true
+            wait_timeout: 120
+          loop: "{{ pxe_test_arches }}"
+          loop_control:
+            label: "{{ item.name | default('pxe-test-' ~ item.arch) }}"

--- a/playbooks/kubevirt/test_netboot_pxe/vm.yaml.j2
+++ b/playbooks/kubevirt/test_netboot_pxe/vm.yaml.j2
@@ -1,28 +1,27 @@
 ---
 # Diskless PXE-boot VM for the netboot.xyz binary smoke test. Rendered
-# by ../test_netboot_pxe.yml with `arch` set to either `bios` or
-# `uefi-x64`. The two variants only differ in whether the firmware
-# block requests EFI; everything else is identical so the same hit
-# counter on rb5009 distinguishes which binary the VM fetched.
+# by ../test_netboot_pxe.yml against each entry in pxe_test_arches.
+# Per-entry fields override the playbook-level pxe_test_* defaults --
+# see the vars block in the parent playbook for the full field list.
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name: pxe-test-{{ arch }}
+  name: {{ item.name | default('pxe-test-' ~ item.arch) }}
   namespace: {{ pxe_test_namespace }}
   labels:
     app: netboot-pxe-smoke-test
-    netboot.test/arch: {{ arch }}
+    netboot.test/arch: {{ item.arch }}
 spec:
   runStrategy: Always
   template:
     metadata:
       labels:
         app: netboot-pxe-smoke-test
-        netboot.test/arch: {{ arch }}
+        netboot.test/arch: {{ item.arch }}
     spec:
       architecture: amd64
       domain:
-{% if arch == 'uefi-x64' %}
+{% if (item.firmware | default(pxe_test_firmware)) == 'efi' %}
         firmware:
           bootloader:
             efi:
@@ -31,21 +30,24 @@ spec:
               secureBoot: false
 {% endif %}
         cpu:
-          cores: 1
+          cores: {{ item.cores | default(pxe_test_cores) }}
         memory:
-          guest: 1Gi
+          guest: {{ item.memory | default(pxe_test_memory) }}
         devices:
           # Default pod network would give the VM a second NIC and DHCP
-          # racing -- we want PXE to see only the vlan9 interface.
+          # racing -- we want PXE to see only the configured CUDN.
           autoattachPodInterface: false
           interfaces:
             - bridge: {}
               model: virtio
               name: nic
               bootOrder: 1
+{% if item.mac is defined %}
+              macAddress: {{ item.mac }}
+{% endif %}
         machine:
           type: pc-q35-rhel9.6.0
       networks:
         - multus:
-            networkName: {{ pxe_test_cudn }}
+            networkName: {{ item.cudn | default(pxe_test_cudn) }}
           name: nic


### PR DESCRIPTION
## Summary

Extends `playbooks/kubevirt/test_netboot_pxe/` so each smoke-test VM verifies — without console scraping — that the netbootxyz container's TFTP server (dnsmasq) responded the expected way to the per-host chain: \`sent\` if the VM's MAC is in \`netboot_host_pins\`, \`file ... not found\` if it isn't. Single observable, two interpretations; status of the dnsmasq RRQ on \`/config/menus/host/MAC-<hex>.ipxe\` is the per-case discriminator.

The previous playbook only checked that the iPXE binary was TFTP-fetched from rb5009 (TFTP hit counter delta). The header comment explicitly deferred verifying the iPXE → TrueNAS chainload because \"that needs console scraping.\" This PR closes that gap headlessly.

### What's new

- \`_preflight.yml\` — HTTP-probe the netbootxyz nginx root, build the pinned-MAC set, deploy smoke pin files into \`{{ netbootxyz_root }}/config/menus/host/\` from inventory's \`netboot_host_pins[].fragment\`, and \`docker exec cat\` each deployed file back to assert a substring.
- \`_dhcp_lease_lookup.yml\` — read the VirtualMachineInstance for its actual MAC (works for both pinned and KubeVirt-generated cases), then poll rb5009 DHCP leases for the IP. 30s budget. Sets \`_vm_mac\` and \`_vm_ip\` and accumulates a \`_pxe_vm_addr_map\` that the parallel path consumes.
- \`_verify_tftp.yml\` — slice the netbootxyz container's \`docker logs\` (carries dnsmasq-tftp lines), parse \`sent <path> to <ip>\` and \`file <path> not found for <ip>\`, and assert exactly one match for the expected per-host path with the expected outcome.
- \`_arch_test.yml\` — serial-mode block extended with pre-snapshot, lease lookup, and TFTP-dispatch assertion (preserves the existing block/always cleanup contract).
- \`test_netboot_pxe.yml\` — preflight include, parallel-mode wiring (shared pre-snapshot + per-VM addr-map + looped verify), refreshed header comment.
- \`vm.yaml.j2\` — per-entry override support (mac/firmware/cores/memory/cudn/name) so the pinned-MAC test fixture can pin its NIC.

Asset-management spec/plan (\`docs/superpowers/specs/2026-05-08-netboot-asset-management-design.md\`, \`docs/superpowers/plans/2026-05-08-netboot-asset-management.md\`) committed alongside as completed prior work.

### Design discoveries (mid-implementation pivots)

Two empirical findings forced spec/plan revisions:
1. \`menu.ipxe\` is served via TFTP, not HTTP. The original \"GET /menu.ipxe\" assumption was wrong.
2. The netbootxyz nginx serves only \`/assets/\`. Per-host chaining is fully TFTP-side via the container's built-in dnsmasq. \`docker logs\` carries dnsmasq-tftp lines; nginx access logs are file-only.

Pivoted to: deploy pin files to the bind-mount, slice \`docker logs\`, assert dnsmasq outcome (\`sent\`/\`not_found\`) on the per-host path. Smoke pin file deployment will eventually be \`playbooks/netboot/deploy_assets.yml\`'s job; inlined in this preflight until that playbook lands.

## Test plan

- [ ] Parallel run with default \`pxe_test_arches\` (4 cases: 2 pinned BIOS/UEFI \`sent\`, 2 random \`not_found\`) → \`failed=0\`. _Running now in this session._
- [ ] Serial run — same fixture, sequential — also \`failed=0\`.
- [ ] Negative: rename \`MAC-020000505801.ipxe\` on TrueNAS, expect preflight 404 / read-back failure before any VM is applied.
- [ ] Negative: override \`pxe_test_substring_defaults\` to a string that won't appear, expect preflight substring assertion failure.
- [ ] Re-run twice with no inventory changes — second run is idempotent (preflight \`copy\` reports \`ok\`, not \`changed\`).
- [ ] \`ansible-lint --profile=production\` and \`yamllint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)