### PR TITLE
[codex] Limit Hermes forwarded environment

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -59,10 +59,7 @@
         BASH_ENV: "{{ hermes_terminal_backend_container_bash_env }}"
         PYTHONUNBUFFERED: "1"
       docker_forward_env:
-        - GITHUB_TOKEN
         - GH_TOKEN
-        - OPENAI_API_KEY
-        - ANTHROPIC_API_KEY
         - OPENCODE_GO_API_KEY
       docker_extra_args:
         - "--userns=keep-id:uid={{ hermes_terminal_backend_container_uid }},gid={{ hermes_terminal_backend_container_gid }}"


### PR DESCRIPTION
## Summary

- Limit the Hermes terminal backend `docker_forward_env` allowlist to `GH_TOKEN` and `OPENCODE_GO_API_KEY`.
- Stop forwarding the broader `GITHUB_TOKEN`, `OPENAI_API_KEY`, and `ANTHROPIC_API_KEY` host environment variable names into backend containers.

## Impact

This narrows which host credentials are inherited by the Hermes backend container while preserving the GitHub CLI token name and OpenCode API key that remain explicitly allowed.

## Validation

- `yamllint playbooks/hermes/configure.yml`
- `ansible-lint --profile=production playbooks/hermes/configure.yml`
- `git diff --check -- playbooks/hermes/configure.yml`

`pre-commit` was not run because it is not installed in this environment.
