### PR TITLE
Update Hermes OS packages during setup

### DIFF
--- a/playbooks/hermes/setup-os.yml
+++ b/playbooks/hermes/setup-os.yml
@@ -197,6 +197,13 @@
     - name: Refresh DNF metadata after repo pinning changes
       ansible.builtin.meta: flush_handlers
 
+    - name: Update installed OS packages
+      ansible.builtin.dnf:
+        name: "*"
+        state: latest  # noqa: package-latest - intentional OS update during the egress install window
+        update_only: true
+      become: true
+
     # Install the host packages the convergence needs, here in the setup phase
     # because it runs during the egress window (dnf needs the mirrors). configure.yml
     # runs with egress LOCKED, so it can only enable nftables, not install it.


### PR DESCRIPTION
## Summary
- add an installed-package DNF update to the Hermes base OS setup playbook
- run the update after CentOS repo pinning and metadata refresh so it uses mirror.stream.centos.org during the egress window

## Verification
- ansible-playbook --syntax-check -i igou-inventory/inventory.yaml playbooks/hermes/setup-os.yml
- ansible-lint --profile=production playbooks/hermes/setup-os.yml
- ansible-playbook --check --diff -i igou-inventory/inventory.yaml playbooks/hermes/setup-os.yml