### PR TITLE
feat(kubernetes): bootstrap-gitops playbook for app-of-apps layout

### DIFF
--- a/playbooks/kubernetes/README.md
+++ b/playbooks/kubernetes/README.md
@@ -63,23 +63,27 @@ playbook handles both via `geerlingguy.containerd` and an
 
 ## Bootstrap (either distro)
 
-`bootstrap-cluster.yml` is distro-agnostic. It needs a working
-kubeconfig and a 1Password service-account token, then it deploys:
-
-1. `external-secrets` operator
-2. `argocd` (overlay from `igou-io/igou-kubernetes`)
-3. A `ClusterSecretStore` wired to the `awx` 1Password vault
+`bootstrap-gitops.yaml` bootstraps a cluster from igou-kubernetes'
+app-of-apps layout (see `docs/bootstrap.md` there). It pulls the
+kubeconfig from `op://claude/<cluster>-kubeconfig` (published by the
+install playbook above), installs argocd, seeds the 1Password Connect
+token secret backing the `onepassword` ClusterSecretStore, and applies
+`clusters/<cluster>` — after which argocd self-manages the cluster.
+Needs `OP_CONNECT_HOST`/`OP_CONNECT_TOKEN` in the env (AAP injects
+them via the "Onepassword Connect" credential).
 
 ```bash
-ansible-navigator run playbooks/kubernetes/bootstrap-cluster.yml \
-  -e overlay=internal \
-  -e vault_name=awx \
-  -e onepassword_token="$(op read 'op://awx/onepassword-token/credential')" \
-  -e kubeconfig=/path/to/rk8s-kubeconfig.yaml
+ansible-playbook playbooks/kubernetes/bootstrap-gitops.yaml \
+  -e gitops_cluster=internal \
+  -e kubeconfig_op_item=rk8s-kubeconfig
 ```
 
-`overlay` selects the overlay directory under
-`https://github.com/igou-io/igou-kubernetes/config/<overlay>/`.
+Application CRs track `targetRevision: HEAD` — only bootstrap from a
+ref whose content matches the repo's default branch.
+
+`bootstrap-cluster.yml` is the legacy version targeting the old
+`config/<overlay>` layout; it is retained until the
+`kubernetes_bootstrap_gitops` AAP template repoints, then it goes.
 
 ## Notes
 

