### PR TITLE
feat(armbian): finish lifecycle consumption — localhost/transport fixes, fresh-image e2e, v0.0.4-alpha pin

### DIFF
--- a/playbooks/armbian/build_and_publish.yaml
+++ b/playbooks/armbian/build_and_publish.yaml
@@ -21,7 +21,10 @@
 
 - name: Build custom images per opted-in host; stage on controller
   hosts: "{{ armbian_builders_group | default('armbian_builders') }}"
-  gather_facts: false
+  # gather_facts required: image_build's argument_specs default cache/output
+  # dirs to "{{ ansible_env.HOME }}/...", templated at role entry before the
+  # role's own setup runs, so ansible_env must already be populated.
+  gather_facts: true
   vars:
     __build_hosts: >-
       {{ groups[armbian_boards_group | default('boards')] | map('extract', hostvars)

--- a/playbooks/armbian/converge_boot_mode.yaml
+++ b/playbooks/armbian/converge_boot_mode.yaml
@@ -16,7 +16,7 @@
       run_once: true
       block:
         - name: Include plumbing check tasks
-          ansible.builtin.include_tasks: "{{ playbook_dir }}/transport/plumbing_check.yml"
+          ansible.builtin.include_tasks: transport/plumbing_check.yml
 
     - name: Resolve effective armbian_board_config
       ansible.builtin.include_tasks: tasks/_resolve_board_config.yml

--- a/playbooks/armbian/tasks/render_and_upload_pxelinux.yml
+++ b/playbooks/armbian/tasks/render_and_upload_pxelinux.yml
@@ -34,6 +34,8 @@
   delegate_to: "{{ armbian_router }}"
   block:
     - name: Include per-host pxelinux upload tasks
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/transport/upload_pxelinux_cfg.yml"
+      # Relative to this task file (tasks/) so it resolves regardless of
+      # playbook_dir (works when included from converge or the e2e tests).
+      ansible.builtin.include_tasks: ../transport/upload_pxelinux_cfg.yml
       vars:
         _upload_pxe_hostname: "{{ inventory_hostname }}"

--- a/playbooks/armbian/tasks/render_and_upload_pxelinux.yml
+++ b/playbooks/armbian/tasks/render_and_upload_pxelinux.yml
@@ -7,6 +7,12 @@
 #   armbian_tftp_cache_dir, armbian_tftp_flash_dir, armbian_router
 - name: Render pxelinux.cfg locally
   delegate_to: localhost
+  # Force a real local connection so the rendered file lands on the real
+  # controller /tmp that net_put reads. Inventory `localhost` defaults to
+  # SSH (build host) and this devcontainer's sshd has PrivateTmp, so an
+  # SSH-delegated render would write to an invisible private /tmp.
+  vars:
+    ansible_connection: local
   become: false
   block:
     - name: Include pxelinux_render role

--- a/playbooks/armbian/tests/_fresh_boot_and_bootstrap.yml
+++ b/playbooks/armbian/tests/_fresh_boot_and_bootstrap.yml
@@ -1,0 +1,56 @@
+---
+# Fresh-image boot + bootstrap + verify — used by fleet_e2e Phases 2 & 4.
+#
+# A board booting a freshly-provisioned rootfs (NFS clone or dd'd SD) has
+# only root + the Armbian default password and a freshly-regenerated SSH
+# host key. So we: render+upload pxelinux (no cycle), PoE-cycle and wait
+# for TCP/22 only (skip the SSH-as-inventory-user stability gate), run
+# bootstrap_armbian as root to create the inventory user, reset the
+# connection, then wait for SSH as the inventory user and verify.
+#
+# Caller (the phase play) provides via vars:
+#   _e2e_boot_mode    nfs | sd
+#   _e2e_phase_label  human label
+# and must have resolved armbian_board_config in its pre_tasks.
+- name: "Plumbing check on router — {{ _e2e_phase_label }}"
+  delegate_to: "{{ armbian_router }}"
+  run_once: true
+  block:
+    - name: "Include plumbing check — {{ _e2e_phase_label }}"
+      ansible.builtin.include_tasks: ../transport/plumbing_check.yml
+
+- name: "Render + upload pxelinux, no cycle — {{ _e2e_phase_label }}"
+  ansible.builtin.include_tasks: ../tasks/render_and_upload_pxelinux.yml
+  vars:
+    armbian_boot_mode: "{{ _e2e_boot_mode }}"
+
+- name: "PoE cycle + TCP/22 wait, skip SSH-as-user — {{ _e2e_phase_label }}"
+  ansible.builtin.include_tasks: ../tasks/cold_boot_with_retry.yml
+  vars:
+    _phase_label: "{{ _e2e_phase_label }}"
+    _boot_max_attempts: "{{ armbian_boot_retry_attempts | default(1) | int + 1 }}"
+    _skip_ssh_stability_check: true
+
+- name: "Bootstrap inventory user as root on fresh image — {{ _e2e_phase_label }}"
+  ansible.builtin.include_role:
+    name: david_igou.armbian.bootstrap_armbian
+  vars:
+    ansible_user: root
+    ansible_password: "{{ armbian_default_password }}"
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    ansible_become: false
+
+- name: "Reset connection to use inventory user — {{ _e2e_phase_label }}"
+  ansible.builtin.meta: reset_connection
+
+- name: "Wait for SSH as inventory user, post-bootstrap — {{ _e2e_phase_label }}"
+  ansible.builtin.include_tasks: ../tasks/wait_for_ssh.yml
+  vars:
+    _phase_label: "{{ _e2e_phase_label }}"
+    _wait_timeout: "{{ armbian_post_boot_wait_timeout | default(300) }}"
+
+- name: "Verify rootfs matches declared mode — {{ _e2e_phase_label }}"
+  ansible.builtin.include_role:
+    name: david_igou.armbian.board_boot_verify
+  vars:
+    boot_mode: "{{ _e2e_boot_mode }}"

--- a/playbooks/armbian/tests/fleet_e2e.yaml
+++ b/playbooks/armbian/tests/fleet_e2e.yaml
@@ -8,11 +8,16 @@
 # NFS + bootstrap + verify; 3 dd SD image; 4 converge SD + bootstrap +
 # verify; 5 converge NFS + reprovision NVMe + converge local_kernel.
 #
+# Fresh-image phases (2 + 4) boot a rootfs that has only root + the
+# Armbian default password and a freshly-regenerated SSH host key, so the
+# shared _fresh_boot_and_bootstrap.yml cycles + boots without waiting for
+# the inventory user, bootstraps it as root, then verifies as that user.
+#
 # Usage:
 #   ansible-playbook playbooks/armbian/tests/fleet_e2e.yaml \
 #     -i igou-inventory/inventory.yaml \
 #     -e target_hosts=board_e2e_canaries -e armbian_e2e_confirm=true
-- name: Phase 0 - PoE-off all target boards (clean slate)
+- name: Pre-flight (confirm + known_hosts bypass + retry defaults)
   hosts: "{{ target_hosts | default('board_e2e_canaries') }}"
   gather_facts: false
   tasks:
@@ -24,21 +29,47 @@
           fleet_e2e is destructive (wipes SD + NVMe). Re-run with
           -e armbian_e2e_confirm=true once you are sure of target_hosts.
 
+    - name: Clear stale known_hosts entries on the controller
+      ansible.builtin.command:
+        cmd: "ssh-keygen -R {{ item }}"
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
+      become: false
+      changed_when: false
+      failed_when: false
+      loop: "{{ [inventory_hostname, ansible_host | default(inventory_hostname)] | unique }}"
+
+    - name: Bypass known_hosts for the run (boot-mode transitions swap host keys)
+      ansible.builtin.set_fact:
+        ansible_ssh_common_args: "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR"
+        armbian_boot_retry_attempts: "{{ armbian_boot_retry_attempts | default(1) | int }}"
+        armbian_poe_cycle_delay: "{{ armbian_poe_cycle_delay | default(30) | int }}"
+
+- name: Phase 0 - PoE-off all target boards (clean slate)
+  hosts: "{{ target_hosts | default('board_e2e_canaries') }}"
+  gather_facts: false
+  tasks:
     - name: PoE-off each board
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/../transport/poe_off.yml"
+      ansible.builtin.include_tasks: ../transport/poe_off.yml
 
 - name: Phase 1 - force-refresh per-host NFS rootfs on netboot server
   ansible.builtin.import_playbook: ../stage_netboot_assets.yaml
   vars:
     armbian_force_refresh: true
 
-- name: Phase 2 - converge NFS, power on, verify
-  ansible.builtin.import_playbook: ../converge_boot_mode.yaml
-  vars:
-    armbian_boot_mode: nfs
-
-- name: Phase 2b - bootstrap freshly NFS-booted boards
-  ansible.builtin.import_playbook: ../bootstrap.yaml
+- name: Phase 2 - NFS boot + bootstrap + verify
+  hosts: "{{ target_hosts | default('board_e2e_canaries') }}"
+  gather_facts: false
+  pre_tasks:
+    - name: Resolve effective armbian_board_config
+      ansible.builtin.include_tasks: ../tasks/_resolve_board_config.yml
+  tasks:
+    - name: Fresh NFS boot + bootstrap + verify
+      ansible.builtin.include_tasks: _fresh_boot_and_bootstrap.yml
+      vars:
+        _e2e_boot_mode: nfs
+        _e2e_phase_label: "Phase 2 (nfs)"
 
 - name: Phase 3 - dd canonical SD image from NFS
   hosts: "{{ target_hosts | default('board_e2e_canaries') }}"
@@ -47,21 +78,25 @@
   tasks:
     - name: Resolve rootfs source (published image URL) per host
       ansible.builtin.include_tasks: ../tasks/_resolve_rootfs_src.yml
-
     - name: Write SD image via disk_image role
       ansible.builtin.include_role:
         name: david_igou.armbian.disk_image
       vars:
         image_source: "{{ armbian_rootfs_src }}"
-        target_device: /dev/mmcblk0
+        target_device: "{{ armbian_sd_device | default('/dev/mmcblk0') }}"
 
-- name: Phase 4 - converge SD, verify
-  ansible.builtin.import_playbook: ../converge_boot_mode.yaml
-  vars:
-    armbian_boot_mode: sd
-
-- name: Phase 4b - bootstrap freshly SD-booted boards
-  ansible.builtin.import_playbook: ../bootstrap.yaml
+- name: Phase 4 - SD boot + bootstrap + verify
+  hosts: "{{ target_hosts | default('board_e2e_canaries') }}"
+  gather_facts: false
+  pre_tasks:
+    - name: Resolve effective armbian_board_config
+      ansible.builtin.include_tasks: ../tasks/_resolve_board_config.yml
+  tasks:
+    - name: Fresh SD boot + bootstrap + verify
+      ansible.builtin.include_tasks: _fresh_boot_and_bootstrap.yml
+      vars:
+        _e2e_boot_mode: sd
+        _e2e_phase_label: "Phase 4 (sd)"
 
 - name: Phase 5 - reprovision NVMe then converge local_kernel
   ansible.builtin.import_playbook: ../reprovision_to_local.yaml

--- a/playbooks/armbian/transport/upload_file.yml
+++ b/playbooks/armbian/transport/upload_file.yml
@@ -14,6 +14,13 @@
   ansible.builtin.stat:
     path: "{{ _upload_local_src }}"
   delegate_to: localhost
+  # Force a real local connection: inventory `localhost` defaults to SSH
+  # (it is an SSH-able build host), and this devcontainer's sshd has
+  # PrivateTmp, so an SSH-delegated stat reads a private /tmp the local
+  # net_put cannot see. net_put reads the real controller fs, so the
+  # stat must too. See feedback_localhost_connection / devcontainer sshd.
+  vars:
+    ansible_connection: local
   become: false
   register: _upload_local_stat
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -64,5 +64,5 @@ collections:
     version: 0.30.0
   - name: https://github.com/david-igou/ansible-collection-armbian.git
     type: git
-    version: v0.0.3-alpha
+    version: v0.0.4-alpha
 ...


### PR DESCRIPTION
## Summary

Makes the recreated `playbooks/armbian/` flows actually run end-to-end on real hardware (local ansible), and bumps the collection pin to the fix. Three changes:

1. **`fix(armbian)`: force local connection for localhost-delegated render + stat** — this devcontainer's inventory `localhost` is SSH-able (build host) and its sshd has PrivateTmp, so `delegate_to: localhost` wrote the rendered pxelinux.cfg into an ephemeral private `/tmp` that `net_put` (reading the real controller fs) couldn't find. Scope `ansible_connection: local` to just those two steps (harmless in EE/AAP where localhost is already local).

2. **`feat(armbian)`: port fresh-image e2e machinery + playbook_dir-independent includes** — `fleet_e2e` now mirrors the collection's deterministic harness for fresh images: a pre-flight that strips known_hosts + bypasses host-key checking (boot-mode transitions swap host keys), and a shared `_fresh_boot_and_bootstrap.yml` (render+upload no-cycle → PoE cycle with `_skip_ssh_stability_check` → `bootstrap_armbian` as root → reset → wait as inventory user → `board_boot_verify`) for Phases 2 & 4. Phase 3 dd targets `armbian_sd_device`. Transport includes use relative paths so they resolve regardless of `playbook_dir`.

3. **`feat(armbian)`: bump pin to `v0.0.4-alpha`** — picks up the collection's `disk_provision` `blkdiscard -f` fix (required by util-linux ≥2.41 on a disk with an existing partition table). See #201.

## Validation (real hardware, local ansible 2.20.5)

- **Full six-phase `fleet_e2e` passes deterministically — 3 consecutive runs on orange-pi-5-01, all `failed=0`** (`ok≈264`), board ending on NVMe/local_kernel each run.
- Earlier: Phases 0–4 passed on opi5pro-01 and orange-pi-5-01 across multiple runs; Phase 5 was blocked only by the pre-fix `blkdiscard` (now resolved via the v0.0.4-alpha bump).
- Roles exercised on hardware: `rootfs_provision`, `pxelinux_render`, `board_boot_verify`, `bootstrap_armbian`, `disk_image`, `disk_provision` + the rb5009 transport.

Closes #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
