### PR TITLE
fix(execution-environments): refresh stale fedora EE base image digest

### DIFF
--- a/execution-environments/igou-awx-ee-fedora/execution-environment.yml
+++ b/execution-environments/igou-awx-ee-fedora/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 images:
   base_image:
     # renovate: datasource=docker depName=quay.io/fedora/fedora
-    name: quay.io/fedora/fedora:45@sha256:b7d39aeed2a70f4cf1052f9ffc19a42cd7047f4bc7ff0a23ad4782af0ed0ed50
+    name: quay.io/fedora/fedora:45@sha256:277f4c735ab59ea13a453d88880d28fcec7d196dc132b9fb2e241cf3faac99fc
 options:
   package_manager_path: /usr/bin/dnf
 dependencies:


### PR DESCRIPTION
The `igou-awx-ee-fedora build` on `main` was failing:

```
Error: creating build container: initializing source
docker://quay.io/fedora/fedora@sha256:b7d39aee…ed0ed50: manifest unknown
```

The pinned `quay.io/fedora/fedora:45` base-image digest had been pruned from the registry after the `:45` tag was rebuilt (Fedora's quay repo prunes superseded digests). Repin `execution-environment.yml` to the current `:45` digest:

- `b7d39aee…ed0ed50` → `277f4c73…faac99fc` (resolved via `skopeo inspect docker://quay.io/fedora/fedora:45`, built 2026-05-30)

`ansible-builder build` regenerates the context Containerfile from this file at build time, so this is the only change needed. The fedora EE build only runs on push to `main` (path-filtered), so it'll execute on merge — I'll confirm it goes green afterward. yamllint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)