### PR TITLE
fix(kubernetes): apply cluster root into the argocd namespace

### DIFF
--- a/playbooks/kubernetes/bootstrap-gitops.yaml
+++ b/playbooks/kubernetes/bootstrap-gitops.yaml
@@ -114,7 +114,11 @@
           ansible.builtin.shell:
             cmd: |
               set -o pipefail
-              kustomize build --enable-helm clusters/{{ gitops_cluster }} | kubectl apply -f -
+              # -n argocd: the cluster root's Application/AppProject CRs carry
+              # no metadata.namespace (argo's own sync places them via the
+              # app-of-apps destination); without it they land in `default`
+              # where argocd never sees them.
+              kustomize build --enable-helm clusters/{{ gitops_cluster }} | kubectl apply -n argocd -f -
             chdir: "{{ _ws.path }}/igou-kubernetes"
             executable: /bin/bash
           environment:


### PR DESCRIPTION
Found on the first real rk8s bootstrap: the cluster root's Application/AppProject CRs carry no `metadata.namespace`, so `kubectl apply` placed all 11 Applications in `default`, where argocd never reconciles them. `-n argocd` fixes the bootstrap path; argo's own app-of-apps sync was never affected (destination.namespace). Cluster was remediated by hand (deleted strays, re-applied with -n argocd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)