### PR TITLE
feat(hermes): restart dashboard on config change + chronyd + render opt-out debug

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -96,6 +96,15 @@
     # NOT cli-config.yaml. The dashboard also writes this file via `save_config`
     # (the UI model picker, skills/MCP toggles, etc.), so re-rendering here would
     # overwrite those edits — gated on `hermes_render_config_yaml` to opt out.
+    - name: Surface that config.yaml render is opted out (UI changes will persist)
+      ansible.builtin.debug:
+        msg: >-
+          hermes_render_config_yaml is false — keeping the on-disk
+          ~/.hermes/config.yaml so dashboard UI edits (model picker, skills/MCP
+          toggles, …) persist. The playbook's pinned model + hardening are NOT
+          enforced this run.
+      when: not (hermes_render_config_yaml | bool)
+
     - name: Render the Hermes config (whole-file render of hermes_config dict)
       ansible.builtin.template:
         src: cli-config.yaml.j2
@@ -105,6 +114,7 @@
         mode: "0600"
       become: true
       when: hermes_render_config_yaml | bool
+      notify: Restart the Hermes dashboard user unit
 
     - name: Remove the stale, never-loaded cli-config.yaml
       ansible.builtin.file:
@@ -120,6 +130,7 @@
         group: "{{ hermes_user }}"
         mode: "0600"
       become: true
+      notify: Restart the Hermes dashboard user unit
 
     # Confined root for the dashboard file browser (HERMES_DASHBOARD_FILES_ROOT) —
     # locks /api/files to this dir instead of allowing arbitrary host file read.
@@ -298,3 +309,21 @@
         name: systemd-journald
         state: restarted
       become: true
+
+    # Pick up the new config.yaml / .env in the running dashboard. The unit's
+    # `state: started` task is idempotent and does NOT restart on its own, so a
+    # rendered change (e.g. model swap, basic-auth rotation) otherwise sits on
+    # disk until something restarts the unit. Gated on the same auth username
+    # that gates the unit's start: no auth = no running dashboard = nothing to
+    # restart. (Empty username also means the render-task notifies a no-op
+    # handler, which is fine.)
+    - name: Restart the Hermes dashboard user unit
+      ansible.builtin.systemd:
+        name: hermes-dashboard.service
+        state: restarted
+        scope: user
+      become: true
+      become_user: "{{ hermes_user }}"
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ getent_passwd[hermes_user][1] }}"
+      when: hermes_dashboard_auth_username | length > 0

--- a/playbooks/hermes/install.yml
+++ b/playbooks/hermes/install.yml
@@ -57,12 +57,26 @@
     #     (setfacl); without it, the broken NFSv4 `chmod A+user:...` fallback fails.
     #   - nftables: the centos-stream10 cloud image ships neither the nft binary nor
     #     nftables.service, which configure.yml enables for the egress ruleset.
-    - name: Install host packages the convergence needs (acl, nftables)
+    #   - chrony: the centos-stream10 cloud image SHIPS it active by default, but
+    #     ensure-present is cheap insurance — a wrong VM clock breaks TLS validation
+    #     against the OpenShift router/api.telegram.org and skews journald correlation
+    #     (observed pre-rebuild: VM clock ran ~24h behind real time).
+    - name: Install host packages the convergence needs (acl, nftables, chrony)
       ansible.builtin.package:
         name:
           - acl
           - nftables
+          - chrony
         state: present
+      become: true
+
+    # Make chrony explicit even though the cloud image enables it — if a future
+    # image variant drops the default, we still get a syncing clock.
+    - name: Ensure chronyd is enabled and running (clock sync)
+      ansible.builtin.systemd:
+        name: chronyd
+        enabled: true
+        state: started
       become: true
 
     # baseline creates hermes as a service user with /sbin/nologin, but the installer


### PR DESCRIPTION
Three small but real gaps from the post-rollout punch-list.

### A1 — Dashboard restart on config / .env change
`configure.yml`'s "start dashboard unit" is `state: started` (idempotent — does **not** restart a running unit). A rendered model swap or basic-auth rotation otherwise sits on disk until something restarts the dashboard. (We hit this during the 35b rollout — I had to `systemctl --user restart hermes-dashboard.service` by hand to pick up the new model.)

Add a `Restart the Hermes dashboard user unit` handler, notified by both the `Render the Hermes config` and `Render the Hermes environment file` tasks. Gated on `hermes_dashboard_auth_username` (same gate as the unit's enable+start): empty auth = no running dashboard = nothing to restart.

### A4 — Ensure chronyd
The centos-stream10 cloud image ships `chrony` active by default, but a wrong VM clock breaks TLS validation against the router / `api.telegram.org` and skews journald correlation. Add `chrony` to the install-phase package list and an explicit `enabled + started` task — defense-in-depth.

### A5 — Surface the render opt-out
When `hermes_render_config_yaml: false`, emit an `ansible.builtin.debug` message so the operator sees in job output that the playbook isn't enforcing the pinned model + hardening this run (instead of silently skipping the task).

### Validation
- `yamllint`: clean
- `ansible-playbook --syntax-check`: clean (both playbooks)
- `ansible-lint --profile=production`: clean for these changes (the offline-mode `community.general.filesystem` resolution miss on `install.yml:28` is a pre-existing unchanged task; CI resolves it)

Refs the post-rollout punch-list (A1/A4/A5). A2 (1Password) and A3 (`igou-inventory` AAP config-as-code) are separate.