### PR TITLE
feat(linux): add baseline configure+harden playbook

### DIFF
--- a/playbooks/linux/baseline.yaml
+++ b/playbooks/linux/baseline.yaml
@@ -1,0 +1,72 @@
+---
+- name: Baseline configure and harden a Linux host
+  hosts: "{{ ansible_limit | default('all') }}"
+  become: true
+  gather_facts: true
+
+  # baseline_* variables are defined in igou-inventory group_vars/all/main.yml
+
+  # pre_tasks run before roles, so the admin user + key + sudo exist before
+  # ssh_hardening disables root login and password auth (prevents lockout).
+  pre_tasks:
+    - name: Ensure sudo is installed
+      ansible.builtin.package:
+        name: sudo
+        state: present
+
+    - name: Create admin user
+      ansible.builtin.user:
+        name: "{{ baseline_user }}"
+        groups: "{{ baseline_user_groups }}"
+        append: true
+        shell: "{{ baseline_user_shell }}"
+        create_home: true
+        password_lock: true  # no password login; key + sudo only
+        state: present
+
+    - name: Install authorized SSH keys
+      ansible.posix.authorized_key:
+        user: "{{ baseline_user }}"
+        key: "{{ item }}"
+        state: present
+      loop: "{{ baseline_authorized_keys }}"
+
+    - name: Grant passwordless sudo
+      ansible.builtin.copy:
+        dest: "/etc/sudoers.d/90-{{ baseline_user }}"
+        content: "{{ baseline_user }} ALL=(ALL) NOPASSWD: ALL\n"
+        owner: root
+        group: root
+        mode: "0440"
+        validate: "visudo -cf %s"
+      when: baseline_passwordless_sudo | bool
+
+    # ssh_hardening's crypto_hostkeys task assumes rsa+ecdsa+ed25519 host keys
+    # all exist (it derives the list from the OpenSSH version, not from disk)
+    # and errors on any missing one. Generate any that are absent first.
+    - name: Check which SSH host keys exist
+      ansible.builtin.stat:
+        path: "/etc/ssh/{{ item }}"
+      loop:
+        - ssh_host_rsa_key
+        - ssh_host_ecdsa_key
+        - ssh_host_ed25519_key
+      register: baseline_ssh_host_keys
+
+    - name: Generate missing SSH host keys
+      ansible.builtin.command: ssh-keygen -A
+      when: baseline_ssh_host_keys.results | rejectattr('stat.exists') | list | length > 0
+      changed_when: true
+
+  roles:
+    - role: devsec.hardening.os_hardening
+      vars:
+        sysctl_overwrite:
+          # Re-enable unprivileged user namespaces for rootless podman.
+          # devsec sets this to 0 (CVE-2021-33909) in its Ubuntu vars.
+          kernel.unprivileged_userns_clone: 1
+
+    - role: devsec.hardening.ssh_hardening
+      vars:
+        ssh_permit_root_login: "no"
+        ssh_server_password_login: false

--- a/requirements.yml
+++ b/requirements.yml
@@ -28,7 +28,7 @@ collections:
   - name: community.general
     version: 12.6.0
   - name: ansible.posix
-    version: 2.1.0
+    version: 2.2.0
   - name: kubernetes.core
     version: 6.4.0
   - name: containers.podman
@@ -50,8 +50,6 @@ collections:
     version: 5.2.0
   - name: vkhitrin.libguestfs
     version: 1.1.5
-  - name: ansible.posix
-    version: 2.1.0
   - name: ansible.netcommon
     version: 8.5.2
   - name: community.routeros


### PR DESCRIPTION
## Summary
- Add `playbooks/linux/baseline.yaml`: creates an admin user with SSH key + passwordless sudo, then applies `devsec.hardening` `os_hardening` and `ssh_hardening`.
- `pre_tasks` ensure the admin user and SSH host keys exist **before** SSH hardening disables root/password login (prevents lockout).
- Re-enable unprivileged user namespaces via `sysctl_overwrite` for rootless podman.
- Bump `ansible.posix` 2.1.0 → 2.2.0 and drop a duplicate `ansible.posix` entry in `requirements.yml`.

## Verification
- `ansible-lint --profile=production` → passed (0 failures, 0 warnings)
- `ansible-playbook --syntax-check` → passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)