### PR TITLE
[codex] Move Hermes runtime mount setup to configure

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -259,6 +259,47 @@
         mode: "0700"
       become: true
 
+    - name: Create host-side directories for igou-devenv Hermes runtime mounts
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "0700"
+      loop:
+        - "{{ hermes_home }}/agent-repos"
+        - "{{ hermes_state_mount }}/cache"
+        - "{{ hermes_state_mount }}/cache/documents"
+        - "{{ hermes_home }}/.ssh"
+        - "{{ hermes_home }}/.kube"
+        - "{{ hermes_home }}/.claude"
+        - "{{ hermes_home }}/.codex"
+        - "{{ hermes_home }}/.config"
+        - "{{ hermes_home }}/.config/opencode"
+        - "{{ hermes_home }}/.config/gh"
+        - "{{ hermes_home }}/.config/argocd"
+        - "{{ hermes_home }}/.config/cursor"
+        - "{{ hermes_home }}/.cursor"
+        - "{{ hermes_home }}/.local"
+        - "{{ hermes_home }}/.local/share"
+        - "{{ hermes_home }}/.local/share/opencode"
+        - "{{ hermes_home }}/.terraform.d"
+      become: true
+
+    - name: Create optional mounted user config files if absent
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: touch
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "{{ item.mode }}"
+        access_time: preserve
+        modification_time: preserve
+      loop:
+        - { path: "{{ hermes_home }}/.claude.json", mode: "0600" }
+        - { path: "{{ hermes_home }}/.gitconfig", mode: "0644" }
+      become: true
+
     - name: Check Hermes config.yaml
       ansible.builtin.stat:
         path: "{{ hermes_state_mount }}/config.yaml"

--- a/playbooks/hermes/setup-os.yml
+++ b/playbooks/hermes/setup-os.yml
@@ -518,54 +518,6 @@
         or hermes_devenv_smoke_test.stdout_lines[1] != "1000"
         or hermes_devenv_smoke_test.stdout_lines[2] != "1000"
 
-    # Future configure.yml phase handoff:
-    # - set HERMES_DOCKER_BINARY=/usr/bin/podman for the Hermes gateway process
-    # - manage Hermes config.yaml with terminal.backend: docker
-    # - set docker_image to {{ hermes_devenv_image_ref }}
-    # - set HOME=/home/igou
-    # - use docker_extra_args: --userns=keep-id:uid=1000,gid=1000 and --user=1000:1000
-    # - use explicit many-volume mappings from /home/hermes into /home/igou
-    # - do not mount all of /home/hermes or use privileged containers
-    - name: Create host-side directories for future igou-devenv Hermes runtime mounts
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        owner: "{{ hermes_user }}"
-        group: "{{ hermes_user }}"
-        mode: "0700"
-      loop:
-        - "{{ hermes_home }}/agent-repos"
-        - "{{ hermes_state_mount }}/cache"
-        - "{{ hermes_state_mount }}/cache/documents"
-        - "{{ hermes_home }}/.ssh"
-        - "{{ hermes_home }}/.kube"
-        - "{{ hermes_home }}/.claude"
-        - "{{ hermes_home }}/.codex"
-        - "{{ hermes_home }}/.config"
-        - "{{ hermes_home }}/.config/opencode"
-        - "{{ hermes_home }}/.config/gh"
-        - "{{ hermes_home }}/.config/argocd"
-        - "{{ hermes_home }}/.config/cursor"
-        - "{{ hermes_home }}/.cursor"
-        - "{{ hermes_home }}/.local"
-        - "{{ hermes_home }}/.local/share"
-        - "{{ hermes_home }}/.local/share/opencode"
-        - "{{ hermes_home }}/.terraform.d"
-      become: true
-
-    - name: Create optional mounted user config files if absent
-      ansible.builtin.file:
-        path: "{{ item.path }}"
-        state: touch
-        owner: "{{ hermes_user }}"
-        group: "{{ hermes_user }}"
-        mode: "{{ item.mode }}"
-        access_time: preserve
-        modification_time: preserve
-      loop:
-        - { path: "{{ hermes_home }}/.claude.json", mode: "0600" }
-        - { path: "{{ hermes_home }}/.gitconfig", mode: "0644" }
-      become: true
   handlers:
     - name: Clean DNF metadata
       ansible.builtin.command:


### PR DESCRIPTION
## Summary

- Move Hermes host-side runtime bind-mount directory creation from `setup-os.yml` into `configure.yml`.
- Keep rootless Podman setup, graphroot creation, SELinux labeling, image pull, and image smoke testing in `setup-os.yml`.
- Create optional mounted config files during configure so rerunning configure can prepare the declared Docker volumes before gateway/dashboard units restart.

## Impact

Running `playbooks/hermes/configure.yml` now ensures the host paths referenced by `hermes_terminal_config.terminal.docker_volumes` exist before writing config and restarting services. `setup-os.yml` still retains the directories it needs for Podman storage and its smoke test does not use the moved bind mounts.

## Validation

- `ansible-lint --profile=production playbooks/hermes/setup-os.yml playbooks/hermes/configure.yml`
- `ansible-playbook --syntax-check -i igou-inventory/inventory.yaml playbooks/hermes/setup-os.yml`
- `ansible-playbook --syntax-check -i igou-inventory/inventory.yaml playbooks/hermes/configure.yml`
- `git diff --check`
