### PR TITLE
tekton: fix git-clone param casing (URL/REVISION/VERBOSE)

### DIFF
--- a/.tekton/igou-aap-ee-rhel9-push.yml
+++ b/.tekton/igou-aap-ee-rhel9-push.yml
@@ -45,11 +45,11 @@ spec:
             - name: namespace
               value: openshift-pipelines
         params:
-          - name: url
+          - name: URL
             value: "{{ repo_url }}"
-          - name: revision
+          - name: REVISION
             value: "{{ revision }}"
-          - name: verbose
+          - name: VERBOSE
             value: "true"
         workspaces:
           - name: output


### PR DESCRIPTION
## Summary
First PipelineRun after #182 merged failed validation with:

```
[User error] Validation failed for pipelinerun igou-aap-ee-rhel9-push-5g2gd with error
invalid input params for task git-clone: missing values for these params which have no
default values: [URL]
```

The cluster-resolver `git-clone` task in `openshift-pipelines` uses uppercase param names (`URL`, `REVISION`, `VERBOSE`) — per OpenShift Pipelines convention. The original PR copied lowercase param names from `djdanielsson/rh1-ee`, whose cluster apparently runs a differently-cased `git-clone` Task variant.

Confirmed against this cluster:

```bash
$ oc -n openshift-pipelines get task git-clone -o jsonpath='{.spec.params[*].name}'
CRT_FILENAME HTTP_PROXY HTTPS_PROXY NO_PROXY SUBDIRECTORY USER_HOME DELETE_EXISTING VERBOSE SSL_VERIFY URL REVISION REFSPEC SUBMODULES DEPTH SPARSE_CHECKOUT_DIRECTORIES
```

The `buildah` task in the same namespace also uses uppercase params, and the `build-image` task in our PipelineRun was already correct (`IMAGE`, `DOCKERFILE`, `CONTEXT`, `BUILD_ARGS`, `VERBOSE`) — no second occurrence of this bug.

## Test plan
- [x] `yamllint .` clean
- [ ] After merge, the next PaC PipelineRun should pass validation and proceed past `fetch-source` to the `ansible-builder` step (where the missing `ansible.cfg` follow-up still applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)