### PR TITLE
feat(linux): rootless podman VPS rollout — service user, split-order ACME, proxy resiliency

### DIFF
--- a/playbooks/linux/acme_certificate_podman_secret.yaml
+++ b/playbooks/linux/acme_certificate_podman_secret.yaml
@@ -70,6 +70,11 @@
         content: "{{ _deployed.secrets[0].SecretData }}"
       delegate_to: localhost
       vars:
+        # The inventory's localhost host has no ansible_connection set (it
+        # defaults to ssh, intentionally - armbian builds SSH back into it), so
+        # a bare delegate_to: localhost tries to ssh into the EE, which has no
+        # sshd. Force local here; never pin it on the inventory host itself.
+        ansible_connection: local
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
       register: _cert
       when: _deployed is not skipped
@@ -94,6 +99,13 @@
              else (letsencrypt_remaining_days ~ ' day(s) remaining; '
                    ~ ('renewing.' if (letsencrypt_needs_issue | bool) else 'within threshold, skipping.')) }}
 
+# We drive the ACME order with the community.crypto split-order modules instead
+# of the felixfontein.acme role, because a wildcard + apex cert needs TWO TXT
+# values at the single name _acme-challenge.<domain>, and the role's Cloudflare
+# provider writes only value[0] with solo:true (deleting the other). Here the
+# "Publish" task loops over EVERY challenge value, using solo only on the first
+# per record (clears stale, then appends) - the multi-value handling Cloudflare
+# needs. TXT records are torn down in always:, even if validation fails.
 - name: Issue the certificate on the control node (Cloudflare DNS-01)
   hosts: "{{ cert_hosts | default('letsencrypt') }}"
   gather_facts: false
@@ -105,34 +117,123 @@
     # interpreter would otherwise be used; pin to the controller's interpreter.
     ansible_python_interpreter: "{{ ansible_playbook_python }}"
     _keys_path: "{{ acme_keys_path | default('/tmp/acme-' ~ inventory_hostname) }}"
+    _cert_basename: "{{ letsencrypt_cert_domains[0] | replace('*', '_') }}"
+    _acme_directory: "{{ letsencrypt_acme_directory | default('https://acme-v02.api.letsencrypt.org/directory') }}"
 
   tasks:
-    # The acme role writes into keys_path but does not create it.
+    - name: Nothing to issue when no renewal is needed
+      ansible.builtin.meta: end_host
+      when: not (letsencrypt_needs_issue | default(false) | bool)
+
+    # Resolve each 1Password secret exactly ONCE. As play vars these lookups are
+    # lazy and re-run on every reference (and every loop item), bursting the 1P
+    # service-account rate limit; materialize them up front and reuse the facts.
+    # The shared ACME account is read on the control node only (never reaches
+    # the host).
+    - name: Resolve issuance secrets from 1Password (once)
+      ansible.builtin.set_fact:
+        _account_content: "{{ lookup('community.general.onepassword', 'acme-key', field='key.b64', vault='awx') | b64decode }}"
+        _account_email: "{{ lookup('community.general.onepassword', 'acme-key', field='email', vault='awx') }}"
+        _cf_token: "{{ acme_certificate_cloudflare_token }}"
+      no_log: true
+
     - name: Ensure the scratch keys directory exists on the control node
       ansible.builtin.file:
         path: "{{ _keys_path }}"
         state: directory
         mode: "0700"
-      when: letsencrypt_needs_issue | default(false) | bool
 
