### PR TITLE
feat(linux): podman quadlets + variable-driven install_packages playbook

### DIFF
--- a/playbooks/linux/install_packages.yaml
+++ b/playbooks/linux/install_packages.yaml
@@ -1,0 +1,15 @@
+---
+- name: Install Linux packages
+  hosts: "{{ ansible_limit | default('all') }}"
+  become: true
+  gather_facts: true
+  vars:
+    # List of package names to install. Override at launch, e.g.
+    # -e '{"install_packages": ["podman"]}'
+    install_packages: []
+  tasks:
+    - name: Ensure requested packages are present
+      ansible.builtin.package:
+        name: "{{ install_packages }}"
+        state: present
+      when: install_packages | length > 0

--- a/playbooks/linux/podman_nginx.yaml
+++ b/playbooks/linux/podman_nginx.yaml
@@ -1,0 +1,22 @@
+---
+- name: Deploy nginx as a rootless quadlet under the igou user
+  hosts: "{{ ansible_limit | default('vps') }}"
+  become: true
+  gather_facts: true
+  roles:
+    - role: linux-system-roles.podman
+      vars:
+        # Run everything rootless under the igou user; the role enables
+        # linger so the units survive logout / start at boot.
+        podman_run_as_user: igou
+        podman_quadlet_specs:
+          - name: nginx
+            type: container
+            Container:
+              Image: docker.io/library/nginx:stable-alpine
+              # rootless can't bind <1024, so publish on a high port
+              PublishPort: "8080:80"
+            Service:
+              Restart: always
+            Install:
+              WantedBy: default.target

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,6 +2,8 @@
 roles:
   - name: xanmanning.k3s
     version: v3.6.2
+  - name: linux-system-roles.podman
+    version: 1.11.1
   - name: githubixx.iscsi_target
     version: 2.0.0
   - name: githubixx.ansible_role_wireguard


### PR DESCRIPTION
## Summary

Adds two new Linux playbooks and the supporting role pin.

- **`playbooks/linux/install_packages.yaml`** — variable-driven package install. Pass `-e '{"install_packages": ["podman"]}'`; no-ops when the list is empty. Targets `ansible_limit | default('all')`.
- **`playbooks/linux/podman_nginx.yaml`** — deploys nginx as a rootless quadlet under the `igou` user via `linux-system-roles.podman`. Runs rootless with linger enabled, publishes on high port `8080:80` (rootless can't bind <1024), `Restart: always`, `WantedBy: default.target`. Targets `ansible_limit | default('vps')`.
- **`requirements.yml`** — pins `linux-system-roles.podman` 1.11.1.

## Test plan

- [ ] `ansible-lint --profile=production`
- [ ] `ansible-galaxy install -r requirements.yml` resolves the new role pin
- [ ] Run `podman_nginx.yaml` against a vps host; confirm rootless quadlet is active and nginx answers on :8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)