### PR TITLE
refactor(hermes): render config.yaml from a dict + opt-out toggle

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -42,12 +42,61 @@
     # enabled when an auth username is set (fail closed — see the start task below).
     hermes_dashboard_host: "0.0.0.0"
     hermes_dashboard_port: 9119
+    # Toggle whether the playbook (re-)renders `~/.hermes/config.yaml` on every
+    # converge. The Hermes dashboard PERSISTS UI changes (model picker, skills
+    # toggles, MCP servers, memory provider, theme, etc.) to that file via the
+    # server's `save_config(cfg)`; re-rendering silently reverts every such UI
+    # edit. Flip to `false` to preserve UI state (the playbook stops enforcing
+    # the pinned model + hardening); leave `true` for code-as-truth.
+    hermes_render_config_yaml: true
+    # The full Hermes CLI config, serialized by the render task with `to_nice_yaml`
+    # — comments below explain the WHY but are not preserved in the rendered file.
+    hermes_config:
+      # Hermes loads `~/.hermes/config.yaml` (what `hermes config path` returns);
+      # `provider: custom` points at an in-cluster OpenAI-compatible endpoint.
+      model:
+        provider: custom
+        base_url: "{{ hermes_llm_base_url }}"
+        model: "{{ hermes_llm_model }}"
+      # Terminal tool backend: local execution in the agent's working directory.
+      terminal:
+        backend: local
+        cwd: "."
+      # Subagent delegation: never auto-approve dangerous-command prompts.
+      delegation:
+        subagent_auto_approve: false
+      # === Native safety hardening ===
+      # Pin Hermes's own controls as code so they survive re-converge rather than
+      # relying on upstream defaults. (Defense-in-depth lives at the OpenShift/OS
+      # layer; this is the app-layer first line.)
+      # Human-in-the-loop: every tool/command runs through a manual approval gate;
+      # cron jobs can never self-approve.
+      approvals:
+        mode: manual
+        cron_mode: deny
+      # Stop runaway tool loops (repeated failures / no forward progress) instead
+      # of only warning — caps a wedged or hostile agent.
+      tool_loop_guardrails:
+        hard_stop_enabled: true
+      # The agent writes and runs its own "skills" (persisted code that survives
+      # restarts). Require approval before one is written so a poisoned
+      # self-authored skill can't silently persist.
+      skills:
+        write_approval: true
+      # Treat the persistent memory store as attacker-influenceable; gate writes.
+      memory:
+        write_approval: true
+      # Pre-exec command scanning (tirith). `fail_open: false` = fail CLOSED: a
+      # command is blocked if tirith flags it OR is unavailable.
+      security:
+        tirith_enabled: true
+        tirith_fail_open: false
   tasks:
-    # Hermes loads ~/.hermes/config.yaml (what `hermes config path` returns) — NOT
-    # cli-config.yaml. Rendering to the wrong name meant the whole config (model,
-    # terminal, delegation, hardening) was silently ignored and the agent ran on
-    # stock defaults (a hosted openrouter model). Render to config.yaml, 0600.
-    - name: Render the Hermes config
+    # Hermes loads `~/.hermes/config.yaml` (what `hermes config path` returns) —
+    # NOT cli-config.yaml. The dashboard also writes this file via `save_config`
+    # (the UI model picker, skills/MCP toggles, etc.), so re-rendering here would
+    # overwrite those edits — gated on `hermes_render_config_yaml` to opt out.
+    - name: Render the Hermes config (whole-file render of hermes_config dict)
       ansible.builtin.template:
         src: cli-config.yaml.j2
         dest: "{{ hermes_state_mount }}/config.yaml"
@@ -55,6 +104,7 @@
         group: "{{ hermes_user }}"
         mode: "0600"
       become: true
+      when: hermes_render_config_yaml | bool
 
     - name: Remove the stale, never-loaded cli-config.yaml
       ansible.builtin.file:

--- a/playbooks/hermes/templates/cli-config.yaml.j2
+++ b/playbooks/hermes/templates/cli-config.yaml.j2
@@ -1,52 +1,5 @@
 {{ ansible_managed | comment }}
-# Hermes Agent CLI config — rendered by the Hermes configure playbook.
-# Keys verified against cli-config.yaml.example (NousResearch/hermes-agent).
-model:
-  provider: custom
-  base_url: "{{ hermes_llm_base_url }}"
-  model: "{{ hermes_llm_model }}"
-
-# Terminal tool backend: local execution in the agent's working directory.
-terminal:
-  backend: local
-  cwd: "."
-
-# Subagent delegation: never auto-approve dangerous-command prompts (auto-deny).
-delegation:
-  subagent_auto_approve: false
-
-# === Native safety hardening ===
-# These pin Hermes's own controls as code so they survive re-converge and are
-# explicit rather than relying on upstream defaults. (Defense-in-depth lives at
-# the OpenShift/OS layer; this is the app-layer first line.)
-
-# Human-in-the-loop. Every tool/command runs through a manual approval gate;
-# cron jobs can never self-approve.
-approvals:
-  mode: manual
-  cron_mode: deny
-
-# Stop runaway tool loops (repeated failures / no forward progress) instead of
-# only warning — caps a wedged or hostile agent.
-tool_loop_guardrails:
-  hard_stop_enabled: true
-
-# The agent writes and runs its own "skills" (persisted code that survives
-# restarts). Require approval before one is written, so a poisoned self-authored
-# skill can't silently persist.
-skills:
-  write_approval: true
-
-# Treat the persistent memory store as attacker-influenceable; gate writes to it.
-memory:
-  write_approval: true
-
-# Pre-exec command scanning (homograph URLs, pipe-to-shell/curl|bash, terminal
-# injection, env manipulation — MITRE T1059.x). The tirith binary is installed
-# during the install phase (egress window). fail_open:false = fail CLOSED: a
-# command is blocked if tirith flags it OR is unavailable. (tirith targets
-# network/supply-chain patterns, not destructive local cmds — the manual
-# approval gate above covers those; the two are complementary.)
-security:
-  tirith_enabled: true
-  tirith_fail_open: false
+# Hermes Agent CLI config — rendered from the configure playbook's hermes_config
+# dict. Comments live in that source dict; they are NOT preserved here (the
+# dashboard would clobber them on the first UI save anyway).
+{{ hermes_config | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
## Why
The Hermes dashboard **persists UI changes** (model picker, skills/MCP toggles, memory provider, themes, agent-plugins, raw YAML editor, …) to `~/.hermes/config.yaml` via the server's `save_config(cfg)`. With the playbook re-rendering the file on every converge, every such UI edit gets silently reverted.

## What

1. **Toggle: `hermes_render_config_yaml` (default `true`).** When `false`, the render task is skipped — UI-driven changes survive a converge, at the cost of the playbook no longer enforcing the pinned model + hardening. Code-as-truth stays the default.
2. **Dict-rendered template.** Move the body from literal YAML in `cli-config.yaml.j2` to a `hermes_config:` dict in the play vars; render via `to_nice_yaml(indent=2)`. It's YAML either way, and a dict is easier to extend/override (e.g. `fallback_model` entries, `custom_providers`, `auxiliary` models). Explanatory comments live next to the dict; they're **not** preserved in the rendered file (the dashboard would clobber them on the first UI save anyway).

## Validation
- `yamllint`: clean
- `ansible-lint --profile=production`: **Passed — 0 failures, 0 warnings**
- `ansible-playbook --syntax-check`: clean
- **Render comparison:** `yaml.safe_load` of the new dict-rendered output equals `yaml.safe_load` of the current live `config.yaml` (semantically identical — only quote style and trailing-comment differences, which Hermes treats as equivalent).