### PR TITLE
feat(hermes): guest convergence — hermes_agent role + install/configure playbooks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,3 +15,4 @@ exclude_paths:
   - roles/kubevirt_provision_survey/  # infra.controller_configuration.job_templates
   - roles/kubevirt_vm_snapshot/  # short interface + internal register/set_fact vars intentionally unprefixed for ergonomic CLI/extra_vars; lint logic via `ansible-lint -x var-naming`
   - roles/kubevirt_vm_provision/  # same: short vm_* interface + internal _kvp_* accumulators; lint logic via `ansible-lint -x var-naming`
+  - roles/hermes_agent/  # short interface + internal vars; lint logic via ansible-lint -x var-naming

--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -1,0 +1,9 @@
+---
+- name: Hermes guest convergence — configure phase (config + nftables + unit)
+  hosts: all
+  become: true
+  tasks:
+    - name: Run hermes_agent configure
+      ansible.builtin.import_role:
+        name: hermes_agent
+        tasks_from: configure

--- a/playbooks/hermes/install.yml
+++ b/playbooks/hermes/install.yml
@@ -1,0 +1,9 @@
+---
+- name: Hermes guest convergence — install phase (state disk + installer)
+  hosts: all
+  become: true
+  tasks:
+    - name: Run hermes_agent install
+      ansible.builtin.import_role:
+        name: hermes_agent
+        tasks_from: install

--- a/playbooks/hermes/templates/hermes-cloudinit.yaml.j2
+++ b/playbooks/hermes/templates/hermes-cloudinit.yaml.j2
@@ -1,6 +1,11 @@
 #cloud-config
 hostname: {{ vm_name }}
 ssh_pwauth: false
