### PR TITLE
Seed 1Password Connect at bootstrap (prompted SA + ocp-connect-bootstrap vault)

### DIFF
--- a/playbooks/openshift/hub-cluster/bootstrap_gitops.yaml
+++ b/playbooks/openshift/hub-cluster/bootstrap_gitops.yaml
@@ -7,6 +7,10 @@
     K8S_AUTH_KUBECONFIG: "{{ kubeconfig | default(omit) }}"
   vars:
     gitops_repo: "https://github.com/igou-io/igou-openshift.git"
+  vars_prompt:
+    - name: op_bootstrap_sa_token
+      prompt: "1Password ocp-bootstrap service-account token (ops_...)"
+      private: true
   tasks:
     - name: Create 1P Connect secrets, deploy and cluster-config application
       tags: create-objects
@@ -59,21 +63,49 @@
               metadata:
                 name: external-secrets-operator
 
-        - name: Create 1password-token secrets
+        # Connect bootstrap seed (chicken-egg): read the Connect server's own
+        # credentials + access token from the dedicated ocp-connect-bootstrap
+        # vault, authenticating as the read-only ocp-bootstrap SA via the
+        # prompted token. Seeds the two Secrets that Connect + ESO need to start.
+        - name: Create onepassword-connect namespace
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: onepassword-connect
+
+        - name: Seed the Connect server credentials Secret
           kubernetes.core.k8s:
             state: present
             definition:
               apiVersion: v1
               kind: Secret
               metadata:
-                name: "{{ item.name }}"
+                name: op-credentials
+                namespace: onepassword-connect
+                annotations:
+                  managed-by: ansible
+              type: Opaque
+              stringData:
+                1password-credentials.json: "{{ lookup('community.general.onepassword_doc', 'ocp-connect-credentials', vault='ocp-connect-bootstrap', service_account_token=op_bootstrap_sa_token) }}"
+          no_log: true
+
+        - name: Seed the Connect access token Secret (for ESO)
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: onepassword-connect-token
                 namespace: external-secrets-operator
                 annotations:
                   managed-by: ansible
               type: Opaque
               stringData:
-                token: "{{ item.contents }}"
-          loop: "{{ onepassword_tokens }}"
+                token: "{{ lookup('community.general.onepassword', 'ocp-connect-token', field='token', vault='ocp-connect-bootstrap', service_account_token=op_bootstrap_sa_token) }}"
           no_log: true
 
         - name: Create Gitops ClusterRoleBinding


### PR DESCRIPTION
## What
Replaces the SDK `onepassword_tokens` seed loop in `bootstrap_gitops.yaml` with seeding the **1Password Connect** bootstrap material:

- creates the `onepassword-connect` namespace
- reads the Connect **credentials document** (`ocp-connect-credentials`) and **access token** (`ocp-connect-token`) from a dedicated **`ocp-connect-bootstrap`** vault
- seeds `op-credentials` (ns `onepassword-connect`) and `onepassword-connect-token` (ns `external-secrets-operator`)

Auth is the read-only `ocp-bootstrap` service account, whose token is **prompted at runtime** (`vars_prompt`, `private: true`) — never stored where the playbook reads, which resolves the chicken-egg. Both reads use the `op` CLI with `OP_SERVICE_ACCOUNT_TOKEN` set per-task (Ansible `environment:` reaches tasks, not lookups).

## Why
Part of the ESO **SDK → Connect** migration in `igou-openshift`. The Connect server is already live on the cluster; this only affects a future from-scratch re-bootstrap.

## Prerequisites (must exist before running)
- Vault `ocp-connect-bootstrap` containing: a Document titled `ocp-connect-credentials` (the `1password-credentials.json`) and a Password item titled `ocp-connect-token` with a field labeled `token`.
- A read-only `ocp-bootstrap` service account scoped to that vault; paste its `ops_…` token at the prompt.

## Not included
- Removal of the SDK rate-limit ArgoCD `resourceHealthChecks` override (the other half of the migration's Task 8) — can be added on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