-    # Not passing renewal_on_remaining_days makes the role always obtain, so the
-    # empty scratch keys_path just receives a fresh keypair+cert. Our host check
-    # already owns the renewal decision.
-    - name: Issue the certificate (only when a renewal is needed)
-      when: letsencrypt_needs_issue | default(false) | bool
-      ansible.builtin.include_role:
-        name: felixfontein.acme.acme_certificate
-      vars:
-        acme_certificate_keys_path: "{{ _keys_path }}"
-        acme_certificate_domains: "{{ letsencrypt_cert_domains }}"
-        acme_certificate_challenge: dns-01
-        acme_certificate_dns_provider: cloudflare
-        acme_certificate_dns_servers: 8.8.8.8
-        acme_certificate_terms_agreed: true
-        acme_certificate_modify_account: true
-        acme_certificate_acme_email: "{{ lookup('community.general.onepassword', 'acme-key', field='email', vault='awx') }}"
-        acme_certificate_acme_account_content: "{{ lookup('community.general.onepassword', 'acme-key', field='key.b64', vault='awx') | b64decode }}"
-        # acme_certificate_cloudflare_token comes from inventory (per-host 1P item).
+    # Fresh keypair each issuance - keys_path is a throwaway scratch dir, so no
+    # private key persists on the controller (the delivery play removes it).
+    - name: Generate the certificate private key
+      community.crypto.openssl_privatekey:
+        path: "{{ _keys_path }}/{{ _cert_basename }}.key"
+        type: RSA
+        size: 4096
+        mode: "0600"
+        force: true
+
+    - name: Generate the CSR with all SANs (wildcard + apex)
+      community.crypto.openssl_csr:
+        path: "{{ _keys_path }}/{{ _cert_basename }}.csr"
+        privatekey_path: "{{ _keys_path }}/{{ _cert_basename }}.key"
+        subject_alt_name: "{{ letsencrypt_cert_domains | map('regex_replace', '^(.*)$', 'DNS:\\1') | list }}"
+        use_common_name_for_san: false
+
+    - name: Ensure the shared ACME account exists (terms agreed)
+      community.crypto.acme_account:
+        account_key_content: "{{ _account_content }}"
+        contact: ["mailto:{{ _account_email }}"]
+        terms_agreed: true
+        allow_creation: true
+        state: present
+        acme_directory: "{{ _acme_directory }}"
+        acme_version: 2
+
+    - name: Create the ACME order and read the DNS-01 challenges
+      community.crypto.acme_certificate_order_create:
+        account_key_content: "{{ _account_content }}"
+        csr: "{{ _keys_path }}/{{ _cert_basename }}.csr"
+        acme_directory: "{{ _acme_directory }}"
+        acme_version: 2
+      register: _order
+
+    # challenge_data_dns is {record_name: [values...]}; apex + wildcard collapse
+    # to one _acme-challenge.<domain> key whose list holds BOTH tokens.
+    - name: Publish, validate, then always tear down the challenge records
+      block:
+        - name: Publish every challenge TXT value to Cloudflare
+          community.general.cloudflare_dns:
+            api_token: "{{ _cf_token }}"
+            zone: "{{ item.0.key | community.dns.get_registrable_domain }}"
+            record: "{{ item.0.key | community.dns.remove_registrable_domain }}"
+            type: TXT
+            value: "{{ item.1 }}"
+            # solo wipes other TXT at this name: do it once per record (first
+            # value) to clear stale tokens, then append the rest.
+            solo: "{{ item.0.value.index(item.1) == 0 }}"
+            state: present
+            ttl: 60
+          loop: "{{ _order.challenge_data_dns | dict2items | subelements('value') }}"
+          loop_control:
+            label: "{{ item.0.key }} = {{ item.1 }}"
+
+        - name: Wait for the challenge TXT records to propagate
+          community.dns.wait_for_txt:
+            records: "{{ _order.challenge_data_dns | dict2items(key_name='name', value_name='values') | list }}"
+            server: 8.8.8.8
+            timeout: "{{ letsencrypt_dns_propagation_timeout | default(120) }}"
+
+        - name: Validate the challenges
+          community.crypto.acme_certificate_order_validate:
+            account_key_content: "{{ _account_content }}"
+            order_uri: "{{ _order.order_uri }}"
+            challenge: dns-01
+            acme_directory: "{{ _acme_directory }}"
+            acme_version: 2
+
+        - name: Finalize the order and write the cert + fullchain
+          community.crypto.acme_certificate_order_finalize:
+            account_key_content: "{{ _account_content }}"
+            order_uri: "{{ _order.order_uri }}"
+            csr: "{{ _keys_path }}/{{ _cert_basename }}.csr"
+            cert_dest: "{{ _keys_path }}/{{ _cert_basename }}.pem"
+            fullchain_dest: "{{ _keys_path }}/{{ _cert_basename }}-fullchain.pem"
+            chain_dest: "{{ _keys_path }}/{{ _cert_basename }}-chain.pem"
+            acme_directory: "{{ _acme_directory }}"
+            acme_version: 2
+      always:
+        - name: Remove the challenge TXT records
+          community.general.cloudflare_dns:
+            api_token: "{{ _cf_token }}"
+            zone: "{{ item.0.key | community.dns.get_registrable_domain }}"
+            record: "{{ item.0.key | community.dns.remove_registrable_domain }}"
+            type: TXT
+            value: "{{ item.1 }}"
+            state: absent
+          loop: "{{ _order.challenge_data_dns | dict2items | subelements('value') }}"
+          loop_control:
+            label: "{{ item.0.key }} = {{ item.1 }}"
 
 - name: Deliver the renewed certificate as podman secrets
   hosts: "{{ cert_hosts | default('letsencrypt') }}"
