### PR TITLE
feat(tailscale): inventory-driven tailnet joins (OAuth secret + tags)

### DIFF
--- a/docs/vps-lifecycle.md
+++ b/docs/vps-lifecycle.md
@@ -17,10 +17,13 @@ managed by hand.
 | Workload state (quadlets, secrets, nginx config) | `playbooks/linux/podman_quadlets.yaml` | `podman_quadlets` | on demand / after host_vars changes |
 | Workload images | `playbooks/linux/podman_auto_update.yaml` | `podman_auto_update` | on demand (deliberate image rolls, auto-rollback) |
 | Website content | `playbooks/linux/deploy_static_site.yaml` | `deploy_static_site` | nightly 20:00 via `deploy_static_site_nightly` (builds only on new commits) |
+| Metrics (node_exporter) | `playbooks/linux/node_exporter.yaml` | `node_exporter` | in the converge workflow (localhost-bound, scraped over Tailscale) |
+| Tailnet membership | `playbooks/tailscale/tailscale.yml` | `tailscale_join` | on demand (OAuth secret from 1Password; designated tags via `tailscale_tags` host var) |
 
 The `vps-converge-e2e` workflow chains baseline → packages → cert → quadlets →
-website in dependency order; every node is idempotent, so it is both the
-fresh-host rebuild runbook and a one-button drift fix.
+website in dependency order (node_exporter fans out after packages); every
+node is idempotent, so it is both the fresh-host rebuild runbook and a
+one-button drift fix.
 
 ## Website model
 

--- a/playbooks/tailscale/tailscale.yml
+++ b/playbooks/tailscale/tailscale.yml
@@ -1,20 +1,45 @@
 ---
-- name: Install tailscale
-  hosts: "{{ ansible_limit | default(none) }}"
+# Join a host to the tailnet via the artis3n.tailscale collection. The authkey
+# is a Tailscale OAuth client secret (tskey-client-...) read from 1Password on
+# the EE side (vault=awx, item=tailscale-oauthkey-ansible, field=client-secret)
+# so it never reaches the host. OAuth joins REQUIRE designated tags: set
+# tailscale_tags in the host's inventory vars (no tag: prefix - the role
+# prepends it) and declare each tag in the tailnet ACL with the ansible OAuth
+# client as an owner.
+#
+# Variables:
+#   Inventory inputs (per host/group, see host_vars/igou.io.yml):
+#     tailscale_tags - designated tags to advertise (REQUIRED with OAuth)
+#   Optional launch-time/inventory inputs:
+#     tailscale_state         - latest (default) | present | absent (leaves the
+#                               tailnet and uninstalls)
+#     tailscale_ephemeral     - register as an ephemeral node (default false:
+#                               these are long-lived hosts; the role's own
+#                               OAuth default would be true)
+#     tailscale_preauthorized - skip manual device approval (default true)
+- name: Join the tailnet
+  hosts: "{{ ansible_limit | default('none') }}"
   become: true
   gather_facts: true
+
   vars:
-    tailscale_state: latest
     tailscale_authkey: "{{ lookup('community.general.onepassword', 'tailscale-oauthkey-ansible', field='client-secret', vault='awx') }}"
-    tailscale_tags:
-      - "ansible"
+
   tasks:
+    - name: Ensure designated tags are set in inventory
+      ansible.builtin.assert:
+        that:
+          - tailscale_tags | default([]) | length > 0
+        fail_msg: >-
+          OAuth-based joins require designated tags; define tailscale_tags
+          for {{ inventory_hostname }} in inventory (no tag: prefix).
+      when: (tailscale_state | default('latest')) != 'absent'
+
     - name: Set up Tailscale
-      tags: tailscale
-      block:
-        - name: Set up Tailscale
-          ansible.builtin.include_role:
-            name: artis3n.tailscale.machine
-          vars:
-            verbose: true
-            state: "{{ tailscale_state }}"
+      ansible.builtin.include_role:
+        name: artis3n.tailscale.machine
+      vars:
+        verbose: true
+        state: "{{ tailscale_state | default('latest') }}"
+        tailscale_oauth_ephemeral: "{{ tailscale_ephemeral | default(false) }}"
+        tailscale_oauth_preauthorized: "{{ tailscale_preauthorized | default(true) }}"


### PR DESCRIPTION
Reworks the tailscale playbook for AAP-driven joins: designated tags come from the host's `tailscale_tags` inventory var (asserted early — OAuth-secret joins require tags; the role prepends `tag:`), nodes register permanent + preauthorized by default instead of the role's ephemeral OAuth default, and targeting matches the other day-2 playbooks (`ansible_limit`, default 'none'). Adds the lifecycle-doc rows for tailnet + metrics.

Companion PR: igou-io/igou-inventory (tailscale_join template + igou.io tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)