### PR TITLE
[codex] Remove cursor agent persistence

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -81,7 +81,6 @@
         - "/home/hermes/.config/gh:{{ hermes_terminal_backend_container_home }}/.config/gh:Z"
         - "/home/hermes/.config/argocd:{{ hermes_terminal_backend_container_home }}/.config/argocd:Z"
         - "/home/hermes/.terraform.d:{{ hermes_terminal_backend_container_home }}/.terraform.d:Z"
-        - "/home/hermes/.local/share/cursor-agent:{{ hermes_terminal_backend_container_home }}/.local/share/cursor-agent:Z"
   tasks:
     - name: Update managed Hermes environment values
       ansible.builtin.lineinfile:

--- a/playbooks/hermes/setup-os.yml
+++ b/playbooks/hermes/setup-os.yml
@@ -548,7 +548,6 @@
         - "{{ hermes_home }}/.local"
         - "{{ hermes_home }}/.local/share"
         - "{{ hermes_home }}/.local/share/opencode"
-        - "{{ hermes_home }}/.local/share/cursor-agent"
         - "{{ hermes_home }}/.terraform.d"
       become: true
 


### PR DESCRIPTION
## Summary

- Stop mounting `/home/hermes/.local/share/cursor-agent` into the Hermes terminal backend container.
- Stop creating the corresponding host-side cursor-agent data directory during Hermes OS setup.

## Impact

Hermes terminal setup no longer preserves Cursor agent state under the managed container home mapping.

## Validation

- `ansible-lint --profile=production playbooks/hermes/configure.yml playbooks/hermes/setup-os.yml`
