### PR TITLE
feat(devenv): casval-burst CentOS devenv test VM (provision + devhost bootstrap)

### DIFF
--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -18,7 +18,7 @@
     # Slim the packages role to only what a devcontainer host needs: the always-on
     # core packages (git/jq/make/curl/unzip) + pinned Node.js + the always-on
     # @devcontainers/cli. Everything heavy (CLIs, pip suite, extra OS packages) off.
-    # Disabling extra_packages also skips the dnf5-fragile CRB/EPEL enablement.
+    # Disabling extra_packages also skips the dnf5-fragile CRB step + bulk OS packages.
     packages_install_nodejs_pinned: true
     packages_install_extra_packages: false
     packages_install_pip_packages: false
@@ -63,7 +63,9 @@
         cmd: cloud-init status --wait
       register: __devenv_cloudinit
       changed_when: false
-      failed_when: false
+      # cloud-init status --wait: 0=done, 2=done with recoverable/degraded errors;
+      # anything else (1=error/disabled, 3=timeout) means the seed failed — surface it.
+      failed_when: __devenv_cloudinit.rc not in [0, 2]
       become: true
 
     - name: Gather facts (after the connection is proven)
@@ -73,27 +75,44 @@
     - role: david_igou.devhost.docker
     - role: david_igou.devhost.packages
 
-  tasks:
+  post_tasks:
     - name: Clone the igou-devenv repo (public, HTTPS — no agent forwarding needed)
       ansible.builtin.git:
         repo: "{{ devenv_repo }}"
         dest: "{{ ansible_user_dir }}/igou-devenv"
         version: "{{ devenv_repo_version }}"
 
-    - name: Launch code-server (detached) from the published devenv image
-      ansible.builtin.shell:
-        cmd: |
-          set -eu
-          docker rm -f igou-devenv-code-server >/dev/null 2>&1 || true
-          docker run -d --restart unless-stopped --name igou-devenv-code-server \
-            --user igou -e HOME=/home/igou -p 8080:8080 \
-            -v "{{ ansible_user_dir }}/igou-devenv:/workspace:Z" \
-            "{{ devenv_image }}" \
-            code-server --bind-addr 0.0.0.0:8080 /workspace --cert
+    - name: Install the Docker SDK for Python (community.docker.docker_container needs it on the target)
+      # python3-docker is in EPEL; enable EPEL only (from the Stream extras repo) — this
+      # does NOT run the dnf5-fragile CRB step the packages role's extra_packages would.
       become: true
-      changed_when: true
+      block:
+        - name: Enable the EPEL repository
+          ansible.builtin.dnf:
+            name: epel-release
+            state: present
+        - name: Install python3-docker
+          ansible.builtin.dnf:
+            name: python3-docker
+            state: present
+
+    - name: Launch code-server (detached) from the published devenv image
+      community.docker.docker_container:
+        name: igou-devenv-code-server
+        image: "{{ devenv_image }}"
+        state: started
+        pull: true
+        restart_policy: unless-stopped
+        user: igou
+        env:
+          HOME: /home/igou
+        ports:
+          - "8080:8080"
+        volumes:
+          - "{{ ansible_user_dir }}/igou-devenv:/workspace:Z"
+        command: code-server --bind-addr 0.0.0.0:8080 /workspace --cert
+      become: true
       when: devenv_launch_devcontainer | bool
-      # noqa command-instead-of-shell -- multi-step (rm -f guard + detached run) needs the shell
 
     - name: Summarize devenv access
       ansible.builtin.debug:

--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -1,0 +1,105 @@
+---
+# Phase 2 of the devenv lifecycle: configure the freshly-provisioned VM into a
+# Docker host capable of running the igou-devenv devcontainer, using my
+# david_igou.devhost collection, then launch code-server from the published image.
+#
+# Reached over SSH by AAP: the kubevirt.core inventory (source igou_kubevirt_ocp)
+# resolves this host's virt-launcher pod IP; the play connects as remote_user igou
+# (ansible.cfg) with the `ansible_user_ed25519` machine credential. The workflow
+# node passes ansible_limit=devenv-devenv (hosts: reads it before group_vars apply).
+#
+# NB: intentionally NO play-level become. The david_igou.devhost roles self-elevate
+# per task, and the packages role's user-level npm / @devcontainers/cli tasks must
+# run as the igou login user (not root).
+- name: Configure the devenv host via david_igou.devhost
+  hosts: "{{ ansible_limit | default('devenv-devenv') }}"
+  gather_facts: false
+  vars:
+    # Slim the packages role to only what a devcontainer host needs: the always-on
+    # core packages (git/jq/make/curl/unzip) + pinned Node.js + the always-on
+    # @devcontainers/cli. Everything heavy (CLIs, pip suite, extra OS packages) off.
+    # Disabling extra_packages also skips the dnf5-fragile CRB/EPEL enablement.
+    packages_install_nodejs_pinned: true
+    packages_install_extra_packages: false
+    packages_install_pip_packages: false
+    packages_install_onepassword: false
+    packages_install_github_cli: false
+    packages_install_claude_code: false
+    packages_install_cursor_agent: false
+    packages_install_kubectl: false
+    packages_install_helm: false
+    packages_install_kustomize: false
+    packages_install_virtctl: false
+    packages_install_argocd: false
+    packages_install_flux: false
+    packages_install_kubeseal: false
+    packages_install_tkn: false
+    packages_install_terraform: false
+    packages_install_sops: false
+    packages_install_oc: false
+    packages_install_kubeconform: false
+    packages_install_kube_burner: false
+    packages_install_kube_burner_ocp: false
+    packages_install_act: false
+    packages_install_mc: false
+    packages_install_rclone: false
+
+    # docker role: install the full daemon (docker-ce + containerd.io).
+    docker_install_daemon: true
+
+    # devenv extras
+    devenv_repo: https://github.com/igou-io/igou-devenv.git
+    devenv_repo_version: main
+    devenv_image: ghcr.io/igou-io/igou-devenv:latest
+    devenv_launch_devcontainer: true
+
+  pre_tasks:
+    - name: Wait for the VM's SSH to come up
+      ansible.builtin.wait_for_connection:
+        timeout: 300
+
+    - name: Wait for cloud-init to finish seeding the user
+      ansible.builtin.command:
+        cmd: cloud-init status --wait
+      register: __devenv_cloudinit
+      changed_when: false
+      failed_when: false
+      become: true
+
+    - name: Gather facts (after the connection is proven)
+      ansible.builtin.setup:
+
+  roles:
+    - role: david_igou.devhost.docker
+    - role: david_igou.devhost.packages
+
+  tasks:
+    - name: Clone the igou-devenv repo (public, HTTPS — no agent forwarding needed)
+      ansible.builtin.git:
+        repo: "{{ devenv_repo }}"
+        dest: "{{ ansible_user_dir }}/igou-devenv"
+        version: "{{ devenv_repo_version }}"
+
+    - name: Launch code-server (detached) from the published devenv image
+      ansible.builtin.shell:
+        cmd: |
+          set -eu
+          docker rm -f igou-devenv-code-server >/dev/null 2>&1 || true
+          docker run -d --restart unless-stopped --name igou-devenv-code-server \
+            --user igou -e HOME=/home/igou -p 8080:8080 \
+            -v "{{ ansible_user_dir }}/igou-devenv:/workspace:Z" \
+            "{{ devenv_image }}" \
+            code-server --bind-addr 0.0.0.0:8080 /workspace --cert
+      become: true
+      changed_when: true
+      when: devenv_launch_devcontainer | bool
+      # noqa command-instead-of-shell -- multi-step (rm -f guard + detached run) needs the shell
+
+    - name: Summarize devenv access
+      ansible.builtin.debug:
+        msg:
+          - "devenv host configured (docker-ce + node + @devcontainers/cli)."
+          - "SSH:         ssh -p 30022 igou@<any-node-ip>"
+          - "code-server: https://<any-node-ip>:30080  (self-signed TLS)"
+          - "cs password: docker exec igou-devenv-code-server cat /home/igou/.config/code-server/config.yaml"
+          - "Test a from-scratch build:  cd ~/igou-devenv && make e2e"