+# Create the admin/connection user the AAP convergence logs in as. This MUST
+# match the username on the AAP machine credential (op://awx/ansible-ssh-ed25519
+# -> 'igou'); otherwise the first baseline task fails SSH auth because only the
+# image's default cloud-user would carry the seeded key. Mirrors rhel-server-e2e.
+user: {{ vm_admin_user | default('igou') }}
 {% if vm_ssh_authorized_key | length > 0 %}
 ssh_authorized_keys:
   - {{ vm_ssh_authorized_key }}

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -1,0 +1,100 @@
+# hermes_agent
+
+The **Hermes-specific** half of a guest convergence for the Hermes Agent VM. It
+does only two things, split into two separately-invoked phases:
+
+1. **install** — format/mount the persistent state disk and run the Hermes
+   installer.
+2. **configure** — render the CLI config, an in-guest nftables egress backstop,
+   the read-only skills dir, and a hardened systemd user unit.
+
+Baseline OS hardening, the `igou`/`hermes` users, and OS package installation
+are **out of scope** for this role. They come from the reused `linux_baseline`
+and `install_packages` playbooks and run separately.
+
+## Two-phase model
+
+The phases are deliberate and ordered around the guest's egress window. There is
+no tag/`never` dispatch; each phase is a separate task file invoked with
+`import_role` + `tasks_from:`.
+
+| Phase       | Task file                | Network         | What it does                                                        |
+| ----------- | ------------------------ | --------------- | ------------------------------------------------------------------- |
+| `install`   | `tasks/install.yml`      | **egress open** | xfs-format `/dev/vdb`, mount at `~/.hermes` (fstab), chown, run installer |
+| `configure` | `tasks/configure.yml`    | **egress locked** | render `cli-config.yaml` + `.env`, load nftables backstop, install (not start) the systemd unit, persistent journald |
+
+Run order: `install` (during the egress window) → lock egress → `configure`.
+
+```bash
+ansible-playbook playbooks/hermes/install.yml   -i <inventory> -l hermes
+# ... lock egress (OVN EgressFirewall) ...
+ansible-playbook playbooks/hermes/configure.yml -i <inventory> -l hermes
+```
+
+## What the installer produces
+
+`curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`, run as the
+`hermes` user, lays down `~/.hermes` and symlinks the `hermes` CLI into
+`~/.local/bin/hermes` (this is the path the systemd unit's `ExecStart` and the
+installer's idempotency `creates:` guard both use). The run command is
+`hermes gateway run`.
+
+## Variable contract
+
+| Variable                     | Default                                                                  | Purpose                                                              |
+| ---------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| `hermes_user`                | `hermes`                                                                  | OS user that owns Hermes and runs the gateway.                      |
+| `hermes_home`                | `/home/hermes`                                                           | Home of `hermes_user`.                                              |
+| `hermes_state_device`        | `/dev/vdb`                                                               | Persistent state disk to format/mount.                             |
+| `hermes_state_mount`         | `{{ hermes_home }}/.hermes`                                              | Mount point + Hermes state dir.                                    |
+| `hermes_llm_base_url`        | `http://qwen35-2b.llmkube-system.svc.cluster.local:8080/v1`             | OpenAI-compatible LLM endpoint (`model.base_url`).                 |
+| `hermes_llm_model`           | `qwen35-2b`                                                              | Model name (`model.model`).                                        |
+| `hermes_llm_api_key`         | `sk-no-key`                                                             | API key placeholder; qwen35-2b accepts any/none.                  |
+| `hermes_cluster_service_cidr`| `172.30.0.0/16`                                                         | Service CIDR allowed on tcp/8080 in the nftables backstop.        |
+| `hermes_install_url`         | `https://hermes-agent.nousresearch.com/install.sh`                      | Installer URL.                                                     |
+
+## Rendered config (`~/.hermes/cli-config.yaml`)
+
+Minimal and verified against `cli-config.yaml.example` in the upstream repo:
+
+- `model.provider: custom`, `model.base_url`, `model.model` — custom
+  OpenAI-compatible endpoint.
+- `terminal.backend: local` — the exec backend (the example calls this section
+  `terminal:`; `backend: local` runs tools locally in the agent cwd).
+- `delegation.subagent_auto_approve: false` — subagents never auto-approve a
+  dangerous-command prompt (auto-deny). This is the manual-approval knob: Hermes
+  defaults to interactive human approval for dangerous commands, and this keeps
+  delegated subagents from bypassing it.
+
+Secrets live in `~/.hermes/.env` (mode `0600`): `OPENAI_API_KEY`,
+`OPENAI_BASE_URL`.
+
+## Security posture
+
+- **systemd unit** (`~/.config/systemd/user/hermes.service`): `NoNewPrivileges`,
+  `ProtectSystem=strict`, `ProtectHome=read-only` with `ReadWritePaths=%h/.hermes`,
+  `PrivateTmp`, `RestrictAddressFamilies`, `RestrictNamespaces`,
+  `SystemCallFilter=@system-service`, `LockPersonality`. Hermes has **no**
+  in-process containment of its own (see the upstream `SECURITY.md`), so the
+  unit provides the sandbox.
+- **nftables backstop** (`/etc/nftables.d/hermes-egress.nft`): default-drop
+  output allowing loopback, established/related, DNS, the LLM service CIDR on
+  8080, and external HTTPS. This is defense-in-depth only — the precise control
+  is the OVN-Kubernetes EgressFirewall (pins external reach to api.telegram.org).
+- **skills** dir is `0555` (read-only).
+- **journald** is set to persistent storage.
+
+## Go-live (messaging deferred)
+
+Telegram/messaging is intentionally deferred: no messaging config or secrets are
+rendered, and the systemd unit is **installed but not enabled or started**. To go
+live:
+
+1. Add the Telegram bot token + chat allowlist to `~/.hermes/.env` (and any
+   messaging block to `cli-config.yaml`).
+2. Enable + start the unit as the `hermes` user:
+   ```bash
+   systemctl --user enable --now hermes.service
+   ```
+   (Enable lingering — `loginctl enable-linger hermes` — so the user manager
+   runs without an active login.)

--- a/roles/hermes_agent/README.md
+++ b/roles/hermes_agent/README.md
@@ -6,11 +6,18 @@ does only two things, split into two separately-invoked phases:
 1. **install** — format/mount the persistent state disk and run the Hermes
    installer.
 2. **configure** — render the CLI config, an in-guest nftables egress backstop,
-   the read-only skills dir, and a hardened systemd user unit.
+   and a hardened systemd user unit.
 
 Baseline OS hardening, the `igou`/`hermes` users, and OS package installation
 are **out of scope** for this role. They come from the reused `linux_baseline`
 and `install_packages` playbooks and run separately.
+
+> **Prerequisite:** `group_vars/hermes` must list `hermes` as a baseline service
+> user so `linux_baseline` creates it and enables systemd **linger** for it.
+> Linger is what materializes `/run/user/<uid>` (and the per-user D-Bus socket),
+> which the rootless `systemctl --user` daemon-reload in the configure phase
+> needs. The role also defensively enables linger itself, so it is self-sufficient
+> if baseline ordering ever slips, but the user must still exist.
 
 ## Two-phase model
 
@@ -21,7 +28,7 @@ no tag/`never` dispatch; each phase is a separate task file invoked with
 | Phase       | Task file                | Network         | What it does                                                        |
 | ----------- | ------------------------ | --------------- | ------------------------------------------------------------------- |
 | `install`   | `tasks/install.yml`      | **egress open** | xfs-format `/dev/vdb`, mount at `~/.hermes` (fstab), chown, run installer |
-| `configure` | `tasks/configure.yml`    | **egress locked** | render `cli-config.yaml` + `.env`, load nftables backstop, install (not start) the systemd unit, persistent journald |
+| `configure` | `tasks/configure.yml`    | **egress locked** | render `cli-config.yaml` + `.env`, validate+load nftables backstop, install (not start) the systemd unit, persistent journald |
 
 Run order: `install` (during the egress window) → lock egress → `configure`.
 
@@ -81,7 +88,14 @@ Secrets live in `~/.hermes/.env` (mode `0600`): `OPENAI_API_KEY`,
   output allowing loopback, established/related, DNS, the LLM service CIDR on
   8080, and external HTTPS. This is defense-in-depth only — the precise control
   is the OVN-Kubernetes EgressFirewall (pins external reach to api.telegram.org).
-- **skills** dir is `0555` (read-only).
+  The ruleset is declare-then-delete at the top so each `nft -f` atomically
+  replaces the table (idempotent re-runs, no duplicate-rule accumulation), and is
+  dry-run validated (`nft -c -f`) before the live load.
+- **skills** dir (`~/.hermes/skills`) is owned by the installer and left
+  writable: Hermes's autonomous skill creation is a core feature, so it is **not**
+  clamped read-only. A `0555` chmod would break that learning loop and is not real
+  immutability anyway. **Proper immutable, Git-gated skills are deferred §5.5
+  work** — do not approximate it with chmod.
 - **journald** is set to persistent storage.
 
 ## Go-live (messaging deferred)
@@ -96,5 +110,5 @@ live:
    ```bash
    systemctl --user enable --now hermes.service
    ```
-   (Enable lingering — `loginctl enable-linger hermes` — so the user manager
-   runs without an active login.)
+   (Lingering is already enabled by the configure phase — and expected from
+   `linux_baseline` — so the user manager runs without an active login.)

--- a/roles/hermes_agent/defaults/main.yml
+++ b/roles/hermes_agent/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+hermes_user: hermes
+hermes_home: /home/hermes
+hermes_state_device: /dev/vdb
+hermes_state_mount: "{{ hermes_home }}/.hermes"
+# LLM (custom OpenAI-compatible endpoint)
+hermes_llm_base_url: "http://qwen35-2b.llmkube-system.svc.cluster.local:8080/v1"
+hermes_llm_model: "qwen35-2b"
+hermes_llm_api_key: "sk-no-key"   # qwen35-2b accepts any/none; placeholder
+# in-guest nftables coarse egress backstop (OVN EgressFirewall is the real control)
+hermes_cluster_service_cidr: "172.30.0.0/16"
+hermes_install_url: "https://hermes-agent.nousresearch.com/install.sh"

--- a/roles/hermes_agent/handlers/main.yml
+++ b/roles/hermes_agent/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart journald
+  ansible.builtin.systemd:
+    name: systemd-journald
+    state: restarted
+  become: true

--- a/roles/hermes_agent/meta/main.yml
+++ b/roles/hermes_agent/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: hermes_agent
+  author: david-igou
+  description: >-
+    Hermes-specific half of a guest convergence: format/mount the state disk
+    and run the Hermes Agent installer (install phase), then render the CLI
+    config, an in-guest nftables egress backstop, and a hardened systemd user
+    unit (configure phase). Baseline hardening, users, and OS packages come
+    from reused playbooks and are out of scope for this role.
+  license: MIT
+  min_ansible_version: "2.15"
+  galaxy_tags:
+    - hermes
+    - kubevirt
+dependencies: []

--- a/roles/hermes_agent/tasks/configure.yml
+++ b/roles/hermes_agent/tasks/configure.yml
@@ -1,8 +1,8 @@
 ---
 # Configure phase — runs with egress LOCKED (no network needed). Renders the
-# CLI config + secrets, the in-guest nftables egress backstop, the read-only
-# skills dir, and a hardened systemd USER unit. The unit is installed but NOT
-# enabled/started: messaging (Telegram) is deferred to go-live.
+# CLI config + secrets, the in-guest nftables egress backstop, and a hardened
+# systemd USER unit. The unit is installed but NOT enabled/started: messaging
+# (Telegram) is deferred to go-live.
 
 - name: Render the Hermes CLI config
   ansible.builtin.template:
@@ -51,11 +51,18 @@
     mode: "0644"
   become: true
 
-- name: Enable the nftables service for boot-time persistence
+- name: Enable and start the nftables service for boot-time persistence
   ansible.builtin.systemd:
     name: nftables
     enabled: true
+    state: started
   become: true
+
+- name: Validate the Hermes egress ruleset (dry-run) before loading
+  ansible.builtin.command:
+    cmd: nft -c -f /etc/nftables.d/hermes-egress.nft
+  become: true
+  changed_when: false
 
 - name: Load the Hermes egress ruleset now
   ansible.builtin.command:
@@ -64,14 +71,10 @@
   when: hermes_nft_ruleset is changed
   changed_when: true
 
-- name: Ensure the read-only skills directory exists
-  ansible.builtin.file:
-    path: "{{ hermes_state_mount }}/skills"
-    state: directory
-    owner: "{{ hermes_user }}"
-    group: "{{ hermes_user }}"
-    mode: "0555"
-  become: true
+# NOTE: ~/.hermes/skills is intentionally left to the installer. Do NOT chmod it
+# read-only — Hermes's autonomous skill creation is a core feature and a 0555
+# clamp would break it (and is not real immutability anyway). Proper immutable,
+# Git-gated skills are deferred §5.5 work; see the role README.
 
 - name: Ensure the hermes user systemd unit directory exists
   ansible.builtin.file:
@@ -91,14 +94,38 @@
     mode: "0644"
   become: true
 
+# The per-user systemd manager (and its /run/user/<uid> runtime dir + D-Bus
+# socket) only exists when the hermes user has linger enabled. linux_baseline is
+# expected to linger hermes as a baseline service user, but enable it here too so
+# this role is self-sufficient. (creates: guard keeps it idempotent.)
+- name: Ensure the hermes user has systemd linger enabled
+  ansible.builtin.command:
+    cmd: "loginctl enable-linger {{ hermes_user }}"
+  args:
+    creates: "/var/lib/systemd/linger/{{ hermes_user }}"
+  become: true
+
+# Resolve the hermes uid so the --user systemctl call below can reach that user's
+# systemd bus via XDG_RUNTIME_DIR (mirrors the rootless idiom in
+# igou-ansible/playbooks/linux/podman_quadlets.yaml).
+- name: Resolve the hermes uid (for the per-user systemd runtime dir)
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ hermes_user }}"
+  become: true
+
 # Reload the per-user systemd manager so the new unit is visible. The unit is
 # deliberately NOT enabled or started — messaging is deferred to go-live.
