### PR TITLE
chore(requirements): add david_igou.routeros_configuration 0.0.1-alpha

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -58,6 +58,8 @@ collections:
     version: 8.5.2
   - name: community.routeros
     version: 3.20.0
+  - name: david_igou.routeros_configuration
+    version: 0.0.1-alpha
   - name: amazon.aws
     version: 11.3.0
   - name: prometheus.prometheus


### PR DESCRIPTION
## What

Adds the `david_igou.routeros_configuration` collection (latest published version, `0.0.1-alpha`) to the shared `requirements.yml`.

## Why

This bundles the collection into the **igou-awx-ee** and **igou-awx-ee-fedora** execution environments (both build from `../../requirements.yml`), making it available to the RouterOS job templates that run on `igou-awx-ee` (`routeros_baseline`, `routeros_backup`, `routeros_backup_s3`). It is the groundwork for retrofitting the RouterOS playbooks onto the collection's roles/modules.

## Validation

- `yamllint requirements.yml` passes.
- Fresh `ansible-galaxy collection install david_igou.routeros_configuration:0.0.1-alpha --force` resolves and downloads cleanly from Galaxy; its deps (`ansible.utils`, `ansible.netcommon`, `community.routeros`) are already pinned here at compatible versions.

## Build impact

Merging triggers rebuilds of `igou-awx-ee` and `igou-awx-ee-fedora` (both watch `requirements.yml`). `igou-networking-ee` also watches `requirements.yml` but uses its own inline collection list, so its rebuild is a no-op for this change. `igou-aap-ee-rhel9` (firewall templates) reads neither and is unaffected — to be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)