### PR TITLE
fix(letsencrypt): drop become on EE-delegated tasks (no sudo in EE)

### DIFF
--- a/playbooks/linux/acme_certificate_podman_secret.yaml
+++ b/playbooks/linux/acme_certificate_podman_secret.yaml
@@ -69,6 +69,9 @@
       community.crypto.x509_certificate_info:
         content: "{{ _deployed.secrets[0].SecretData }}"
       delegate_to: localhost
+      # The play's become:true must not follow the delegation - parsing a cert
+      # needs no privilege and the EE has no sudo.
+      become: false
       vars:
         # The inventory's localhost host has no ansible_connection set (it
         # defaults to ssh, intentionally - armbian builds SSH back into it), so
@@ -294,6 +297,8 @@
         path: "{{ _keys_path }}"
         state: absent
       delegate_to: localhost
+      # Same as the expiry read above: no become on the EE side (no sudo there).
+      become: false
       vars:
         # See the cert-expiry task above: the inventory localhost defaults to
         # ssh, so force a local connection for this control-node cleanup rather


### PR DESCRIPTION
The cert-expiry read and scratch-key cleanup in `acme_certificate_podman_secret.yaml` delegate to localhost (the EE) while inheriting the play's `become: true`. The EE image has no sudo, so any run where the TLS secret already exists fails with `Premature end of stream waiting for become success` before the renewal decision. Bootstrap issuance skipped the expiry read, which is why this never surfaced until the first day-2 run (vps-converge-e2e node 3 / the new letsencrypt_renew_weekly path).

Both tasks need no privilege — parse a cert from memory, delete a /tmp scratch dir — so `become: false` is correct.

Verified: syntax-check + ansible-lint --profile=production pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)