### PR TITLE
fix(vps): hugo --noBuildLock for the read-only source mount

### DIFF
--- a/playbooks/linux/deploy_static_site.yaml
+++ b/playbooks/linux/deploy_static_site.yaml
@@ -78,6 +78,9 @@
           - "{{ _builder }}"
           - hugo
           - --minify
+          # The source mounts read-only, so hugo must not write its
+          # .hugo_build.lock there.
+          - --noBuildLock
           - --source
           - /src
           - --destination


### PR DESCRIPTION
First live run of `deploy_static_site.yaml` failed: hugo 0.163 writes `.hugo_build.lock` into the source tree, which mounts `:ro` by design. `--noBuildLock` skips the lock file — nothing else builds in that checkout — and keeps the source mount immutable. (The site repo's own `deploy/build.sh` podman fallback has the same latent issue.)

Verified: ansible-lint --profile=production passes; live re-run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)