### PR TITLE
feat(deps): add onepassword.connect collection to EE requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -64,6 +64,8 @@ collections:
     version: 11.3.0
   - name: prometheus.prometheus
     version: 0.30.0
+  - name: onepassword.connect
+    version: 2.4.0
   - name: https://github.com/david-igou/ansible-collection-armbian.git
     type: git
     version: v0.0.4-alpha


### PR DESCRIPTION
## Summary
- Adds `onepassword.connect` 2.4.0 to `requirements.yml` (baked into the EEs).
- `community.general` onepassword lookups only cover **reads**; this collection's modules (`generic_item`, etc.) enable **writing** items to 1Password vaults from AAP jobs, using the same `OP_CONNECT_HOST`/`OP_CONNECT_TOKEN` injection the Onepassword Connect credential type already provides.
- First consumer: automatic upload of generated secrets (e.g. the rk8s kubeconfig) into a vault from cluster workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)