--- a/playbooks/devenv/provision-vm.yml
+++ b/playbooks/devenv/provision-vm.yml
@@ -1,0 +1,138 @@
+---
+# Provision / reprovision the CentOS "devenv" test VM on the casval burst node.
+#
+# Phase 1 of the devenv lifecycle. Creates the namespace, the VM (via the generic
+# kubevirt_vm_provision role: pod network + masquerade, cloned from the
+# centos-stream10 DataSource, pinned to the burst node), and the NodePort services
+# that expose SSH (22) and code-server (8080) for the operator's external access.
+# cloud-init is intentionally minimal (igou login user + keys + qemu-guest-agent);
+# the host is configured afterwards over SSH by playbooks/devenv/bootstrap.yml
+# (david_igou.devhost).
+#
+# Cluster API auth is ambient: kubevirt.core / kubernetes.core read the K8S_AUTH_*
+# env vars injected by the `virtualmachine-deployer-token` credential (custom type
+# `Kubernetes API Token`, see igou-inventory/group_vars/aap/credential_types.yml).
+# Run locally with a KUBECONFIG instead.
+#
+# Lifecycle knobs (pass as extra_vars at launch):
+#   rebuild=true       -> destructive reprovision (fresh VM, namespace/services kept)
+#   vm_state=absent    -> tear down VM + services (lets the autoscaler scale casval to 0)
+- name: Provision the devenv KubeVirt VM
+  hosts: "{{ host | default('localhost') }}"
+  # Talks to the cluster API via env-injected K8S_AUTH_* vars; no SSH. Force local
+  # so the inventory's localhost entry doesn't default to ssh.
+  connection: local
+  gather_facts: false
+  vars:
+    vm_name: devenv
+    vm_namespace: devenv
+    vm_state: present
+    vm_rebuild: "{{ rebuild | default(false) | bool }}"
+    vm_run_strategy: Always
+
+    # Root disk: clone the centos-stream10 golden image on the DEFAULT StorageClass.
+    # Keep the size at the golden 30Gi — the default democratic-csi class deadlocks
+    # on resize-during-clone, and no available credential can expand the PVC.
+    vm_os_datasource: centos-stream10
+    vm_storage_class: ""              # empty -> cluster default StorageClass
+    vm_root_size: 30Gi
+
+    # Compute (overridable at launch). No resources block -> Burstable QoS.
+    vm_cpu_cores: 8
+    vm_memory: 16Gi
+    vm_firmware: bios                 # the centos-stream10 golden image is BIOS-only
+
+    # Pin the versioned machine type so the burst autoscaler's synthetic template
+    # node (built from the casval MachineSet capacity-labels annotation) matches;
+    # otherwise the VM stays Pending and never triggers scale-from-zero.
+    vm_machine_type: pc-q35-rhel9.6.0
+    vm_architecture: amd64
+
+    # Burst placement (casval), passed explicitly to the generic role.
+    vm_node_selector:
+      node-role.kubernetes.io/burst: ""
+    vm_tolerations:
+      - key: workload
+        operator: Equal
+        value: burst
+        effect: NoSchedule
+
+    # Labels land on the VM and (via the module) on the virt-launcher pod, so the
+    # NodePort services below can select it.
+    vm_labels:
+      app: devenv
+      app.kubernetes.io/managed-by: ansible
+
+    # cloud-init login user + authorized keys. The igou public half of the AAP
+    # machine credential (op://awx/ansible-ssh-ed25519 field "public key") is baked
+    # in so AAP can converge the guest unattended in Phase 2. Append a personal key
+    # for direct NodePort SSH via -e devenv_ssh_authorized_key='ssh-ed25519 ...'.
+    vm_admin_user: igou
+    devenv_ansible_pubkey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHO7UsiIgAepf5+s2z+1CbPQf2eqJo8aNK/vT9Oaf4B"
+    devenv_ssh_authorized_key: ""
+    devenv_authorized_keys: >-
+      {{ [devenv_ansible_pubkey]
+         + ([devenv_ssh_authorized_key] if (devenv_ssh_authorized_key | length > 0) else []) }}
+
+  pre_tasks:
+    - name: Render the devenv cloud-init
+      ansible.builtin.set_fact:
+        vm_cloud_init: "{{ lookup('template', 'templates/devenv-cloudinit.yaml.j2') }}"
+      when: vm_state == "present"
+
+  tasks:
+    - name: Ensure the devenv namespace exists
+      kubernetes.core.k8s:
+        state: present
+        api_version: v1
+        kind: Namespace
+        name: "{{ vm_namespace }}"
+      when: vm_state == "present"
+
+    - name: Converge the devenv VM
+      ansible.builtin.include_role:
+        name: kubevirt_vm_provision
+
+    - name: Manage the NodePort service exposing SSH
+      kubernetes.core.k8s:
+        state: "{{ vm_state }}"
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: devenv-ssh
+            namespace: "{{ vm_namespace }}"
+            labels:
+              app: devenv
+          spec:
+            type: NodePort
+            selector:
+              app: devenv
+            ports:
+              - name: ssh
+                port: 22
+                targetPort: 22
+                nodePort: 30022
+                protocol: TCP
+
+    - name: Manage the NodePort service exposing code-server
+      kubernetes.core.k8s:
+        state: "{{ vm_state }}"
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: devenv-code-server
+            namespace: "{{ vm_namespace }}"
+            labels:
+              app: devenv
+          spec:
+            type: NodePort
+            selector:
+              app: devenv
+            ports:
+              - name: code-server
+                port: 8080
+                targetPort: 8080
+                nodePort: 30080
+                protocol: TCP

