### PR TITLE
fix(armbian): make build_and_publish actually runnable (partial-run + arg-spec facts)

### DIFF
--- a/playbooks/armbian/build_and_publish.yaml
+++ b/playbooks/armbian/build_and_publish.yaml
@@ -25,6 +25,7 @@
   vars:
     __build_hosts: >-
       {{ groups[armbian_boards_group | default('boards')] | map('extract', hostvars)
+         | selectattr('__wants_custom_build', 'defined')
          | selectattr('__wants_custom_build', 'equalto', true)
          | map(attribute='inventory_hostname') | list }}
   tasks:
@@ -86,5 +87,6 @@
       changed_when: true
       loop: >-
         {{ groups[armbian_boards_group | default('boards')] | map('extract', hostvars)
+           | selectattr('__wants_custom_build', 'defined')
            | selectattr('__wants_custom_build', 'equalto', true)
            | map(attribute='inventory_hostname') | list }}

--- a/playbooks/armbian/build_and_publish.yaml
+++ b/playbooks/armbian/build_and_publish.yaml
@@ -21,7 +21,10 @@
 
 - name: Build custom images per opted-in host; stage on controller
   hosts: "{{ armbian_builders_group | default('armbian_builders') }}"
-  gather_facts: false
+  # gather_facts is required: the image_build role's argument_specs default
+  # several paths to "{{ ansible_env.HOME }}/...", and validate_argument_spec
+  # templates those at role entry (before the role's own setup runs).
+  gather_facts: true
   vars:
     __build_hosts: >-
       {{ groups[armbian_boards_group | default('boards')] | map('extract', hostvars)


### PR DESCRIPTION
Two runtime bugs found while validating a real single-board build against the live fleet (inherited from the collection's reference playbook):

1. **Partial-run crash** — `__build_hosts` ran `selectattr('__wants_custom_build','equalto',true)` over the whole `boards` group; boards excluded by `--limit` never set the fact and modern ansible-core errors on the missing attribute. Filter to `defined` first.
2. **arg-spec facts** — `image_build`'s argument_specs default cache/output dirs to `{{ ansible_env.HOME }}/...`, templated at role entry before the role's own `setup`; the builder play ran `gather_facts: false` so `ansible_env` was undefined. Gather facts on the builder play.

With both fixes, `build_and_publish` clears preflight/checkout/userpatch and invokes the real `./compile.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)