### PR TITLE
fix(ee): pin ansible.controller >=4.8.0 (AAP 2.6 token 404)

### DIFF
--- a/execution-environments/igou-aap-ee-rhel9/execution-environment.yml
+++ b/execution-environments/igou-aap-ee-rhel9/execution-environment.yml
@@ -59,6 +59,11 @@ dependencies:
       - name: ansible.hub
       - name: ansible.eda
       - name: ansible.controller
+        # >=4.8.0: replaces controller-local OAuth token minting (POST
+        # /api/controller/v2/tokens/, removed in AAP 2.6 gateway) with
+        # per-request HTTP Basic auth. <4.8.0 fails configure-aap with
+        # "Failed to get token: HTTP Error 404".
+        version: ">=4.8.0"
       - name: infra.aap_configuration
       - name: infra.aap_utilities
 additional_build_steps:


### PR DESCRIPTION
## Problem

`make aap-configure` (`infra.aap_configuration.dispatch`) fails at the controller-side org task:

```
fatal: [aap_host]: FAILED! => "msg": "error: Failed to get token: HTTP Error 404: Not Found"
```

The gateway/platform org step succeeds (auth is fine) — only the controller modules fail.

## Root cause

AAP 2.6's gateway removed controller-local OAuth. `POST /api/controller/v2/tokens/` now 404s (tokens live at `/api/gateway/v1/tokens/`). `ansible.controller` ≤4.7.11's `authenticate()` *unconditionally* mints a session token at that dead endpoint when given username/password — there is no gateway code path in it.

Endpoint probe against the live AAP confirmed:

| Endpoint | Result |
|---|---|
| `/api/controller/v2/ping/` | 200 (controller healthy) |
| `/api/controller/v2/tokens/` | **404** |
| `/api/gateway/v1/tokens/` (POST) | 200 (tokens moved here) |

## Fix

Pin `ansible.controller` to **>=4.8.0**. 4.8.0 rewrote `authenticate()` to drop token minting and use per-request HTTP Basic auth (`GET /api/controller/v2/me`).

Bumping `infra.aap_configuration` does **not** help (4.6.0 changelog has no auth changes) — the bug is purely in the certified `ansible.controller` collection.

## Verification

Overlaid 4.8.0 onto the current EE image and ran the exact operation that failed, against the live AAP with username/password:

```
TASK [Create/assert controller org (auth path under test)]
ok: [localhost]
"msg": "changed=False  (no 404 => 4.8.0 auth works)"
```

## Notes

- Requires the EE rebuild (Tekton `igou-aap-ee-rhel9-push.yml`) to take effect.
- The `>=4.8.0` constraint will fail the build loudly if 4.8.0 isn't yet published to the RH Certified hub the build pulls from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)