+# XDG_RUNTIME_DIR is required or `systemctl --user` can't find the bus
+# ("Failed to connect to bus").
 - name: Reload the hermes user systemd manager
   ansible.builtin.systemd:
     daemon_reload: true
     scope: user
   become: true
   become_user: "{{ hermes_user }}"
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ getent_passwd[hermes_user][1] }}"
 
 - name: Make journald storage persistent
   ansible.builtin.lineinfile:

--- a/roles/hermes_agent/tasks/configure.yml
+++ b/roles/hermes_agent/tasks/configure.yml
@@ -1,0 +1,112 @@
+---
+# Configure phase — runs with egress LOCKED (no network needed). Renders the
+# CLI config + secrets, the in-guest nftables egress backstop, the read-only
+# skills dir, and a hardened systemd USER unit. The unit is installed but NOT
+# enabled/started: messaging (Telegram) is deferred to go-live.
+
+- name: Render the Hermes CLI config
+  ansible.builtin.template:
+    src: cli-config.yaml.j2
+    dest: "{{ hermes_state_mount }}/cli-config.yaml"
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_user }}"
+    mode: "0644"
+  become: true
+
+- name: Render the Hermes environment file
+  ansible.builtin.template:
+    src: hermes.env.j2
+    dest: "{{ hermes_state_mount }}/.env"
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_user }}"
+    mode: "0600"
+  become: true
+
+- name: Ensure the nftables drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/nftables.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  become: true
+
+- name: Render the Hermes egress nftables ruleset
+  ansible.builtin.template:
+    src: hermes-egress.nft.j2
+    dest: /etc/nftables.d/hermes-egress.nft
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  register: hermes_nft_ruleset
+
+- name: Ensure /etc/sysconfig/nftables.conf includes the drop-in
+  ansible.builtin.lineinfile:
+    path: /etc/sysconfig/nftables.conf
+    line: 'include "/etc/nftables.d/hermes-egress.nft"'
+    create: true
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+
+- name: Enable the nftables service for boot-time persistence
+  ansible.builtin.systemd:
+    name: nftables
+    enabled: true
+  become: true
+
+- name: Load the Hermes egress ruleset now
+  ansible.builtin.command:
+    cmd: nft -f /etc/nftables.d/hermes-egress.nft
+  become: true
+  when: hermes_nft_ruleset is changed
+  changed_when: true
+
+- name: Ensure the read-only skills directory exists
+  ansible.builtin.file:
+    path: "{{ hermes_state_mount }}/skills"
+    state: directory
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_user }}"
+    mode: "0555"
+  become: true
+
+- name: Ensure the hermes user systemd unit directory exists
+  ansible.builtin.file:
+    path: "{{ hermes_home }}/.config/systemd/user"
+    state: directory
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_user }}"
+    mode: "0755"
+  become: true
+
+- name: Render the hardened Hermes systemd user unit
+  ansible.builtin.template:
+    src: hermes.service.j2
+    dest: "{{ hermes_home }}/.config/systemd/user/hermes.service"
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_user }}"
+    mode: "0644"
+  become: true
+
+# Reload the per-user systemd manager so the new unit is visible. The unit is
+# deliberately NOT enabled or started — messaging is deferred to go-live.
+- name: Reload the hermes user systemd manager
+  ansible.builtin.systemd:
+    daemon_reload: true
+    scope: user
+  become: true
+  become_user: "{{ hermes_user }}"
+
+- name: Make journald storage persistent
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/journald.conf
+    regexp: '^#?\s*Storage='
+    line: Storage=persistent
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  notify: Restart journald

