### PR TITLE
fix(hermes): match Hermes's expected model: shape exactly to keep provider:custom

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -96,17 +96,19 @@
         {{ hermes_llm_providers
             | map('combine', {'api_key': hermes_llm_api_key})
             | list }}
-      # Primary model: use the generic `provider: custom` with inline base_url
-      # + model (NOT a `custom:<slug>` reference). Naming the primary by slug
-      # causes the dashboard's `/api/model/options` to dedupe the named entry
-      # out of the picker rows — so the user can't switch back to it from the
-      # UI. Inline form keeps all three `custom_providers:` entries visible
-      # as switchable rows AND lets the picker correctly mark the matching
-      # one as `is_current`.
+      # Primary model: generic `provider: custom` with inline base_url + model
+      # + api_key + default. Mirror EXACTLY the shape Hermes itself saves when
+      # the operator picks a custom endpoint in the UI — anything less (e.g.
+      # missing `api_key` and `default`) and the agent "completes" the config
+      # by switching `provider: custom -> openai-api`, clearing `base_url`,
+      # and moving `model` into `default`. With all five fields present, the
+      # save_config round-trip is a no-op and `provider:` stays `custom`.
       model:
         provider: custom
         base_url: "{{ (hermes_llm_providers | selectattr('name','equalto', hermes_llm_primary) | first).base_url }}"
         model: "{{ (hermes_llm_providers | selectattr('name','equalto', hermes_llm_primary) | first).model }}"
+        api_key: "{{ hermes_llm_api_key }}"
+        default: "{{ (hermes_llm_providers | selectattr('name','equalto', hermes_llm_primary) | first).model }}"
       # Ordered fallback chain — references the same `custom_providers:` rows
       # by slug. Each entry already provides base_url/api_key; only provider +
       # model needed here.


### PR DESCRIPTION
Live config shows `provider: openai-api` and a cleared `base_url` despite us rendering `provider: custom`. Hermes "completes" partial configs on save_config: when `model:` lacks `api_key` and `default`, it switches to `openai-api`.

The UI-saved form that didn't trigger the rewrite had five fields: provider + base_url + model + api_key + default. Mirror it exactly — both new fields derived from `hermes_llm_providers` + `hermes_llm_primary` + `hermes_llm_api_key` (no new operator surface).