### PR TITLE
feat(kubernetes): publish kubeconfig to 1Password after k3s install

### DIFF
--- a/playbooks/kubernetes/README.md
+++ b/playbooks/kubernetes/README.md
@@ -37,10 +37,15 @@ ansible-navigator run playbooks/kubernetes/install-k3s-cluster.yml \
   -e ansible_limit=rk8s
 ```
 
-After install, grab the kubeconfig from the control-plane node
-(`/etc/rancher/k3s/k3s.yaml`), rewrite the server URL to point at
-`rock-5b-01.igou.systems:6443`, and stash it where the bootstrap step
-expects it (see below).
+After install, the imported `publish-kubeconfig-1password.yaml` play
+slurps the kubeconfig from the control-plane node
+(`/etc/rancher/k3s/k3s.yaml`), rewrites the server URL to the control
+node's FQDN, and upserts it to `op://awx/<cluster>-kubeconfig` (the
+`kubeconfig` field is base64 — decode on use). Needs `OP_CONNECT_HOST`
+and `OP_CONNECT_TOKEN` in the env (AAP injects them via the
+"Onepassword Connect" credential); without them the publish step skips
+with a warning. Re-publish on demand via the `k3s_publish_kubeconfig`
+AAP template or by running the publish playbook directly.
 
 ## Install — kubernetes (alternative)
 

--- a/playbooks/kubernetes/install-k3s-cluster.yml
+++ b/playbooks/kubernetes/install-k3s-cluster.yml
@@ -18,51 +18,7 @@
         - "'firewalld.service' in ansible_facts.services"
         - ansible_facts.services['firewalld.service'].status != 'not-found'
 
-# - hosts: "{{ ansible_limit | default('none') }}"
-#   name: Create secret store kubeconfig entry
-#   no_log: false
-#   gather_facts: false
-#   tasks:
-
-#   # Copy /etc/rancher/k3s/k3s.yaml from a single master node determined by k3s_control_node=true
-
-#     - name: Get Kubeconfig from master
-#       tags: get_kubeconfig
-#       become: true
-#       when: k3s_control_node | default(false) | bool
-#       block:
-#       - name: Slurp kubeconfig
-#         ansible.builtin.slurp:
-#           src: '/etc/rancher/k3s/k3s.yaml'
-#         register: kubeconfig
-
-#       - name: Set fact to hostname of first control node in group
-#         ansible.builtin.set_fact:
-#           first_k3s_control_node: >-
-#             {{ (groups[ansible_limit] | map('extract', hostvars) |
-#                 selectattr('k3s_control_node', 'defined') |
-#                 selectattr('k3s_control_node') |
-#                 map(attribute='inventory_hostname') |
-#                 list).0 }}
-#         delegate_to: localhost
-
-#       - name: Save secrets to 1password
-#         delegate_to: localhost
-#         tags: op_save
-#         block:
-#         - name: Create kubeconfig facts
-#           ansible.builtin.set_fact:
-#             kubeconfig_contents: "{{ kubeconfig.content | b64decode | regex_replace('https://127.0.0.1:6443', 'https://' + first_k3s_control_node + ':6443') }}"
-#             kubeconfig_dict: "{{ kubeconfig.content | b64decode | from_yaml }}"
-
-#       - name: Set facts for password
-#         ansible.builtin.set_fact:
-#           op_item_name: "{{ ansible_limit + '-kubeconfig-' + now(utc=true,fmt='%Y%m%d%H%M') }}"
-#           client_certificate_data: "{{ kubeconfig_dict.users[0].user['client-certificate-data'] }}"
-#           client_key_data: "{{ kubeconfig_dict.users[0].user['client-key-data'] }}"
-#           api_url: "{{ 'https://' + ansible_host + ':6443' }}"
-
-#       - name: Save auth info to 1password
-#         ansible.builtin.shell:
-#           cmd: op item create --category=login --title {{ op_item_name }} --vault=awx kubeconfig[password]={{ kubeconfig_contents | b64encode }} client_certificate_data[password]={{ client_certificate_data }} client_key_data[password]={{ client_key_data }} api_url[password]={{ api_url }}</dev/null
-#         delegate_to: localhost
+# Refresh op://awx/<cluster>-kubeconfig after every install/update. Skips
+# with a warning when OP_CONNECT_* env is absent (local runs w/o Connect).
+- name: Publish kubeconfig to 1Password
+  ansible.builtin.import_playbook: publish-kubeconfig-1password.yaml