@@ -193,3 +294,8 @@
         path: "{{ _keys_path }}"
         state: absent
       delegate_to: localhost
+      vars:
+        # See the cert-expiry task above: the inventory localhost defaults to
+        # ssh, so force a local connection for this control-node cleanup rather
+        # than pinning ansible_connection on the inventory host.
+        ansible_connection: local

--- a/playbooks/linux/baseline.yaml
+++ b/playbooks/linux/baseline.yaml
@@ -41,6 +41,38 @@
         validate: "visudo -cf %s"
       when: baseline_passwordless_sudo | bool
 
+    # Unprivileged service accounts that own workloads (e.g. the rootless
+    # podman run user). Deliberately NOT in wheel/sudo and login-locked with a
+    # nologin shell, so a compromised container cannot reach root. Ansible still
+    # drives them via become_user from the admin user's session, so they need no
+    # SSH access of their own. Created as regular (non-system) users so useradd
+    # allocates the /etc/subuid + /etc/subgid ranges rootless podman requires;
+    # linger is enabled later by linux-system-roles.podman, not here.
+    - name: Create unprivileged service users
+      ansible.builtin.user:
+        name: "{{ item.name }}"
+        shell: "{{ item.shell | default('/usr/sbin/nologin') }}"
+        create_home: true
+        password_lock: true
+        system: false
+        state: present
+      loop: "{{ baseline_service_users | default([]) }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    # Enable linger now so each service user's systemd instance + /run/user/<uid>
+    # exist at boot, before any session. linux-system-roles.podman also enables
+    # linger, but a nologin service user has no login session to create the
+    # runtime dir, and plays that query its rootless podman (e.g. the cert
+    # renewal decision) run BEFORE that role does - so seed it here.
+    - name: Enable linger for service users
+      ansible.builtin.command: "loginctl enable-linger {{ item.name }}"
+      args:
+        creates: "/var/lib/systemd/linger/{{ item.name }}"
+      loop: "{{ baseline_service_users | default([]) }}"
+      loop_control:
+        label: "{{ item.name }}"
+
     # ssh_hardening's crypto_hostkeys task assumes rsa+ecdsa+ed25519 host keys
     # all exist (it derives the list from the OpenSSH version, not from disk)
     # and errors on any missing one. Generate any that are absent first.