--- a/roles/hermes_agent/tasks/install.yml
+++ b/roles/hermes_agent/tasks/install.yml
@@ -1,0 +1,46 @@
+---
+# Install phase — runs DURING the egress window (installer needs the network).
+# Formats/mounts the persistent state disk, chowns it to the hermes user, then
+# runs the Hermes Agent installer as that user. Idempotent throughout.
+
+- name: Create xfs filesystem on the Hermes state device
+  community.general.filesystem:
+    fstype: xfs
+    dev: "{{ hermes_state_device }}"
+    force: false   # format only when the device is unformatted
+  become: true
+
+- name: Mount the Hermes state device and persist it in fstab
+  ansible.posix.mount:
+    path: "{{ hermes_state_mount }}"
+    src: "{{ hermes_state_device }}"
+    fstype: xfs
+    opts: defaults
+    state: mounted
+  become: true
+
+- name: Own the Hermes state mount to the hermes user
+  ansible.builtin.file:
+    path: "{{ hermes_state_mount }}"
+    state: directory
+    owner: "{{ hermes_user }}"
+    group: "{{ hermes_user }}"
+    recurse: true
+  become: true
+
+- name: Install Hermes Agent as the hermes user
+  ansible.builtin.shell:
+    cmd: "set -o pipefail && curl -fsSL {{ hermes_install_url }} | bash"
+    creates: "{{ hermes_home }}/.local/bin/hermes"
+    executable: /bin/bash
+  become: true
+  become_user: "{{ hermes_user }}"
+  changed_when: true   # only runs when 'creates' target is absent
+
+- name: Confirm the Hermes CLI and capture its version
+  ansible.builtin.command:
+    cmd: "{{ hermes_home }}/.local/bin/hermes --version"
+  become: true
+  become_user: "{{ hermes_user }}"
+  register: hermes_version
+  changed_when: false