--- a/playbooks/kubernetes/publish-kubeconfig-1password.yaml
+++ b/playbooks/kubernetes/publish-kubeconfig-1password.yaml
@@ -1,0 +1,104 @@
+---
+# Publish a k3s cluster kubeconfig to 1Password (upsert by item name).
+#
+# Slurps /etc/rancher/k3s/k3s.yaml from the cluster's control-plane node,
+# rewrites the loopback server URL to the control node's FQDN (which is in
+# the cert's tls-san, see group_vars/rk8s.yml), and upserts
+# op://<op_vault>/<cluster_name>-kubeconfig via 1Password Connect.
+# The kubeconfig field is stored base64-encoded (1Password flattens
+# multi-line values); consume with `... | b64decode`.
+#
+# Auth: OP_CONNECT_HOST + OP_CONNECT_TOKEN env, injected by the AAP
+# credential type "Onepassword Connect". When the env is absent (e.g. a
+# local run without Connect access) the play skips with a warning instead
+# of failing, so the install playbook can import this unconditionally.
+# onepassword.connect modules only accept a vault UUID, so the play
+# resolves `op_vault` (name) through the Connect REST API first.
+#
+# Scoped like the install playbook:
+#   ansible-playbook ... -e ansible_limit=rk8s
+# AAP template: k3s_publish_kubeconfig (igou-inventory job_templates.yml);
+# also imported by install-k3s-cluster.yml so every install/update run
+# refreshes the vault item.
+- name: Publish kubeconfig to 1Password
+  hosts: "{{ ansible_limit | default('none') }}"
+  gather_facts: false
+  become: false
+
+  vars:
+    op_vault: awx
+    kubeconfig_src: /etc/rancher/k3s/k3s.yaml
+    op_item_name: "{{ cluster_name | default(ansible_limit) }}-kubeconfig"
+    _op_connect_host: "{{ lookup('ansible.builtin.env', 'OP_CONNECT_HOST') | regex_replace('/$', '') }}"
+
+  tasks:
+    - name: Warn when 1Password Connect env is absent
+      ansible.builtin.debug:
+        msg: >-
+          OP_CONNECT_HOST/OP_CONNECT_TOKEN not set — skipping kubeconfig
+          publish. Attach the "Onepassword Connect" credential (AAP) or
+          export the env (local) to enable it.
+      run_once: true
+      when: _op_connect_host | length == 0
+
+    - name: Publish kubeconfig from the control-plane node
+      run_once: true
+      when: _op_connect_host | length > 0
+      block:
+        - name: Determine first control-plane node
+          ansible.builtin.set_fact:
+            _k3s_control_node: >-
+              {{ ansible_play_hosts_all | map('extract', hostvars) |
+                 selectattr('k3s_control_node', 'defined') |
+                 selectattr('k3s_control_node') |
+                 map(attribute='inventory_hostname') | first }}
+
+        - name: Slurp kubeconfig from control-plane node
+          ansible.builtin.slurp:
+            src: "{{ kubeconfig_src }}"
+          delegate_to: "{{ _k3s_control_node }}"
+          become: true
+          register: _kubeconfig_raw
+          no_log: true
+
+        - name: Rewrite kubeconfig server URL to the control node FQDN
+          ansible.builtin.set_fact:
+            _kubeconfig: >-
+              {{ _kubeconfig_raw.content | b64decode |
+                 replace('https://127.0.0.1:6443', 'https://' ~ _k3s_control_node ~ ':6443') }}
+          no_log: true
+
+        - name: Resolve 1Password vault id
+          ansible.builtin.uri:
+            url: "{{ _op_connect_host }}/v1/vaults?filter={{ ('name eq \"' ~ op_vault ~ '\"') | urlencode }}"
+            headers:
+              Authorization: "Bearer {{ lookup('ansible.builtin.env', 'OP_CONNECT_TOKEN') }}"
+          delegate_to: localhost
+          register: _op_vaults
+          no_log: true
+
+        - name: "Upsert 1Password kubeconfig item {{ op_item_name }}"
+          onepassword.connect.generic_item:
+            vault_id: "{{ (_op_vaults.json | selectattr('name', '==', op_vault) | first).id }}"
+            name: "{{ op_item_name }}"
+            category: api_credential
+            state: present
+            fields:
+              - label: kubeconfig
+                field_type: concealed
+                value: "{{ _kubeconfig | b64encode }}"
+              - label: api_url
+                field_type: url
+                value: "https://{{ _k3s_control_node }}:6443"
+              - label: client_certificate_data
+                field_type: concealed
+                value: "{{ (_kubeconfig | from_yaml).users[0].user['client-certificate-data'] }}"
+              - label: client_key_data
+                field_type: concealed
+                value: "{{ (_kubeconfig | from_yaml).users[0].user['client-key-data'] }}"
+          delegate_to: localhost
+          no_log: true
+
+        - name: Report published item
+          ansible.builtin.debug:
+            msg: "Published op://{{ op_vault }}/{{ op_item_name }} (server: https://{{ _k3s_control_node }}:6443)"


### PR DESCRIPTION
## Summary
- New `playbooks/kubernetes/publish-kubeconfig-1password.yaml`: slurps `/etc/rancher/k3s/k3s.yaml` from the control-plane node, rewrites the loopback server URL to the control node FQDN (in tls-san), and upserts `op://awx/<cluster>-kubeconfig` (kubeconfig field base64, plus api_url / client cert+key fields) using `onepassword.connect.generic_item` (added to the EE in #222).
- Vault name → UUID resolved at runtime via the Connect REST API (the collection only accepts `vault_id`).
- Imported at the end of `install-k3s-cluster.yml`, replacing the long-dead commented `op item create` block — every install/update run now refreshes the vault item. Skips with a warning when `OP_CONNECT_*` env is absent.
- Companion AAP template `k3s_publish_kubeconfig` lands in igou-inventory.

## Testing
- `yamllint`, `ansible-lint --profile=production`, syntax check: pass.
- Ran for real against rk8s from the devcontainer: slurp/rewrite/vault-resolution all verified; the final upsert was blocked only by the local Connect token being read-only on the awx vault (`403 create`), which confirms the module call is well-formed. End-to-end completion pending a write-capable token (AAP credential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)