### PR TITLE
chore(ee): remove digest pinning from centos base images

### DIFF
--- a/execution-environments/igou-awx-ee/execution-environment.yml
+++ b/execution-environments/igou-awx-ee/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 images:
   base_image:
     # renovate: datasource=docker depName=quay.io/centos/centos
-    name: quay.io/centos/centos:stream10-minimal@sha256:db3197606c9f1a310b14a4074b432c6cfc10be08631d71998d961e6b5104b55d
+    name: quay.io/centos/centos:stream10-minimal
 options:
   package_manager_path: /usr/bin/microdnf
 dependencies:

--- a/execution-environments/igou-networking-ee/execution-environment.yml
+++ b/execution-environments/igou-networking-ee/execution-environment.yml
@@ -4,7 +4,7 @@ version: 3
 images:
   base_image:
     # renovate: datasource=docker depName=quay.io/centos/centos
-    name: quay.io/centos/centos:stream9-minimal@sha256:99281d546d574f5a40bc1ae92f80ea2a9ae9292c15f4c543e56e4086fb77aa0c
+    name: quay.io/centos/centos:stream9-minimal
 options:
   package_manager_path: /usr/bin/microdnf
 dependencies:


### PR DESCRIPTION
Drop the `@sha256` digest pins on the centos base images so EE builds track the tag:
- `igou-awx-ee` → `quay.io/centos/centos:stream10-minimal`
- `igou-networking-ee` → `quay.io/centos/centos:stream9-minimal`

Fedora (`igou-awx-ee-fedora`) and the rhel9 OCP base are unaffected. `context/` is gitignored (ansible-builder regenerates it from `execution-environment.yml`), so only the two source defs change.

Note: builds now pull the mutable `stream{9,10}-minimal` tags rather than a fixed digest — less reproducible, but tracks upstream. If Renovate is configured with `pinDigests`, it may re-add the `@sha256` pins on its next run; the renovate config would need adjusting to keep them off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)