### PR TITLE
feat(kubernetes): publish kubeconfig to the claude vault

### DIFF
--- a/playbooks/kubernetes/README.md
+++ b/playbooks/kubernetes/README.md
@@ -40,12 +40,14 @@ ansible-navigator run playbooks/kubernetes/install-k3s-cluster.yml \
 After install, the imported `publish-kubeconfig-1password.yaml` play
 slurps the kubeconfig from the control-plane node
 (`/etc/rancher/k3s/k3s.yaml`), rewrites the server URL to the control
-node's FQDN, and upserts it to `op://awx/<cluster>-kubeconfig` (the
-`kubeconfig` field is base64 — decode on use). Needs `OP_CONNECT_HOST`
-and `OP_CONNECT_TOKEN` in the env (AAP injects them via the
-"Onepassword Connect" credential); without them the publish step skips
-with a warning. Re-publish on demand via the `k3s_publish_kubeconfig`
-AAP template or by running the publish playbook directly.
+node's FQDN, and upserts it to `op://claude/<cluster>-kubeconfig` (the
+`kubeconfig` field is base64 — decode on use). The devcontainer loads
+it with `use rk8s` (igou-devenv `envs/rk8s.env`). Needs
+`OP_CONNECT_HOST` and `OP_CONNECT_TOKEN` in the env (AAP injects them
+via the "Onepassword Connect" credential) and a token with write access
+to the claude vault; without the env the publish step skips with a
+warning. Re-publish on demand via the `k3s_publish_kubeconfig` AAP
+template or by running the publish playbook directly.
 
 ## Install — kubernetes (alternative)
 

--- a/playbooks/kubernetes/publish-kubeconfig-1password.yaml
+++ b/playbooks/kubernetes/publish-kubeconfig-1password.yaml
@@ -8,6 +8,11 @@
 # The kubeconfig field is stored base64-encoded (1Password flattens
 # multi-line values); consume with `... | b64decode`.
 #
+# Default vault is `claude` so the devcontainer `use` command can load it:
+# igou-devenv envs/rk8s.env points KUBECONFIG_DATA at
+# op://claude/rk8s-kubeconfig/kubeconfig (`use rk8s`). The Connect token
+# must have write access to that vault.
+#
 # Auth: OP_CONNECT_HOST + OP_CONNECT_TOKEN env, injected by the AAP
 # credential type "Onepassword Connect". When the env is absent (e.g. a
 # local run without Connect access) the play skips with a warning instead
@@ -26,7 +31,7 @@
   become: false
 
   vars:
-    op_vault: awx
+    op_vault: claude
     kubeconfig_src: /etc/rancher/k3s/k3s.yaml
     op_item_name: "{{ cluster_name | default(ansible_limit) }}-kubeconfig"
     _op_connect_host: "{{ lookup('ansible.builtin.env', 'OP_CONNECT_HOST') | regex_replace('/$', '') }}"


### PR DESCRIPTION
## Summary
- Default `op_vault` for the kubeconfig publish is now `claude` (was `awx`): `op://claude/rk8s-kubeconfig/kubeconfig` matches the devcontainer `use` convention, paired with `envs/rk8s.env` in igou-devenv (`KUBECONFIG_DATA=op://claude/rk8s-kubeconfig/kubeconfig`).
- Connect token needs write access to the claude vault (AAP credential updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)