### PR TITLE
feat(hermes): managed dashboard systemd unit + point at qwen3-35b-a3b backend

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -2,8 +2,10 @@
 - name: Hermes guest convergence — configure phase (config + nftables + unit)
   # Hermes guest convergence — CONFIGURE phase. Runs with egress LOCKED (needs no
   # network). Renders the CLI config + secrets (~/.hermes/config.yaml + .env), the
-  # in-guest nftables egress backstop, persistent journald, and a hardened systemd
-  # USER unit — installed but NOT enabled/started (messaging is deferred to go-live).
+  # in-guest nftables egress backstop, persistent journald, and two hardened systemd
+  # USER units: the agent gateway (hermes.service, installed but NOT started — going
+  # live is deferred) and the dashboard web UI (hermes-dashboard.service, started
+  # when dashboard auth is configured, so it survives reboot/reprovision).
   # Run order: install (egress open) → lock egress → configure.
   # (Formerly the hermes_agent role's tasks/configure.yml, inlined here.)
   #
@@ -31,6 +33,13 @@
     hermes_dashboard_auth_password_hash: ""
     hermes_dashboard_auth_secret: ""
     hermes_dashboard_files_root: "{{ hermes_state_mount }}/dashboard-files"
+    # The dashboard web UI runs as a managed systemd --user unit
+    # (hermes-dashboard.service) so it survives reboot/reprovision and self-restarts
+    # — replacing the prior out-of-band `nohup hermes dashboard`, which a rebuild
+    # silently wiped. It binds non-loopback behind the BasicAuthProvider and is only
+    # enabled when an auth username is set (fail closed — see the start task below).
+    hermes_dashboard_host: "0.0.0.0"
+    hermes_dashboard_port: 9119
   tasks:
     # Hermes loads ~/.hermes/config.yaml (what `hermes config path` returns) — NOT
     # cli-config.yaml. Rendering to the wrong name meant the whole config (model,
@@ -148,6 +157,15 @@
         mode: "0644"
       become: true
 
+    - name: Render the hardened Hermes dashboard systemd user unit
+      ansible.builtin.template:
+        src: hermes-dashboard.service.j2
+        dest: "{{ hermes_home }}/.config/systemd/user/hermes-dashboard.service"
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "0644"
+      become: true
+
     # The per-user systemd manager (and its /run/user/<uid> runtime dir + D-Bus
     # socket) only exists when the hermes user has linger enabled. linux_baseline is
     # expected to linger hermes as a baseline service user, but enable it here too so
@@ -168,8 +186,9 @@
         key: "{{ hermes_user }}"
       become: true
 
-    # Reload the per-user systemd manager so the new unit is visible. The unit is
-    # deliberately NOT enabled or started — messaging is deferred to go-live.
+    # Reload the per-user systemd manager so the new units are visible. The agent
+    # gateway unit (hermes.service) is deliberately NOT enabled or started — going
+    # live with messaging is deferred. The dashboard unit IS started below.
     # XDG_RUNTIME_DIR is required or `systemctl --user` can't find the bus
     # ("Failed to connect to bus").
     - name: Reload the hermes user systemd manager
@@ -180,6 +199,24 @@
       become_user: "{{ hermes_user }}"
       environment:
         XDG_RUNTIME_DIR: "/run/user/{{ getent_passwd[hermes_user][1] }}"
+
+    # Unlike the agent gateway unit, the dashboard unit IS enabled + started — it is
+    # the managed replacement for the old out-of-band nohup, so it must come up on
+    # its own after a reboot/reprovision. Guard on the auth username: with --host
+    # 0.0.0.0 and no --insecure, Hermes refuses to bind unless the BasicAuthProvider
+    # is registered, so starting it without creds would crash-loop. No username =
+    # the dashboard stays down (fail closed) — pass the auth extra-vars to activate.
+    - name: Enable and start the Hermes dashboard user unit
+      ansible.builtin.systemd:
+        name: hermes-dashboard.service
+        enabled: true
+        state: started
+        scope: user
+      become: true
+      become_user: "{{ hermes_user }}"
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ getent_passwd[hermes_user][1] }}"
+      when: hermes_dashboard_auth_username | length > 0
 
     - name: Ensure the journald drop-in directory exists
       ansible.builtin.file:

--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -17,10 +17,12 @@
     hermes_user: hermes
     hermes_home: /home/hermes
     hermes_state_mount: "{{ hermes_home }}/.hermes"
