### PR TITLE
Mount Cursor agent auth state into Hermes terminal backend

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -80,6 +80,8 @@
         - "/home/hermes/.local/share/opencode:{{ hermes_terminal_backend_container_home }}/.local/share/opencode:Z"
         - "/home/hermes/.config/gh:{{ hermes_terminal_backend_container_home }}/.config/gh:Z"
         - "/home/hermes/.config/argocd:{{ hermes_terminal_backend_container_home }}/.config/argocd:Z"
+        - "/home/hermes/.config/cursor:{{ hermes_terminal_backend_container_home }}/.config/cursor:ro,Z"
+        - "/home/hermes/.cursor:{{ hermes_terminal_backend_container_home }}/.cursor:Z"
         - "/home/hermes/.terraform.d:{{ hermes_terminal_backend_container_home }}/.terraform.d:Z"
   tasks:
     - name: Update managed Hermes environment values

--- a/playbooks/hermes/setup-os.yml
+++ b/playbooks/hermes/setup-os.yml
@@ -545,6 +545,8 @@
         - "{{ hermes_home }}/.config/opencode"
         - "{{ hermes_home }}/.config/gh"
         - "{{ hermes_home }}/.config/argocd"
+        - "{{ hermes_home }}/.config/cursor"
+        - "{{ hermes_home }}/.cursor"
         - "{{ hermes_home }}/.local"
         - "{{ hermes_home }}/.local/share"
         - "{{ hermes_home }}/.local/share/opencode"


### PR DESCRIPTION
## Summary
- Add `docker_volumes` mounts for `/home/hermes/.cursor` and `/home/hermes/.config/cursor` (read-only) into the Hermes terminal backend container, matching `igou-devenv` `cursor-run` behavior.
- Ensure `setup-os.yml` creates the host-side `.cursor` and `.config/cursor` directories before configure runs.

This persists Cursor agent login/session state (`cli-config.json` authInfo, auth tokens) across container launches instead of requiring re-login each time.

## Test plan
- [x] `ansible-playbook --syntax-check playbooks/hermes/configure.yml -i igou-inventory/inventory.yaml`
- [x] `ansible-lint --profile=production playbooks/hermes/configure.yml playbooks/hermes/setup-os.yml`
- [x] `ansible-playbook --check playbooks/hermes/configure.yml -i igou-inventory/inventory.yaml --limit hermes-hermes`
- [ ] Run `hermes_configure` on the guest and confirm Cursor agent sessions survive a new terminal container launch without re-auth


Made with [Cursor](https://cursor.com)