### PR TITLE
fix(ee): bump igou-awx-ee base image to current stream10-minimal digest

### DIFF
--- a/execution-environments/igou-awx-ee/execution-environment.yml
+++ b/execution-environments/igou-awx-ee/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 images:
   base_image:
     # renovate: datasource=docker depName=quay.io/centos/centos
-    name: quay.io/centos/centos:stream10-minimal@sha256:96ec023a5306c35c44797f918d9ba369d174a4ed9d4025f9d3902752b17cf8bf
+    name: quay.io/centos/centos:stream10-minimal@sha256:8553fc71b29dfcbba3e82349dfdbff2f57f45c6dbf0cbcb631f662c81e0124d6
 options:
   package_manager_path: /usr/bin/microdnf
 dependencies:


### PR DESCRIPTION
The pinned base image digest `quay.io/centos/centos@sha256:96ec023a…` was garbage-collected by CentOS Stream → `manifest unknown`, which fails **every** `igou-awx-ee` build (not just the devenv change that happened to trigger it — see the failed run on the #277 merge commit).

Bumps to the current `stream10-minimal` manifest digest `sha256:8553fc71b29dfcbba3e82349dfdbff2f57f45c6dbf0cbcb631f662c81e0124d6` (verified via `skopeo inspect docker://quay.io/centos/centos:stream10-minimal`). Renovate will keep it current going forward.

Unblocks the EE rebuild that ships `david_igou.devhost` 26.4.0 for the devenv bootstrap job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)