### PR TITLE
fix(hermes): resolve dashboard auth via set_fact (group_vars Jinja2 lookups silent-empty)

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -92,6 +92,23 @@
         tirith_enabled: true
         tirith_fail_open: false
   tasks:
+    # Resolve the dashboard basic-auth from 1Password BEFORE rendering .env.
+    # Jinja2 lookups assigned in `group_vars/*.yml` don't reliably resolve in
+    # this AAP execution environment (silent empty return, no error in stdout
+    # — observed live and matches the workaround playbooks/aap/smoketest-
+    # onepassword.yml already uses for the same reason). Setting the fact at
+    # task time evaluates the lookup eagerly and stores the resolved value on
+    # the host. Gated on the var being empty so a launch-time `-e
+    # hermes_dashboard_auth_username=…` extra-var (operator override / smoke
+    # test) wins over the 1Password lookup.
+    - name: Resolve dashboard basic-auth from 1Password
+      ansible.builtin.set_fact:
+        hermes_dashboard_auth_username: "{{ lookup('community.general.onepassword', 'hermes-dashboard', field='username', vault='awx') }}"
+        hermes_dashboard_auth_password_hash: "{{ lookup('community.general.onepassword', 'hermes-dashboard', field='password_hash', vault='awx') }}"
+        hermes_dashboard_auth_secret: "{{ lookup('community.general.onepassword', 'hermes-dashboard', field='password_secret', vault='awx') }}"
+      no_log: true
+      when: hermes_dashboard_auth_username | length == 0
+
     # Hermes loads `~/.hermes/config.yaml` (what `hermes config path` returns) —
     # NOT cli-config.yaml. The dashboard also writes this file via `save_config`
     # (the UI model picker, skills/MCP toggles, etc.), so re-rendering here would


### PR DESCRIPTION
PR #55 (igou-inventory) moved the dashboard-auth `community.general.onepassword` lookups out of workflow node `extra_data` and into `group_vars/hermes.yml`. Live test (workflow 757 on a fresh VM): the three lookups returned the **empty string** at template time — no error or warning in stdout — and the "Enable and start the Hermes dashboard user unit" task skipped its `when: hermes_dashboard_auth_username | length > 0` guard.

Direct evidence the playbook + EE are fine:
- `linux_baseline` + `install_packages` succeeded → `group_vars/hermes.yml` **does** attach to the kubevirt-discovered host (those plain-data vars work).
- An override-test run with `-e hermes_dashboard_auth_username=DEBUG_OVERRIDE_admin …` → dashboard unit enabled+active.
- `playbooks/aap/smoketest-onepassword.yml` already uses **`set_fact`** for the same auth pattern (the in-repo workaround for the same quirk).

So Jinja2 lookups assigned as group_vars values don't resolve reliably in this EE's variable-templating order, and the conventional, proven location is a `set_fact` task in the playbook.

### Fix
Resolve the three auth vars via `set_fact` at the top of `configure.yml`:
- `no_log: true` keeps them out of logs.
- `when: hermes_dashboard_auth_username | length == 0` lets a launch-time `-e` extra-var still win (smoke tests, manual overrides).
- `group_vars/hermes.yml` (companion PR in igou-inventory) drops the three lookups; keeps `baseline_service_users` + `linux_install_packages` (which work fine).