--- a/playbooks/devenv/provision-vm.yml
+++ b/playbooks/devenv/provision-vm.yml
@@ -70,9 +70,7 @@
     vm_admin_user: igou
     devenv_ansible_pubkey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHO7UsiIgAepf5+s2z+1CbPQf2eqJo8aNK/vT9Oaf4B"
     devenv_ssh_authorized_key: ""
-    devenv_authorized_keys: >-
-      {{ [devenv_ansible_pubkey]
-         + ([devenv_ssh_authorized_key] if (devenv_ssh_authorized_key | length > 0) else []) }}
+    devenv_authorized_keys: "{{ [devenv_ansible_pubkey, devenv_ssh_authorized_key] | reject('equalto', '') | list }}"
 
   pre_tasks:
     - name: Render the devenv cloud-init

--- a/playbooks/devenv/templates/devenv-cloudinit.yaml.j2
+++ b/playbooks/devenv/templates/devenv-cloudinit.yaml.j2
@@ -1,4 +1,5 @@
 #cloud-config
+{{ ansible_managed | comment }}
 # Minimal seed only: create the igou login user with authorized SSH keys and
 # enable the qemu-guest-agent (required so the kubevirt.core inventory reports the
 # virt-launcher pod IP, which is how AAP reaches the VM). ALL host configuration is

--- a/playbooks/devenv/templates/devenv-cloudinit.yaml.j2
+++ b/playbooks/devenv/templates/devenv-cloudinit.yaml.j2
@@ -1,0 +1,22 @@
+#cloud-config
+# Minimal seed only: create the igou login user with authorized SSH keys and
+# enable the qemu-guest-agent (required so the kubevirt.core inventory reports the
+# virt-launcher pod IP, which is how AAP reaches the VM). ALL host configuration is
+# done afterwards by Ansible over SSH (playbooks/devenv/bootstrap.yml ->
+# david_igou.devhost). Deliberately no packages / docker / host prep here.
+hostname: {{ vm_name }}
+ssh_pwauth: false
+users:
+  - default
+  - name: {{ vm_admin_user }}
+    groups:
+      - wheel
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    lock_passwd: true
+    shell: /bin/bash
+    ssh_authorized_keys:
+{% for key in devenv_authorized_keys %}
+      - {{ key }}
+{% endfor %}
+runcmd:
+  - ["systemctl", "enable", "--now", "qemu-guest-agent"]

--- a/requirements.yml
+++ b/requirements.yml
@@ -69,4 +69,7 @@ collections:
   - name: https://github.com/david-igou/ansible-collection-armbian.git
     type: git
     version: v0.0.4-alpha
+  - name: https://github.com/david-igou/ansible-collection-devhost.git
+    type: git
+    version: main
 ...

--- a/requirements.yml
+++ b/requirements.yml
@@ -71,5 +71,5 @@ collections:
     version: v0.0.4-alpha
   - name: https://github.com/david-igou/ansible-collection-devhost.git
     type: git
-    version: main
+    version: 26.4.0
 ...

--- a/roles/kubevirt_vm_provision/README.md
+++ b/roles/kubevirt_vm_provision/README.md
@@ -43,6 +43,9 @@ module reads `K8S_AUTH_*` (AAP/EE) or your kubeconfig.
 | `vm_memory` | `4Gi` | Guest memory (`domain.memory.guest`; Burstable QoS) |
 | `vm_firmware` | `bios` | `bios` \| `efi` |
 | `vm_machine_type` | `q35` | Machine type |
+| `vm_architecture` | `""` | `spec.template.spec.architecture` (e.g. `amd64`); omitted when empty |
+| `vm_node_selector` | `{}` | `spec.template.spec.nodeSelector`; omitted when empty. Caller supplies the labels (e.g. burst: `{node-role.kubernetes.io/burst: ""}`) |
+| `vm_tolerations` | `[]` | `spec.template.spec.tolerations`; omitted when empty (e.g. burst: `[{key: workload, operator: Equal, value: burst, effect: NoSchedule}]`) |
 | `vm_log_serial_console` | `true` | Enable serial-console logging (a virtio-rng device is always attached) |
 | `vm_extra_pvcs` | `[]` | Existing PVCs to attach as data disks: `[{name, claim}]` |
 | `vm_cloud_init` | `""` | cloud-init NoCloud userData string (empty → no cloud-init disk) |