--- a/roles/hermes_agent/tasks/install.yml
+++ b/roles/hermes_agent/tasks/install.yml
@@ -35,6 +35,9 @@
     executable: /bin/bash
   become: true
   become_user: "{{ hermes_user }}"
+  # hermes is a service user that may have a nologin shell; -i forces a login
+  # shell so the install script gets a sane $HOME/$PATH environment.
+  become_flags: '-i'
   changed_when: true   # only runs when 'creates' target is absent
 
 - name: Confirm the Hermes CLI and capture its version
@@ -42,5 +45,6 @@
     cmd: "{{ hermes_home }}/.local/bin/hermes --version"
   become: true
   become_user: "{{ hermes_user }}"
+  become_flags: '-i'
   register: hermes_version
   changed_when: false

--- a/roles/hermes_agent/templates/cli-config.yaml.j2
+++ b/roles/hermes_agent/templates/cli-config.yaml.j2
@@ -1,0 +1,16 @@
+{{ ansible_managed | comment }}
+# Hermes Agent CLI config — rendered by the hermes_agent role.
+# Keys verified against cli-config.yaml.example (NousResearch/hermes-agent).
+model:
+  provider: custom
+  base_url: "{{ hermes_llm_base_url }}"
+  model: "{{ hermes_llm_model }}"
+
+# Terminal tool backend: local execution in the agent's working directory.
+terminal:
+  backend: local
+  cwd: "."
+
+# Subagent delegation: never auto-approve dangerous-command prompts (auto-deny).
+delegation:
+  subagent_auto_approve: false

