### PR TITLE
fix(vps): mount the site source read-write for Hugo's resources cache

### DIFF
--- a/playbooks/linux/deploy_static_site.yaml
+++ b/playbooks/linux/deploy_static_site.yaml
@@ -62,9 +62,12 @@
       environment: "{{ _rootless_env }}"
       register: _checkout
 
-    # Same one-shot build deploy/build.sh in the site repo performs by hand:
-    # the repo mounts read-only, Hugo writes the minified site over the served
-    # dir (--cleanDestinationDir prunes files deleted from the source).
+    # Same one-shot build deploy/build.sh in the site repo performs by hand.
+    # The source mounts read-write: Hugo's image processing writes its
+    # resources/_gen cache into the project tree (so it persists between runs),
+    # and the git task's force:true keeps tracked files canonical anyway. Hugo
+    # writes the minified site over the served dir (--cleanDestinationDir
+    # prunes files deleted from the source).
     - name: Build the site with a one-shot Hugo container
       ansible.builtin.command:
         argv:
@@ -72,15 +75,12 @@
           - run
           - --rm
           - --volume
-          - "{{ _src }}:/src:ro,Z"
+          - "{{ _src }}:/src:Z"
           - --volume
           - "{{ _dest }}:/out:Z"
           - "{{ _builder }}"
           - hugo
           - --minify
-          # The source mounts read-only, so hugo must not write its
-          # .hugo_build.lock there.
-          - --noBuildLock
           - --source
           - /src
           - --destination


### PR DESCRIPTION
Second live-run failure of `deploy_static_site.yaml`: the site's homepage resizes splash images, and Hugo writes the processed-image cache to `resources/_gen` inside the project tree — impossible with the `:ro` source mount. Mounting rw fixes the build, persists the resize cache between runs, and the checkout stays canonical via the git task's `force: true`. `--noBuildLock` from #229 is no longer needed.

Note: the site repo's own `deploy/build.sh` podman fallback mounts `:ro` too and would hit the same wall — its host-hugo path is why this never surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)