@@ -74,6 +77,9 @@ loop to provision several VMs in one play.
 ```
 
 > The role emits a single masquerade interface on the pod network and no
-> resources block (Burstable QoS). For secondary/Multus networks, GPUs, host
-> devices, or Guaranteed QoS, drive `kubevirt.core.kubevirt_vm` directly — and
-> note that admission policies (e.g. a VAP) may forbid those for hardened VMs.
+> resources block (Burstable QoS). Node placement is generic —
+> `vm_node_selector` / `vm_tolerations` / `vm_architecture` are passthroughs the
+> caller sets (e.g. to target the casval burst node). For secondary/Multus
+> networks, GPUs, host devices, or Guaranteed QoS, drive
+> `kubevirt.core.kubevirt_vm` directly — and note that admission policies (e.g. a
+> VAP) may forbid those for hardened VMs.

--- a/roles/kubevirt_vm_provision/defaults/main.yml
+++ b/roles/kubevirt_vm_provision/defaults/main.yml
@@ -31,6 +31,13 @@ vm_memory: 4Gi
 vm_firmware: bios
 vm_machine_type: q35
 
+# Scheduling / placement. All optional and emitted only when set; the caller
+# supplies the concrete values (e.g. the casval burst node label + taint). Keeping
+# these generic keeps the role free of any node-topology knowledge.
+vm_architecture: ""          # spec.template.spec.architecture (e.g. amd64); omitted when empty
+vm_node_selector: {}         # spec.template.spec.nodeSelector; omitted when empty
+vm_tolerations: []           # spec.template.spec.tolerations; omitted when empty
+
 # Devices (a virtio-rng device is always attached)
 vm_log_serial_console: true
 

--- a/roles/kubevirt_vm_provision/tasks/main.yml
+++ b/roles/kubevirt_vm_provision/tasks/main.yml
@@ -69,6 +69,9 @@
                   requests:
                     storage: "{{ vm_root_size }}"
         spec:
+          architecture: "{{ vm_architecture if (vm_architecture | length > 0) else omit }}"
+          nodeSelector: "{{ vm_node_selector if (vm_node_selector | length > 0) else omit }}"
+          tolerations: "{{ vm_tolerations if (vm_tolerations | length > 0) else omit }}"
           domain:
             cpu:
               cores: "{{ vm_cpu_cores | int }}"


### PR DESCRIPTION
Provision a CentOS Stream 10 VM on the on-demand **casval** burst node to test the igou-devenv devcontainer, driven from AAP. Pairs with igou-inventory PR (AAP job templates + workflow).

## Changes
- **`roles/kubevirt_vm_provision`** — generic placement passthrough: `vm_architecture` / `vm_node_selector` / `vm_tolerations` (emitted only when set). Burst specifics live in the caller, not the role. Hermes unaffected (defaults empty → omit).
- **`playbooks/devenv/provision-vm.yml`** (+ `templates/devenv-cloudinit.yaml.j2`) — Phase 1: namespace + VM (pod net + masquerade, `centos-stream10` clone on the **default** StorageClass at 30Gi, burst nodeSelector/toleration, `pc-q35-rhel9.6.0`) + NodePort Services `devenv-ssh` (30022) / `devenv-code-server` (30080). cloud-init is minimal (igou user + authorized keys + qemu-guest-agent).
- **`playbooks/devenv/bootstrap.yml`** — Phase 2: configure the guest over SSH with `david_igou.devhost` (docker-ce + node + @devcontainers/cli, podman role skipped), clone igou-devenv, launch code-server detached from the published image.
- **`requirements.yml`** — add `david_igou.devhost` (git) so the `igou-awx-ee` EE ships it.

## Notes
- Default StorageClass (democratic-csi) deadlocks on resize-on-clone → root pinned to the 30Gi golden size.
- Burst scale-from-zero needs the pinned machine type + amd64 so the autoscaler's synthetic node matches.

## Verification
- `yamllint` clean; `ansible-lint --profile=production` passes; `ansible-playbook --syntax-check` passes for both playbooks.
- Live end-to-end (provision → inventory sync → bootstrap) runs after the EE rebuilds with devhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)