--- a/playbooks/linux/podman_migrate_run_user.yaml
+++ b/playbooks/linux/podman_migrate_run_user.yaml
@@ -1,0 +1,99 @@
+---
+# One-time migration: tear down a rootless podman stack that was running under a
+# previous run user, so a new linux_podman_run_as_user can own it cleanly.
+#
+# Two rootless users cannot both publish 80/443, so before pointing the cert +
+# quadlet playbooks at the new user this play stops the OLD user's units (frees
+# the ports immediately), removes their quadlet definitions (so systemd can't
+# regenerate them), reloads that user's systemd, and disables their linger (so
+# nothing comes back at boot or when the admin's SSH session ends).
+#
+# Run once, before acme_certificate_podman_secret.yaml + podman_quadlets.yaml:
+#   ansible-navigator run playbooks/linux/podman_migrate_run_user.yaml \
+#     -i igou-inventory/inventory.yaml
+#
+# This is a CLEAN rebuild: the new user starts with fresh secrets (the cert
+# re-issues on bootstrap) and fresh data dirs. The old user's home/containers,
+# secrets and data are left on disk untouched for you to inspect/remove.
+#
+# Variables:
+#   linux_podman_old_run_user - the user to tear down (default: igou)
+
+- name: Tear down the previous rootless podman run user's stack
+  hosts: "{{ ansible_limit | default('vps') }}"
+  become: true
+  gather_facts: false
+
+  vars:
+    _old_user: "{{ linux_podman_old_run_user | default('igou') }}"
+    _quadlet_dir: "/home/{{ _old_user }}/.config/containers/systemd"
+    _rootless_env:
+      XDG_RUNTIME_DIR: "/run/user/{{ getent_passwd[_old_user][1] }}"
+
+  tasks:
+    - name: Resolve the old run user's uid (for its rootless runtime dir)
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ _old_user }}"
+
+    - name: Find the old user's quadlet definitions
+      ansible.builtin.find:
+        paths: "{{ _quadlet_dir }}"
+        patterns:
+          - "*.container"
+          - "*.network"
+          - "*.volume"
+          - "*.pod"
+          - "*.kube"
+      register: _old_quadlets
+
+    # Map each quadlet file to the systemd unit the generator produces:
+    #   foo.container / foo.kube -> foo.service
+    #   foo.network -> foo-network.service   foo.volume -> foo-volume.service
+    #   foo.pod     -> foo-pod.service
+    - name: Derive the unit names from the quadlet files
+      ansible.builtin.set_fact:
+        _old_units: >-
+          {{ _old_quadlets.files | map(attribute='path') | map('basename')
+             | map('regex_replace', '\.container$', '.service')
+             | map('regex_replace', '\.kube$', '.service')
+             | map('regex_replace', '\.network$', '-network.service')
+             | map('regex_replace', '\.volume$', '-volume.service')
+             | map('regex_replace', '\.pod$', '-pod.service')
+             | list }}
+
+    - name: Stop the old user's podman units (frees 80/443)
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        scope: user
+        state: stopped
+      become: true
+      become_user: "{{ _old_user }}"
+      environment: "{{ _rootless_env }}"
+      loop: "{{ _old_units }}"
+      failed_when: false
+
+    - name: Remove the old user's quadlet definitions
+      ansible.builtin.file:
+        path: "{{ _quadlet_dir }}"
+        state: absent
+
+    - name: Reload the old user's systemd so the removed units disappear
+      ansible.builtin.systemd:
+        daemon_reload: true
+        scope: user
+      become: true
+      become_user: "{{ _old_user }}"
+      environment: "{{ _rootless_env }}"
+      failed_when: false
+
+    - name: Disable linger so the old user's manager stops and stays down
+      ansible.builtin.command: "loginctl disable-linger {{ _old_user }}"
+      changed_when: true
+
+    - name: Report what was torn down
+      ansible.builtin.debug:
+        msg: >-
+          Stopped and removed {{ _old_units | length }} unit(s) for
+          '{{ _old_user }}'. Its home/containers, secrets and data remain on
+          disk; remove them manually once the new run user is verified.

--- a/playbooks/linux/podman_teardown.yaml
+++ b/playbooks/linux/podman_teardown.yaml
@@ -1,0 +1,33 @@
+---
+# DESTRUCTIVE. For each candidate run user that has a live rootless podman
+# runtime on the host, this stops its quadlet units (removing their containers +
+# networks), force-removes any remaining containers, and DELETES every podman
+# secret it owns (including TLS certs).
+#
+# It deliberately LEAVES quadlet definition files, bind-mounted data/config
+# dirs, the users, and linger in place - so a `systemctl --user daemon-reload`
+# or a reboot can bring the (now secret-less) stack back. To also remove those,
+# tear them down separately.
+#
+# Run:
+#   ansible-navigator run playbooks/linux/podman_teardown.yaml -i igou-inventory/inventory.yaml
+#   # or: ansible-playbook playbooks/linux/podman_teardown.yaml -i igou-inventory/inventory.yaml
+#
+# Variables:
+#   linux_podman_teardown_users - candidate users to check
+#                                 (default: [igou, containers])
+
+- name: Tear down rootless podman containers and secrets
+  hosts: "{{ ansible_limit | default('vps') }}"
+  become: true
+  gather_facts: false
+
+  vars:
+    _candidate_users: "{{ linux_podman_teardown_users | default(['igou', 'containers']) }}"
+
+  tasks:
+    - name: Tear down each candidate run user's podman stack
+      ansible.builtin.include_tasks: tasks/podman_teardown_user.yml
+      loop: "{{ _candidate_users }}"
+      loop_control:
+        loop_var: _user