-    # LLM (custom OpenAI-compatible endpoint)
-    hermes_llm_base_url: "http://qwen35-2b.llmkube-system.svc.cluster.local:8080/v1"
-    hermes_llm_model: "qwen35-2b"
-    hermes_llm_api_key: "sk-no-key"   # qwen35-2b accepts any/none; placeholder
+    # LLM (custom OpenAI-compatible endpoint). Primary backend is the larger
+    # in-cluster reasoning model qwen3-35b-a3b (Qwen3.6-35B-A3B, ~70 tok/s on the
+    # 2x RTX 4060 Ti burst node); qwen35-2b remains available as a smaller fallback.
+    hermes_llm_base_url: "http://qwen3-35b-a3b.llmkube-system.svc.cluster.local:8080/v1"
+    hermes_llm_model: "qwen3-35b-a3b"
+    hermes_llm_api_key: "sk-no-key"   # llama.cpp server accepts any/none; placeholder
     # In-guest nftables coarse egress backstop CIDR (OVN EgressFirewall is the real
     # control); allowed on tcp/8080 for the in-cluster LLM service.
     hermes_cluster_service_cidr: "172.30.0.0/16"

--- a/playbooks/hermes/templates/hermes-dashboard.service.j2
+++ b/playbooks/hermes/templates/hermes-dashboard.service.j2
@@ -1,0 +1,29 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Hermes Agent dashboard (web UI)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Serve the prebuilt UI dist (built during the install phase) with --skip-build so
+# the unit never reruns tsc+vite at start. Bind non-loopback WITHOUT --insecure so
+# the native scrypt BasicAuthProvider gate (HERMES_DASHBOARD_BASIC_AUTH_* in
+# ~/.hermes/.env) is enforced — Hermes refuses to bind a public host unless an auth
+# provider is registered, which is why this unit is only enabled when auth is set.
+ExecStart=%h/.local/bin/hermes dashboard --host {{ hermes_dashboard_host }} --port {{ hermes_dashboard_port }} --skip-build --no-open
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=%h/.hermes
+PrivateTmp=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+LockPersonality=true
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Why
The Hermes dashboard web UI was only ever started by hand as `nohup hermes dashboard ...` — outside any supervisor or the convergence playbook. A VM reprovision (and any reboot) silently killed it and nothing relaunched it, so the `hermes-dashboard` Service lost its backend and the Route returned **503**. This is the "make the dashboard persistent" item in #240, and it bit us live.

## What
- New **`templates/hermes-dashboard.service.j2`** — a hardened systemd **`--user`** unit (mirrors `hermes.service` hardening: `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome=read-only` + `ReadWritePaths=%h/.hermes`, `SystemCallFilter=@system-service`, …). Serves with `--skip-build` (the UI dist is built during the install phase) and binds non-loopback **without `--insecure`** so the native scrypt `BasicAuthProvider` gate is enforced. `Restart=on-failure`.
- **`configure.yml`** renders the unit and **enables + starts** it, guarded on `hermes_dashboard_auth_username`: with `--host 0.0.0.0` and no `--insecure`, Hermes refuses to bind unless an auth provider is registered, so **no creds → the dashboard stays down (fail closed)** rather than crash-looping. Pass the auth extra-vars to activate.
- The agent gateway unit (`hermes.service`) is **unchanged** — installed but not started (go-live deferred).

## Validation (live VM, placeholder auth via extra-vars)
- `yamllint` clean; `ansible-lint --profile=production` clean on `configure.yml`; `--syntax-check` passes.
- `configure.yml` converges clean: `ok=19 changed=3 failed=0`.
- Dashboard comes up **enabled + active** behind the gate; Route returns `302` (→login) / `401` (unauth API) / `200` (login + authed API).
- **Crash self-heal:** `SIGKILL` the process → systemd restarts it (~2s, `Restart=on-failure`).
- **Reboot self-heal:** full VM reboot → dashboard auto-starts within ~2s, no manual action (`enabled` + linger). This is the exact event class that killed the old nohup.

## Deferred (not in this PR)
- **1Password wiring** for the dashboard scrypt hash + session secret — per request, this PR uses **placeholder secrets passed as extra-vars** for testing. Production should source them from 1Password / vault (devcontainer `op` is Connect/read-only and can't create items).
- Go-live items remain tracked in #240: re-lock egress, scope the dashboard NetworkPolicy, enable `hermes.service`, tear down temp debug aids.

Refs #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)