### PR TITLE
fix(ee): pin ansible.platform <2.7 (async incompat with 2.7 action plugins)

### DIFF
--- a/execution-environments/igou-aap-ee-rhel9/execution-environment.yml
+++ b/execution-environments/igou-aap-ee-rhel9/execution-environment.yml
@@ -56,6 +56,14 @@ dependencies:
       - name: infra.ah_configuration
       - name: redhat.rhel_system_roles
       - name: ansible.platform
+        # <2.7: ansible.platform 2.7 ships action plugins for every gateway
+        # module (organization, application, authenticator, role_*, route,
+        # service, settings, team, user, ...), which do not support `async`.
+        # infra.aap_configuration's gateway_* roles wrap every call in
+        # `async: 1000, poll: 0` unconditionally, so 2.7 hard-fails with
+        # "async is not supported for this task." 2.6.x (used by the
+        # deployed AAP 2.6 gateway) has plain modules and works.
+        version: "<2.7"
       - name: ansible.hub
       - name: ansible.eda
       - name: ansible.controller


### PR DESCRIPTION
## Problem

After the EE rebuild for #204, `make aap-configure` fails at every gateway role with:

```
msg: "async is not supported for this task."
item: Create/Update AAP Platform Organizations igou
```

So the token 404 is gone, but a different error blocks the run.

## Root cause

`ansible.platform` floated **2.6.20260504 → 2.7.20260515** during the rebuild. 2.7 ships **action plugins** for every gateway module:

```
plugins/action/: organization.py, application.py, authenticator.py,
                 authenticator_map.py, authenticator_user.py, ca_certificate.py,
                 feature_flag.py, http_port.py, role_definition.py,
                 role_team_assignment.py, role_user_assignment.py, route.py,
                 service.py, service_cluster.py, service_key.py,
                 service_node.py, service_type.py, settings.py, team.py,
                 token.py, ui_plugin_route.py, user.py
```

Action plugins do **not** support `async`. But `infra.aap_configuration` 4.6.0's `gateway_*` roles wrap every module call in `async: 1000, poll: 0` (`gateway_organizations/tasks/main.yml:26-27`) — unconditionally, no toggle in defaults. So 2.7's action-plugin modules hard-fail.

Latest `infra.aap_configuration` on Galaxy is 4.6.0 — there's no newer build that handles this. The deployed AAP gateway is 2.6, and 2.6.x of `ansible.platform` (plain modules, no action plugins) is what worked in the original run.

## Fix

Pin `ansible.platform` to `<2.7` in the EE. Combined with the `ansible.controller >=4.8.0` pin from #204, this is the proven-working combination against the live AAP 2.6 gateway.

## Notes

- Requires another EE rebuild (Tekton `igou-aap-ee-rhel9-push.yml`) to take effect.
- If/when Red Hat publishes an `infra.aap_configuration` release that removes async from gateway role calls (or AAP/`ansible.platform` regains module-side `async` support), the upper bound can be relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)