--- a/playbooks/linux/tasks/podman_teardown_user.yml
+++ b/playbooks/linux/tasks/podman_teardown_user.yml
@@ -1,0 +1,104 @@
+---
+# Tear down one rootless run user's podman containers + secrets.
+# Caller passes _user (loop_var). Safe no-op when the user is absent or has no
+# live rootless runtime (e.g. linger off and no session), so the candidate list
+# can name users that may not exist on every host.
+
+- name: "Check for run user {{ _user }}"
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ _user }}"
+    fail_key: false
+
+- name: "Tear down podman stack for {{ _user }}"
+  when: getent_passwd[_user] | default([], true) | length > 0
+  vars:
+    _uid: "{{ getent_passwd[_user][1] }}"
+    _rootless_env:
+      XDG_RUNTIME_DIR: "/run/user/{{ _uid }}"
+  block:
+    - name: "Check rootless runtime dir for {{ _user }}"
+      ansible.builtin.stat:
+        path: "/run/user/{{ _uid }}"
+      register: _rt
+
+    - name: "Report no live runtime for {{ _user }}"
+      ansible.builtin.debug:
+        msg: "{{ _user }}: no /run/user/{{ _uid }} (no active rootless podman); nothing to tear down."
+      when: not _rt.stat.exists
+
+    - name: "Operate on podman runtime for {{ _user }}"
+      when: _rt.stat.exists
+      become: true
+      become_user: "{{ _user }}"
+      environment: "{{ _rootless_env }}"
+      block:
+        - name: "Find quadlet definitions for {{ _user }}"
+          ansible.builtin.find:
+            paths: "/home/{{ _user }}/.config/containers/systemd"
+            patterns: ["*.container", "*.network", "*.volume", "*.pod", "*.kube"]
+          register: _quadlets
+
+        # foo.container/.kube -> foo.service; foo.network -> foo-network.service;
+        # foo.volume -> foo-volume.service; foo.pod -> foo-pod.service.
+        - name: "Stop quadlet units (removes containers + networks) for {{ _user }}"
+          ansible.builtin.systemd:
+            name: "{{ item }}"
+            scope: user
+            state: stopped
+          loop: >-
+            {{ _quadlets.files | map(attribute='path') | map('basename')
+               | map('regex_replace', '\.container$', '.service')
+               | map('regex_replace', '\.kube$', '.service')
+               | map('regex_replace', '\.network$', '-network.service')
+               | map('regex_replace', '\.volume$', '-volume.service')
+               | map('regex_replace', '\.pod$', '-pod.service')
+               | list }}
+          failed_when: false
+
+        - name: "Gather remaining containers for {{ _user }}"
+          containers.podman.podman_container_info:
+          register: _ctrs
+
+        - name: "Force-remove remaining containers for {{ _user }}"
+          containers.podman.podman_container:
+            name: "{{ item }}"
+            state: absent
+          loop: "{{ _ctrs.containers | map(attribute='Name') | list }}"
+          loop_control:
+            label: "{{ item }}"
+
+        # Quadlet *.network units create the network on start but do not remove
+        # it on stop, so the network object lingers after the units are down.
+        # Remove every network except podman's built-in default.
+        - name: "Gather networks for {{ _user }}"
+          containers.podman.podman_network_info:
+          register: _nets
+
+        - name: "Remove non-default networks for {{ _user }}"
+          containers.podman.podman_network:
+            name: "{{ item }}"
+            state: absent
+          loop: "{{ _nets.networks | map(attribute='name') | reject('equalto', 'podman') | list }}"
+          loop_control:
+            label: "{{ item }}"
+
+        - name: "Gather secrets for {{ _user }}"
+          containers.podman.podman_secret_info:
+          register: _secs
+
+        - name: "Delete secrets for {{ _user }}"
+          containers.podman.podman_secret:
+            name: "{{ item }}"
+            state: absent
+          loop: "{{ _secs.secrets | map(attribute='Spec.Name') | list }}"
+          loop_control:
+            label: "{{ item }}"
+
+        - name: "Report teardown for {{ _user }}"
+          ansible.builtin.debug:
+            msg: >-
+              {{ _user }}: stopped {{ _quadlets.files | length }} quadlet unit(s),
+              removed {{ _ctrs.containers | length }} container(s),
+              removed {{ _nets.networks | map(attribute='name') | reject('equalto', 'podman') | list | length }} network(s),
+              deleted {{ _secs.secrets | length }} secret(s).