--- a/roles/hermes_agent/templates/hermes-egress.nft.j2
+++ b/roles/hermes_agent/templates/hermes-egress.nft.j2
@@ -1,0 +1,24 @@
+{{ ansible_managed | comment }}
+# Coarse in-guest egress backstop (defense-in-depth). The PRECISE control is the
+# OVN-Kubernetes EgressFirewall on the VM's masquerade network, which restricts
+# external reach to api.telegram.org. This ruleset is only a guest-side backstop:
+# default-drop output, allowing loopback, established/related, DNS, the in-cluster
+# LLM service CIDR on 8080, and external HTTPS (443).
+table inet hermes_egress {
+  chain output {
+    type filter hook output priority 0; policy drop;
+
+    oif "lo" accept
+    ct state established,related accept
+
+    # DNS resolution
+    udp dport 53 accept
+    tcp dport 53 accept
+
+    # In-cluster LLM (qwen35-2b OpenAI-compatible endpoint)
+    ip daddr {{ hermes_cluster_service_cidr }} tcp dport 8080 accept
+
+    # External HTTPS (OVN EgressFirewall already pins this to api.telegram.org)
+    tcp dport 443 accept
+  }
+}

--- a/roles/hermes_agent/templates/hermes-egress.nft.j2
+++ b/roles/hermes_agent/templates/hermes-egress.nft.j2
@@ -4,6 +4,13 @@
 # external reach to api.telegram.org. This ruleset is only a guest-side backstop:
 # default-drop output, allowing loopback, established/related, DNS, the in-cluster
 # LLM service CIDR on 8080, and external HTTPS (443).
+#
+# Declare-then-delete makes each `nft -f` of this file fully replace the table
+# atomically: the table is ensured to exist (so the delete can't error on a fresh
+# load) and then removed, so re-runs don't accumulate duplicate rules.
+table inet hermes_egress
+delete table inet hermes_egress
+
 table inet hermes_egress {
   chain output {
     type filter hook output priority 0; policy drop;

--- a/roles/hermes_agent/templates/hermes.env.j2
+++ b/roles/hermes_agent/templates/hermes.env.j2
@@ -1,0 +1,3 @@
+{{ ansible_managed | comment }}
+OPENAI_API_KEY={{ hermes_llm_api_key }}
+OPENAI_BASE_URL={{ hermes_llm_base_url }}

--- a/roles/hermes_agent/templates/hermes.service.j2
+++ b/roles/hermes_agent/templates/hermes.service.j2
@@ -1,0 +1,23 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Hermes Agent gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/hermes gateway run
+Restart=on-failure
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=%h/.hermes
+PrivateTmp=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+LockPersonality=true
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Phase-2b: the Hermes-specifics-only `hermes_agent` role (state disk + installer; cli-config + .env + nftables + hardened systemd unit) + the two-phase `playbooks/hermes/{install,configure}.yml`. Baseline hardening + the rootless `hermes` user + deps come from the REUSED `linux_baseline` + `install_packages` playbooks. Telegram deferred → ends installed/configured/contained, unit stopped. LLM = in-cluster qwen35-2b. Reviewed: XDG_RUNTIME_DIR + linger for the rootless unit, nft idempotency, dropped a skills-chmod that would've broken Hermes's learning loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)