--- a/playbooks/kubernetes/bootstrap-gitops.yaml
+++ b/playbooks/kubernetes/bootstrap-gitops.yaml
@@ -1,0 +1,134 @@
+---
+# Bootstrap a cluster from igou-kubernetes (app-of-apps layout).
+#
+# Mirrors igou-kubernetes docs/bootstrap.md, with the secret seed between
+# the two applies:
+#   1. kustomize build --enable-helm components/argocd | kubectl apply --server-side
+#   2. seed external-secrets/onepassword-connect-token from the OP_CONNECT_*
+#      env (AAP "Onepassword Connect" credential) — backs the `onepassword`
+#      ClusterSecretStore so ExternalSecrets can resolve
+#   3. kustomize build --enable-helm clusters/<cluster> | kubectl apply
+# After step 3 the cluster self-manages: argocd adopts its own install and
+# reconciles everything in the repo.
+#
+# The kubeconfig comes from op://<vault>/<item>/kubeconfig (base64), as
+# published by install-k3s-cluster.yml / the k3s_publish_kubeconfig AAP
+# template. NOTE: Application CRs track targetRevision HEAD — only run this
+# against a gitops_ref whose content is (or is about to be) the repo's
+# default branch, or argocd will immediately reconcile back to master.
+#
+#   ansible-playbook playbooks/kubernetes/bootstrap-gitops.yaml \
+#     [-e gitops_ref=master] [-e gitops_cluster=internal] \
+#     [-e kubeconfig_op_item=rk8s-kubeconfig]
+- name: Bootstrap cluster GitOps from igou-kubernetes
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    gitops_repo: https://github.com/igou-io/igou-kubernetes.git
+    gitops_ref: master
+    gitops_cluster: internal
+    kubeconfig_op_vault: claude
+    kubeconfig_op_item: rk8s-kubeconfig
+    connect_secret_namespace: external-secrets
+    connect_secret_name: onepassword-connect-token
+
+  tasks:
+    - name: Assert 1Password Connect env is present
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.env', 'OP_CONNECT_HOST') | length > 0
+          - lookup('ansible.builtin.env', 'OP_CONNECT_TOKEN') | length > 0
+        fail_msg: >-
+          OP_CONNECT_HOST/OP_CONNECT_TOKEN are not set. Attach the
+          "Onepassword Connect" credential (AAP) or export the env (local).
+
+    - name: Create workspace directory
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: -gitops-bootstrap
+      register: _ws
+
+    - name: Bootstrap from the cloned repo
+      block:
+        - name: Clone igou-kubernetes ({{ gitops_ref }})
+          ansible.builtin.git:
+            repo: "{{ gitops_repo }}"
+            dest: "{{ _ws.path }}/igou-kubernetes"
+            version: "{{ gitops_ref }}"
+            depth: 1
+
+        - name: Materialize kubeconfig from 1Password
+          ansible.builtin.copy:
+            content: "{{ lookup('community.general.onepassword', kubeconfig_op_item, field='kubeconfig', vault=kubeconfig_op_vault) | b64decode }}"
+            dest: "{{ _ws.path }}/kubeconfig"
+            mode: "0600"
+          no_log: true
+
+        - name: Install argocd (server-side apply)
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              kustomize build --enable-helm components/argocd | kubectl apply --server-side -f -
+            chdir: "{{ _ws.path }}/igou-kubernetes"
+            executable: /bin/bash
+          environment:
+            KUBECONFIG: "{{ _ws.path }}/kubeconfig"
+          register: _argocd_apply
+          changed_when: "' configured' in _argocd_apply.stdout or ' created' in _argocd_apply.stdout"
+
+        - name: Wait for argocd server rollout
+          ansible.builtin.command:
+            cmd: kubectl -n argocd rollout status deployment/argocd-server --timeout=300s
+          environment:
+            KUBECONFIG: "{{ _ws.path }}/kubeconfig"
+          changed_when: false
+
+        - name: Ensure the external-secrets namespace exists
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              kubectl create namespace {{ connect_secret_namespace }} --dry-run=client -o yaml | kubectl apply -f -
+            executable: /bin/bash
+          environment:
+            KUBECONFIG: "{{ _ws.path }}/kubeconfig"
+          register: _ns_apply
+          changed_when: "' created' in _ns_apply.stdout"
+
+        - name: Seed the 1Password Connect token secret
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              kubectl -n {{ connect_secret_namespace }} create secret generic {{ connect_secret_name }} \
+                --from-literal=token="$OP_CONNECT_TOKEN" --dry-run=client -o yaml \
+                | kubectl apply --server-side --force-conflicts -f -
+            executable: /bin/bash
+          environment:
+            KUBECONFIG: "{{ _ws.path }}/kubeconfig"
+          register: _seed_apply
+          changed_when: "' configured' in _seed_apply.stdout or ' created' in _seed_apply.stdout"
+          no_log: true
+
+        - name: Apply the cluster root ({{ gitops_cluster }})
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              kustomize build --enable-helm clusters/{{ gitops_cluster }} | kubectl apply -f -
+            chdir: "{{ _ws.path }}/igou-kubernetes"
+            executable: /bin/bash
+          environment:
+            KUBECONFIG: "{{ _ws.path }}/kubeconfig"
+          register: _root_apply
+          changed_when: "' configured' in _root_apply.stdout or ' created' in _root_apply.stdout"
+
+        - name: Report
+          ansible.builtin.debug:
+            msg: >-
+              Bootstrapped {{ gitops_cluster }} from {{ gitops_repo }}@{{ gitops_ref }};
+              argocd now self-manages the cluster.
+      always:
+        - name: Remove workspace directory
+          ansible.builtin.file:
+            path: "{{ _ws.path }}"
+            state: absent


### PR DESCRIPTION
## Summary
- New `playbooks/kubernetes/bootstrap-gitops.yaml` matching the refactored igou-kubernetes layout (`docs/bootstrap.md`): clone repo @ ref → install argocd (`kustomize build --enable-helm | kubectl apply --server-side`) → seed `external-secrets/onepassword-connect-token` from the AAP-injected `OP_CONNECT_*` env (backs the `onepassword` ClusterSecretStore) → apply `clusters/<cluster>` root → argocd self-manages.
- Kubeconfig resolves from `op://claude/<cluster>-kubeconfig` — the publish pipeline from #223/#224 — so no kubeconfig handling outside 1Password.
- Safe to merge now: defaults target `master`; the comment + README warn that Application CRs track `targetRevision: HEAD`, so bootstrapping waits for the igou-kubernetes refactor to merge.
- Legacy `bootstrap-cluster.yml` retained until the `kubernetes_bootstrap_gitops` AAP template repoints (igou-inventory follow-up).

## Testing
- `yamllint`, `ansible-lint --profile=production` (offline), syntax check: pass. Not executed against the cluster — blocked on the igou-kubernetes refactor merging (HEAD-tracking noted above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)