--- a/playbooks/linux/templates/nginx.conf.j2
+++ b/playbooks/linux/templates/nginx.conf.j2
@@ -12,6 +12,15 @@ http {
   tcp_nopush on;
   server_tokens off;
 
+  # Resolve upstream container names at request time, not just once at startup.
+  # A backend restart (config change, auto-update, reboot) gives it a new IP on
+  # the podman network; with a static proxy_pass nginx caches the old IP and
+  # 502s until it is itself restarted. Pairing this resolver with a variable in
+  # proxy_pass (below) makes nginx re-resolve within the TTL, so backends can
+  # come and go without touching nginx. 10.89.0.1 is podman's aardvark-dns on
+  # the proxy network; override via linux_proxy_resolver if the subnet differs.
+  resolver {{ linux_proxy_resolver | default('10.89.0.1') }} valid=10s ipv6=off;
+
   # Placeholder for the apex and any unmatched SNI. The *.igou.io wildcard does
   # not cover the bare apex, so the apex is served over HTTP and the HTTPS
   # default server presents the wildcard cert (browsers warn on the apex name).
@@ -67,7 +76,10 @@ http {
     ssl_prefer_server_ciphers off;
 
     location / {
-      proxy_pass {{ svc.upstream }};
+      # Variable in proxy_pass forces runtime DNS re-resolution (see resolver
+      # above); $request_uri preserves the original path + query string.
+      set $upstream {{ svc.upstream }};
+      proxy_pass $upstream$request_uri;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Follow-up fixes and additions on top of the podman quadlet + TLS reverse-proxy work (#189, #191, #192), shaken out by a real rollout to the `igou.io` VPS.

## Changes

**`baseline.yaml`** — create login-locked, non-sudo service users (`baseline_service_users`) that own the rootless podman stack, and enable their linger early so a nologin user's systemd instance + `/run/user/<uid>` exist before any session (the cert renewal-decision play queries rootless podman before `linux-system-roles.podman` enables linger itself).

**`acme_certificate_podman_secret.yaml`**
- Replace the `felixfontein.acme` role with the `community.crypto` split-order modules. A wildcard + apex cert needs **two** TXT values at the single name `_acme-challenge.igou.io`; the role's Cloudflare provider writes only the first (`solo: true` deletes the other), so issuance now publishes every challenge value itself and tears them down in `always:`.
- Resolve 1Password lookups once (avoid bursting the service-account rate limit); `end_host` early when no renewal is needed.
- Force `ansible_connection: local` on the two `delegate_to: localhost` tasks — the inventory localhost defaults to ssh (armbian builds need that), so a bare delegation tried to ssh into the EE, which has no sshd. The cert-expiry task would have broken **every** renewal run, not just bootstrap.

**`templates/nginx.conf.j2`** — re-resolve upstream container names at request time via a `resolver` + a variable in `proxy_pass`. A static `proxy_pass` caches the backend IP at startup and 502s after any backend restart (new podman IP) until nginx is itself restarted; runtime re-resolution lets backends come and go untouched.

**New playbooks**
- `podman_migrate_run_user.yaml` — one-time clean migration of the rootless stack from an old run user to a new one (stop units, drop quadlets, disable linger) so they don't contend for 80/443.
- `podman_teardown.yaml` (+ `tasks/podman_teardown_user.yml`) — destructive helper to stop a user's quadlet stack and delete its podman secrets.

## Verification

Deployed end-to-end on `igou.io` (run user migrated `igou` → `containers`):
- All four vhosts (`whoami`/`hello`/`example`/`gotify`) serve **200 over a valid `*.igou.io` cert**; http→https 301 redirect works.
- Regression-tested the proxy fix: restarting a backend changed its IP (`10.89.0.11`→`.12`) and nginx self-healed within the resolver TTL **without** an nginx restart.
- `ansible-lint --profile=production` and `yamllint .` clean locally.

> [!NOTE]
> Depends on matching inventory changes for `igou.io` (host_vars: `linux_podman_run_as_user: containers`, gotify, wildcard+apex domains) — tracked separately in the igou-inventory repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)