### PR TITLE
fix(execution-environments): refresh stale base image digests

### DIFF
--- a/execution-environments/igou-awx-ee-fedora/execution-environment.yml
+++ b/execution-environments/igou-awx-ee-fedora/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 images:
   base_image:
     # renovate: datasource=docker depName=quay.io/fedora/fedora
-    name: quay.io/fedora/fedora:45@sha256:d37b25a44a5aa98b0369f958f1f031252366890fdbc8c9e556f32f2f0a11bada
+    name: quay.io/fedora/fedora:45@sha256:b7d39aeed2a70f4cf1052f9ffc19a42cd7047f4bc7ff0a23ad4782af0ed0ed50
 options:
   package_manager_path: /usr/bin/dnf
 dependencies:

--- a/execution-environments/igou-awx-ee/execution-environment.yml
+++ b/execution-environments/igou-awx-ee/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 images:
   base_image:
     # renovate: datasource=docker depName=quay.io/centos/centos
-    name: quay.io/centos/centos:stream10-minimal@sha256:e3338c46d18f1e851d915886d7b0879a44201b78cd5719e8ebcc0d3eca7eac31
+    name: quay.io/centos/centos:stream10-minimal@sha256:db3197606c9f1a310b14a4074b432c6cfc10be08631d71998d961e6b5104b55d
 options:
   package_manager_path: /usr/bin/microdnf
 dependencies:

--- a/execution-environments/igou-networking-ee/execution-environment.yml
+++ b/execution-environments/igou-networking-ee/execution-environment.yml
@@ -4,7 +4,7 @@ version: 3
 images:
   base_image:
     # renovate: datasource=docker depName=quay.io/centos/centos
-    name: quay.io/centos/centos:stream9-minimal@sha256:5b7fdab2e3ca82648bb3d489d0a42a46ad007729c0a712d158a7e00b5c96231b
+    name: quay.io/centos/centos:stream9-minimal@sha256:99281d546d574f5a40bc1ae92f80ea2a9ae9292c15f4c543e56e4086fb77aa0c
 options:
   package_manager_path: /usr/bin/microdnf
 dependencies:


### PR DESCRIPTION
## Summary
All three EE build jobs on `main` were failing with `manifest unknown` — the pinned base-image digests had been garbage-collected from Quay after upstream rebuilt the `*-minimal`/`fedora` images.

Refreshed each pin to the current published manifest for its tag:

| EE | Tag | Old digest | New digest |
|---|---|---|---|
| `igou-awx-ee` | `centos:stream10-minimal` | `e3338c46…` | `db319760…` |
| `igou-awx-ee-fedora` | `fedora:45` | `d37b25a4…` | `b7d39aee…` |
| `igou-networking-ee` | `centos:stream9-minimal` | `5b7fdab2…` | `99281d54…` |

Digests resolved via `skopeo inspect` against the live tags. Renovate manages these pins, but builds stay red until it bumps them — this unblocks CI now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)