### PR TITLE
feat(ghapp): gated GitHub App token wiring for devenv + hermes (default OFF)

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,3 +15,9 @@ exclude_paths:
   - roles/kubevirt_provision_survey/  # infra.controller_configuration.job_templates
   - roles/kubevirt_vm_snapshot/  # short interface + internal register/set_fact vars intentionally unprefixed for ergonomic CLI/extra_vars; lint logic via `ansible-lint -x var-naming`
   - roles/kubevirt_vm_provision/  # same: short vm_* interface + internal _kvp_* accumulators; lint logic via `ansible-lint -x var-naming`
+  # ghapp-e2e provisioner shims import david_igou.molecule_provisioners (pinned
+  # in the scenario's collections.yml, not installed in the lint env). converge/
+  # verify stay linted; these three only import_playbook the external collection.
+  - molecule/ghapp-e2e/create.yml
+  - molecule/ghapp-e2e/destroy.yml
+  - molecule/ghapp-e2e/prepare.yml

--- a/molecule/ghapp-e2e/collections.yml
+++ b/molecule/ghapp-e2e/collections.yml
@@ -1,0 +1,11 @@
+---
+collections:
+  - name: david_igou.molecule_provisioners
+    version: 0.0.4-alpha
+  - name: https://github.com/david-igou/ansible-collection-devhost.git
+    type: git
+    version: 27.1.0
+  - name: kubernetes.core
+    version: ">=5.0.0"
+  - name: community.general
+    version: ">=10.0.0"

--- a/molecule/ghapp-e2e/collections.yml
+++ b/molecule/ghapp-e2e/collections.yml
@@ -4,7 +4,7 @@ collections:
     version: 0.0.4-alpha
   - name: https://github.com/david-igou/ansible-collection-devhost.git
     type: git
-    version: 27.1.0
+    version: 27.1.2
   - name: kubernetes.core
     version: ">=5.0.0"
   - name: community.general

--- a/molecule/ghapp-e2e/converge.yml
+++ b/molecule/ghapp-e2e/converge.yml
@@ -1,0 +1,90 @@
+---
+# Converge mirrors the two gated integration slices exactly as the real
+# playbooks invoke them (playbooks/devenv/bootstrap.yml and
+# playbooks/hermes/setup-hermes.yml) — same role, same variable mapping, same
+# gates — against real App identities resolved from 1Password at runtime.
+# The full playbook chains stay with the AAP workflows; this scenario proves
+# the ghapp system itself end-to-end on real cluster VMs.
+
+- name: Converge the devenv-style host (ghapp client / local mint — igou-dev)
+  hosts: ghapp-devenv
+  gather_facts: true
+  vars:
+    devenv_ghapp_enabled: true
+    ghapp_client_enabled: true
+    ghapp_client_user: cloud-user
+    ghapp_client_id: >-
+      {{ lookup('ansible.builtin.pipe', 'op read op://claude/igou-dev-github-app/client_id') }}
+    ghapp_client_app_slug: igou-dev
+    ghapp_client_installations:
+      david-igou: >-
+        {{ lookup('ansible.builtin.pipe',
+                  'op read "op://claude/igou-dev-github-app/installation_id_david-igou"') }}
+      igou-io: >-
+        {{ lookup('ansible.builtin.pipe',
+                  'op read op://claude/igou-dev-github-app/installation_id_igou-io') }}
+    ghapp_client_private_key_content: >-
+      {{ lookup('ansible.builtin.pipe', 'op read op://claude/igou-dev-github-app/private_key') }}
+  roles:
+    - role: david_igou.devhost.ghapp
+      when: devenv_ghapp_enabled | bool
+
+- name: Converge the hermes-style host (ghapp broker — igou-hermes)
+  hosts: ghapp-hermes
+  gather_facts: true
+  become: true
+  vars:
+    hermes_user: hermes
+    hermes_ghapp_broker_enabled: true
+    hermes_ghapp_client_id: >-
+      {{ lookup('ansible.builtin.pipe', 'op read op://awx/igou-hermes-github-app/client_id') }}
+    hermes_ghapp_installations:
+      david-igou: >-
+        {{ lookup('ansible.builtin.pipe',
+                  'op read "op://awx/igou-hermes-github-app/installation_id_david-igou"') }}
+      igou-io: >-
+        {{ lookup('ansible.builtin.pipe',
+                  'op read op://awx/igou-hermes-github-app/installation_id_igou-io') }}
+    hermes_ghapp_private_key: >-
+      {{ lookup('ansible.builtin.pipe', 'op read op://awx/igou-hermes-github-app/private_key') }}
+    hermes_ghapp_policy:
+      allowed_repos:
+        - david-igou/hermes_github_app_plugin
+        - igou-io/igou-infrastructure
+      max_permissions:
+        contents: write
+        pull_requests: write
+        issues: write
+      default_permissions:
+        contents: read
+  tasks:
+    - name: Create the hermes service user (as the hermes VM lifecycle does)
+      ansible.builtin.user:
+        name: "{{ hermes_user }}"
+        shell: /bin/bash
+        state: present
+
+    - name: Install podman for the terminal-backend simulation in verify
+      ansible.builtin.package:
+        name: podman
+        state: present
+
+    - name: Enable lingering for rootless podman as the hermes user
+      ansible.builtin.command:
+        cmd: "loginctl enable-linger {{ hermes_user }}"
+      args:
+        creates: "/var/lib/systemd/linger/{{ hermes_user }}"
+
+    # Identical include + variable mapping to playbooks/hermes/setup-hermes.yml.
+    - name: Deploy the ghapp GitHub App token broker
+      ansible.builtin.include_role:
+        name: david_igou.devhost.ghapp
+      vars:
+        ghapp_broker_enabled: true
+        ghapp_broker_socket_group: "{{ hermes_user }}"
+        ghapp_broker_client_id: "{{ hermes_ghapp_client_id }}"
+        ghapp_broker_app_slug: "{{ hermes_ghapp_app_slug | default('igou-hermes') }}"
+        ghapp_broker_installations: "{{ hermes_ghapp_installations }}"
+        ghapp_broker_private_key_content: "{{ hermes_ghapp_private_key }}"
+        ghapp_broker_policy: "{{ hermes_ghapp_policy }}"
+      when: hermes_ghapp_broker_enabled | default(false) | bool

--- a/molecule/ghapp-e2e/create.yml
+++ b/molecule/ghapp-e2e/create.yml
@@ -1,0 +1,3 @@
+---
+- name: Provision molecule instances
+  import_playbook: david_igou.molecule_provisioners.create

--- a/molecule/ghapp-e2e/destroy.yml
+++ b/molecule/ghapp-e2e/destroy.yml
@@ -1,0 +1,3 @@
+---
+- name: Tear down molecule instances
+  import_playbook: david_igou.molecule_provisioners.destroy

--- a/molecule/ghapp-e2e/inventory/group_vars/molecule.yml
+++ b/molecule/ghapp-e2e/inventory/group_vars/molecule.yml
@@ -1,0 +1,5 @@
+---
+# This scenario is inherently kubevirt: it exists to validate the ghapp
+# wiring on real VMs against real GitHub. No podman/docker fallback.
+mp_backend: kubevirt
+mp_kubevirt_wait_timeout: 600

--- a/molecule/ghapp-e2e/inventory/hosts.yml
+++ b/molecule/ghapp-e2e/inventory/hosts.yml
@@ -1,0 +1,58 @@
+---
+all:
+  children:
+    molecule:
+      hosts:
+        ghapp-devenv:
+          mp:
+            kubevirt:
+              boot_source:
+                type: container_disk
+                image: quay.io/containerdisks/centos-stream:10
+              ssh_user: cloud-user
+              cpu:
+                cores: 2
+              memory: 4Gi
+              # Burst placement: pin to casval like the devenv/hermes provision
+              # playbooks. The machine-type/architecture pin matches the burst
+              # MachineSet capacity labels (see playbooks/devenv/provision-vm.yml).
+              node_selector:
+                node-role.kubernetes.io/burst: ""
+              tolerations:
+                - key: workload
+                  operator: Equal
+                  value: burst
+                  effect: NoSchedule
+              vm_overrides:
+                spec:
+                  template:
+                    spec:
+                      architecture: amd64
+                      domain:
+                        machine:
+                          type: pc-q35-rhel9.6.0
+        ghapp-hermes:
+          mp:
+            kubevirt:
+              boot_source:
+                type: container_disk
+                image: quay.io/containerdisks/centos-stream:10
+              ssh_user: cloud-user
+              cpu:
+                cores: 2
+              memory: 4Gi
+              node_selector:
+                node-role.kubernetes.io/burst: ""
+              tolerations:
+                - key: workload
+                  operator: Equal
+                  value: burst
+                  effect: NoSchedule
+              vm_overrides:
+                spec:
+                  template:
+                    spec:
+                      architecture: amd64
+                      domain:
+                        machine:
+                          type: pc-q35-rhel9.6.0

--- a/molecule/ghapp-e2e/molecule.yml
+++ b/molecule/ghapp-e2e/molecule.yml
@@ -1,0 +1,54 @@
+---
+# ghapp-e2e: live end-to-end test of the GitHub App runtime-token wiring on
+# real KubeVirt VMs (burst/casval node) via david_igou.molecule_provisioners.
+#
+# Two instances mirror the two consumers:
+#   ghapp-devenv — client/local-mint mode (the devenv/bootstrap.yml gate)
+#   ghapp-hermes — broker mode (the hermes setup-hermes/configure.yml gates)
+#
+# Requirements to run:
+#   - KUBECONFIG for a principal with VM + Service CRUD and node reads in the
+#     `molecule` namespace (the `ansible-molecule` SA:
+#     op://claude/ocp-ansible-molecule/token, host api.ocp.igou.systems:6443)
+#   - 1Password CLI signed in (converge resolves the real igou-dev /
+#     igou-hermes App keys at runtime; nothing is stored in the repo)
+#   - the casval burst node up (autoscaler scale-from-zero for VMs is broken,
+#     see igou-openshift#262 — `oc scale machineset.cluster.x-k8s.io/casval-worker
+#     -n openshift-cluster-api --replicas=1` if it is down)
+#
+# Run:  molecule test -s ghapp-e2e
+prerun: false
+
+dependency:
+  name: galaxy
+  options:
+    requirements-file: molecule/ghapp-e2e/collections.yml
+    force: true
+
+ansible:
+  executor:
+    args:
+      ansible_playbook:
+        - --inventory=inventory/
+        - --inventory=${MOLECULE_EPHEMERAL_DIRECTORY}/inventory/
+  playbooks:
+    create: create.yml
+    destroy: destroy.yml
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+
+scenario:
+  name: ghapp-e2e
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy
+
+verifier:
+  name: ansible

--- a/molecule/ghapp-e2e/prepare.yml
+++ b/molecule/ghapp-e2e/prepare.yml
@@ -1,0 +1,3 @@
+---
+- name: Prepare molecule instances
+  import_playbook: david_igou.molecule_provisioners.prepare

--- a/molecule/ghapp-e2e/verify.yml
+++ b/molecule/ghapp-e2e/verify.yml
@@ -1,0 +1,270 @@
+---
+# Live verification against real GitHub: every mint here is a real
+# installation token from the real igou-dev / igou-hermes apps, scoped to the
+# scratch repos the installations allow.
+
+- name: Verify the devenv-style host (client / local mint)
+  hosts: ghapp-devenv
+  gather_facts: false
+  vars:
+    __ghapp_env:
+      GHAPP_CONFIG: /home/cloud-user/.config/ghapp/config.yaml
+  tasks:
+    - name: Mint a real scoped token (igou-io installation)
+      ansible.builtin.command:
+        cmd: ghapp token --repo igou-io/igou-infrastructure --permission contents=read --json
+      environment: "{{ __ghapp_env }}"
+      become: true
+      become_user: cloud-user
+      register: __mint_io
+      changed_when: false
+      no_log: true
+
+    - name: Assert the token is scoped to exactly the requested repo
+      ansible.builtin.assert:
+        that:
+          - __mint_json.token is match('^gh[a-z]_')
+          - __mint_json.auth.scoped_repositories == ['igou-io/igou-infrastructure']
+          - __mint_json.auth.scoped_permissions.contents == 'read'
+        fail_msg: "igou-io mint returned an unexpected scope"
+      vars:
+        __mint_json: "{{ __mint_io.stdout | from_json }}"
+
+    - name: Mint a real scoped token (david-igou installation, cross-org)
+      ansible.builtin.command:
+        cmd: >-
+          ghapp token --repo david-igou/hermes_github_app_plugin
+          --permission contents=read --json
+      environment: "{{ __ghapp_env }}"
+      become: true
+      become_user: cloud-user
+      register: __mint_dav
+      changed_when: false
+      no_log: true
+
+    - name: Assert the cross-org token is scoped correctly
+      ansible.builtin.assert:
+        that:
+          - __mint_json.auth.scoped_repositories == ['david-igou/hermes_github_app_plugin']
+        fail_msg: "david-igou mint returned an unexpected scope"
+      vars:
+        __mint_json: "{{ __mint_dav.stdout | from_json }}"
+
+    - name: Attempt a mint for a repo outside the installation (must fail)
+      ansible.builtin.command:
+        cmd: ghapp token --repo igou-io/not-in-the-installation --permission contents=read
+      environment: "{{ __ghapp_env }}"
+      become: true
+      become_user: cloud-user
+      register: __mint_denied
+      changed_when: false
+      failed_when: __mint_denied.rc == 0
+
+    - name: Exercise the git credential helper protocol
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          printf 'protocol=https\nhost=github.com\npath=igou-io/igou-infrastructure.git\n\n'
+          | git-credential-ghapp get
+      args:
+        executable: /bin/bash
+      environment: "{{ __ghapp_env }}"
+      become: true
+      become_user: cloud-user
+      register: __cred_helper
+      changed_when: false
+      no_log: true
+
+    - name: Assert the credential helper answered with a token
+      ansible.builtin.assert:
+        that:
+          - "'username=x-access-token' in __cred_helper.stdout"
+          - __cred_helper.stdout is search('password=gh[a-z]_')
+        fail_msg: "credential helper did not return a usable credential"
+
+    - name: Authenticated git ls-remote through the credential helper
+      ansible.builtin.command:
+        cmd: git ls-remote https://github.com/igou-io/igou-infrastructure.git HEAD
+      environment: "{{ __ghapp_env }}"
+      become: true
+      become_user: cloud-user
+      register: __ls_remote
+      changed_when: false
+
+    - name: Assert git resolved HEAD over HTTPS
+      ansible.builtin.assert:
+        that:
+          - __ls_remote.stdout | length > 0
+        fail_msg: "git ls-remote via the credential helper failed"
+
+    - name: Summarize devenv verification
+      ansible.builtin.debug:
+        msg: >-
+          Verified live: single-repo scoped mints for both installations,
+          out-of-installation mint rejected by GitHub, credential helper
+          protocol + authenticated git ls-remote.
+
+- name: Verify the hermes-style host (broker)
+  hosts: ghapp-hermes
+  gather_facts: false
+  become: true
+  vars:
+    __socket: /run/ghbroker/ghbroker.sock
+  tasks:
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert the broker service is active
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['ghapp-broker.service'].state == 'running'
+        fail_msg: "ghapp-broker.service is not running"
+
+    - name: Report SELinux mode (context for the container socket test)
+      ansible.builtin.command:
+        cmd: getenforce
+      register: __selinux
+      changed_when: false
+      failed_when: false
+
+    - name: Stat the broker key
+      ansible.builtin.stat:
+        path: /etc/ghbroker/key.pem
+      register: __key
+
+    - name: Assert key ownership and mode
+      ansible.builtin.assert:
+        that:
+          - __key.stat.pw_name == "ghbroker"
+          - __key.stat.mode == "0600"
+        fail_msg: "broker key has wrong owner/mode"
+
+    - name: Assert the hermes user cannot read the broker key
+      ansible.builtin.command:
+        cmd: runuser -u hermes -- cat /etc/ghbroker/key.pem
+      register: __key_probe
+      changed_when: false
+      failed_when: __key_probe.rc == 0
+
+    - name: Stat the broker socket
+      ansible.builtin.stat:
+        path: "{{ __socket }}"
+      register: __sock
+
+    - name: Assert socket group and mode
+      ansible.builtin.assert:
+        that:
+          - __sock.stat.gr_name == "hermes"
+          - __sock.stat.mode == "0660"
+        fail_msg: "broker socket has wrong group/mode"
+
+    - name: Read broker status over the socket
+      ansible.builtin.uri:
+        url: http://localhost/status
+        unix_socket: "{{ __socket }}"
+        return_content: true
+      register: __status
+
+    - name: Assert broker identity and policy
+      ansible.builtin.assert:
+        that:
+          - __status.json.app_slug == "igou-hermes"
+          - "'igou-io/igou-infrastructure' in __status.json.policy.allowed_repos"
+        fail_msg: "broker /status does not reflect the converged config"
+
+    - name: Mint a real token through the broker
+      ansible.builtin.uri:
+        url: http://localhost/token
+        unix_socket: "{{ __socket }}"
+        method: POST
+        body_format: json
+        body:
+          repo: igou-io/igou-infrastructure
+          permissions:
+            contents: read
+        return_content: true
+      register: __broker_mint
+      no_log: true
+
+    - name: Assert the broker minted a real scoped token
+      ansible.builtin.assert:
+        that:
+          - __broker_mint.json.token is match('^gh[a-z]_')
+          - __broker_mint.json.repositories == ['igou-io/igou-infrastructure']
+        fail_msg: "broker mint failed or returned an unexpected scope"
+
+    - name: Request a repo outside the policy (must be denied)
+      ansible.builtin.uri:
+        url: http://localhost/token
+        unix_socket: "{{ __socket }}"
+        method: POST
+        body_format: json
+        body:
+          repo: igou-io/igou-ansible
+          permissions:
+            contents: read
+        status_code: 403
+
+    - name: Request a permission above the ceiling (must be denied)
+      ansible.builtin.uri:
+        url: http://localhost/token
+        unix_socket: "{{ __socket }}"
+        method: POST
+        body_format: json
+        body:
+          repo: igou-io/igou-infrastructure
+          permissions:
+            secrets: write
+        status_code: 403
+
+    - name: Check the denials landed in journald
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          journalctl -u ghapp-broker.service --no-pager
+          | grep -c '"decision": "denied"'
+      args:
+        executable: /bin/bash
+      register: __audit
+      changed_when: false
+      failed_when: __audit.stdout | int < 2
+
+    # The terminal-backend simulation: a rootless podman container run AS the
+    # hermes user, mounting the broker runtime dir exactly like
+    # playbooks/hermes/configure.yml wires the Hermes terminal backend.
+    # This is the SELinux/userns reality check for the production mount.
+    - name: Mint from inside a rootless container as the hermes user
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail;
+          runuser -u hermes -- env XDG_RUNTIME_DIR=/run/user/$(id -u hermes)
+          podman run --rm
+          -v /run/ghbroker:/run/ghbroker
+          -e GHAPP_BROKER_SOCKET={{ __socket }}
+          quay.io/centos/centos:stream10
+          curl -sf --unix-socket {{ __socket }}
+          -X POST http://ghapp-broker/token
+          -H 'Content-Type: application/json'
+          -d '{"repo": "igou-io/igou-infrastructure", "permissions": {"contents": "read"}}'
+      args:
+        executable: /bin/bash
+      register: __container_mint
+      changed_when: false
+      no_log: true
+
+    - name: Assert the in-container mint returned a real token
+      ansible.builtin.assert:
+        that:
+          - (__container_mint.stdout | from_json).token is match('^gh[a-z]_')
+        fail_msg: >-
+          Mint from inside the rootless container failed — check SELinux
+          (getenforce reported above) and the socket group mapping.
+
+    - name: Summarize hermes verification
+      ansible.builtin.debug:
+        msg: >-
+          Verified live: broker unit active; key 0600 ghbroker and unreadable
+          to hermes; socket 0660 group hermes; real broker mint scoped to one
+          repo; out-of-policy repo and permission denied (403) and audited in
+          journald; real mint from inside a rootless podman container via the
+          production-style /run/ghbroker mount (SELinux={{ __selinux.stdout | default('unknown') }}).

--- a/molecule/ghapp-e2e/verify.yml
+++ b/molecule/ghapp-e2e/verify.yml
@@ -82,7 +82,7 @@
           - __cred_helper.stdout is search('password=gh[a-z]_')
         fail_msg: "credential helper did not return a usable credential"
 
-    - name: Authenticated git ls-remote through the credential helper
+    - name: Authenticated git ls-remote through the credential helper  # noqa: command-instead-of-module -- exercises the git credential helper end to end, which the module bypasses
       ansible.builtin.command:
         cmd: git ls-remote https://github.com/igou-io/igou-infrastructure.git HEAD
       environment: "{{ __ghapp_env }}"
@@ -248,6 +248,9 @@
           -d '{"repo": "igou-io/igou-infrastructure", "permissions": {"contents": "read"}}'
       args:
         executable: /bin/bash
+        # runuser drops to hermes; start from a dir hermes can traverse (the
+        # play runs as root, whose home hermes cannot chdir into).
+        chdir: /
       register: __container_mint
       changed_when: false
       no_log: true

--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -37,6 +37,15 @@
     devenv_image: ghcr.io/igou-io/igou-devenv:latest
     devenv_launch_devcontainer: true
 
+    # GitHub App runtime tokens (ghapp, local-mint mode). Gated OFF so this is
+    # a no-op until launched with -e devenv_ghapp_enabled=true plus the client
+    # identity extra-vars (ghapp_client_id, ghapp_client_installations, and a
+    # key source — for the test VM, ghapp_client_private_key_content delivered
+    # no_log from AAP; an op-read private_key_cmd is the devcontainer variant).
+    devenv_ghapp_enabled: false
+    ghapp_client_enabled: true
+    ghapp_client_user: igou
+
   pre_tasks:
     - name: Wait for the VM's SSH to come up
       ansible.builtin.wait_for_connection:
@@ -58,6 +67,8 @@
   roles:
     - role: david_igou.devhost.docker
     - role: david_igou.devhost.packages
+    - role: david_igou.devhost.ghapp
+      when: devenv_ghapp_enabled | bool
 
   post_tasks:
     - name: Clone the igou-devenv repo (public, HTTPS — no agent forwarding needed)

--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -38,13 +38,15 @@
     devenv_launch_devcontainer: true
 
     # GitHub App runtime tokens (ghapp, local-mint mode). Gated OFF so this is
-    # a no-op until launched with -e devenv_ghapp_enabled=true plus the client
-    # identity extra-vars (ghapp_client_id, ghapp_client_installations, and a
-    # key source — for the test VM, ghapp_client_private_key_content delivered
-    # no_log from AAP; an op-read private_key_cmd is the devcontainer variant).
+    # a no-op until launched with -e devenv_ghapp_enabled=true. When on, the
+    # igou-dev App identity/key default from 1Password (vault claude; override
+    # devenv_ghapp_op_vault/_item or pass ghapp_client_* directly). The role
+    # params below are only templated when the gated role runs.
     devenv_ghapp_enabled: false
     ghapp_client_enabled: true
     ghapp_client_user: igou
+    devenv_ghapp_op_item: igou-dev-github-app
+    devenv_ghapp_op_vault: claude
 
   pre_tasks:
     - name: Wait for the VM's SSH to come up
@@ -69,6 +71,15 @@
     - role: david_igou.devhost.packages
     - role: david_igou.devhost.ghapp
       when: devenv_ghapp_enabled | bool
+      vars:
+        ghapp_client_id: >-
+          {{ ghapp_client_id | default(lookup('community.general.onepassword',
+             devenv_ghapp_op_item, field='client_id', vault=devenv_ghapp_op_vault), true) }}
+        ghapp_client_app_slug: "{{ ghapp_client_app_slug | default('igou-dev') }}"
+        ghapp_client_installations: "{{ ghapp_client_installations | default(dict([['david-igou', lookup('community.general.onepassword', devenv_ghapp_op_item, field='installation_id_david-igou', vault=devenv_ghapp_op_vault)], ['igou-io', lookup('community.general.onepassword', devenv_ghapp_op_item, field='installation_id_igou-io', vault=devenv_ghapp_op_vault)]]), true) }}"
+        ghapp_client_private_key_content: >-
+          {{ ghapp_client_private_key_content | default(lookup('community.general.onepassword',
+             devenv_ghapp_op_item, field='private_key', vault=devenv_ghapp_op_vault), true) }}
 
   post_tasks:
     - name: Clone the igou-devenv repo (public, HTTPS — no agent forwarding needed)

--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -41,6 +41,20 @@
     # enabled when an auth username is set (fail closed — see the start task below).
     hermes_dashboard_host: "0.0.0.0"
     hermes_dashboard_port: 9119
+    # ghapp token broker wiring (gated OFF — flip with
+    # -e hermes_ghapp_broker_enabled=true, same gate as the broker deploy in
+    # setup-hermes.yml). When enabled the terminal containers mount the broker
+    # runtime directory (directory, not the socket file, so a broker restart
+    # doesn't leave stale bind-mounted inodes), get GHAPP_BROKER_SOCKET so
+    # ghapp/gh-app/git-credential-ghapp mint through the broker, and LOSE the
+    # static GH_TOKEN forward and the mounted human gh config.
+    # NOTE: mounted without :Z — /run/ghbroker is a root-managed runtime dir
+    # shared with the broker; if SELinux blocks the socket connect on the VM,
+    # resolve at the podman level (label=disable for this mount), not by
+    # relabeling the system directory.
+    hermes_ghapp_broker_enabled: false
+    hermes_ghapp_broker_runtime_dir: /run/ghbroker
+    hermes_ghapp_broker_socket: "{{ hermes_ghapp_broker_runtime_dir }}/ghbroker.sock"
     hermes_terminal_config:
       backend: docker
       docker_image: "{{ hermes_terminal_backend_image_ref }}"
@@ -54,33 +68,51 @@
       container_memory: 8192
       container_persistent: true
       docker_run_as_host_user: false
-      docker_env:
-        HOME: "{{ hermes_terminal_backend_container_home }}"
-        BASH_ENV: "{{ hermes_terminal_backend_container_bash_env }}"
-        PYTHONUNBUFFERED: "1"
-      docker_forward_env:
-        - GH_TOKEN
-        - OPENCODE_GO_API_KEY
+      docker_env: >-
+        {{
+          {
+            'HOME': hermes_terminal_backend_container_home,
+            'BASH_ENV': hermes_terminal_backend_container_bash_env,
+            'PYTHONUNBUFFERED': '1',
+          }
+          | combine(
+              {'GHAPP_BROKER_SOCKET': hermes_ghapp_broker_socket}
+              if (hermes_ghapp_broker_enabled | bool) else {}
+            )
+        }}
+      docker_forward_env: >-
+        {{
+          ([] if (hermes_ghapp_broker_enabled | bool) else ['GH_TOKEN'])
+          + ['OPENCODE_GO_API_KEY']
+        }}
       docker_extra_args:
         - "--userns=keep-id:uid={{ hermes_terminal_backend_container_uid }},gid={{ hermes_terminal_backend_container_gid }}"
         - "--user={{ hermes_terminal_backend_container_uid }}:{{ hermes_terminal_backend_container_gid }}"
-      docker_volumes:
-        - "/home/hermes/agent-repos:/workspace:Z"
-        - "/home/hermes/.hermes/cache/documents:/output:Z"
-        - "/home/hermes/.gitconfig:{{ hermes_terminal_backend_container_home }}/.gitconfig:ro,Z"
-        - "/home/hermes/.ssh:{{ hermes_terminal_backend_container_home }}/.ssh:ro,Z"
-        - "/home/hermes/.kube:{{ hermes_terminal_backend_container_home }}/.kube:ro,Z"
-        - "/home/hermes/.claude:{{ hermes_terminal_backend_container_home }}/.claude:Z"
-        - "/home/hermes/.claude.json:{{ hermes_terminal_backend_container_home }}/.claude.json:Z"
-        - "/home/hermes/.codex:{{ hermes_terminal_backend_container_home }}/.codex:Z"
-        - "/home/hermes/.agents/skills:{{ hermes_terminal_backend_container_home }}/.agents/skills:Z"
-        - "/home/hermes/.config/opencode:{{ hermes_terminal_backend_container_home }}/.config/opencode:Z"
-        - "/home/hermes/.local/share/opencode:{{ hermes_terminal_backend_container_home }}/.local/share/opencode:Z"
-        - "/home/hermes/.config/gh:{{ hermes_terminal_backend_container_home }}/.config/gh:Z"
-        - "/home/hermes/.config/argocd:{{ hermes_terminal_backend_container_home }}/.config/argocd:Z"
-        - "/home/hermes/.config/cursor:{{ hermes_terminal_backend_container_home }}/.config/cursor:ro,Z"
-        - "/home/hermes/.cursor:{{ hermes_terminal_backend_container_home }}/.cursor:Z"
-        - "/home/hermes/.terraform.d:{{ hermes_terminal_backend_container_home }}/.terraform.d:Z"
+      docker_volumes: >-
+        {{
+          [
+            '/home/hermes/agent-repos:/workspace:Z',
+            '/home/hermes/.hermes/cache/documents:/output:Z',
+            '/home/hermes/.gitconfig:' ~ hermes_terminal_backend_container_home ~ '/.gitconfig:ro,Z',
+            '/home/hermes/.ssh:' ~ hermes_terminal_backend_container_home ~ '/.ssh:ro,Z',
+            '/home/hermes/.kube:' ~ hermes_terminal_backend_container_home ~ '/.kube:ro,Z',
+            '/home/hermes/.claude:' ~ hermes_terminal_backend_container_home ~ '/.claude:Z',
+            '/home/hermes/.claude.json:' ~ hermes_terminal_backend_container_home ~ '/.claude.json:Z',
+            '/home/hermes/.codex:' ~ hermes_terminal_backend_container_home ~ '/.codex:Z',
+            '/home/hermes/.agents/skills:' ~ hermes_terminal_backend_container_home ~ '/.agents/skills:Z',
+            '/home/hermes/.config/opencode:' ~ hermes_terminal_backend_container_home ~ '/.config/opencode:Z',
+            '/home/hermes/.local/share/opencode:' ~ hermes_terminal_backend_container_home ~ '/.local/share/opencode:Z',
+            '/home/hermes/.config/argocd:' ~ hermes_terminal_backend_container_home ~ '/.config/argocd:Z',
+            '/home/hermes/.config/cursor:' ~ hermes_terminal_backend_container_home ~ '/.config/cursor:ro,Z',
+            '/home/hermes/.cursor:' ~ hermes_terminal_backend_container_home ~ '/.cursor:Z',
+            '/home/hermes/.terraform.d:' ~ hermes_terminal_backend_container_home ~ '/.terraform.d:Z',
+          ]
+          + (
+              [hermes_ghapp_broker_runtime_dir ~ ':' ~ hermes_ghapp_broker_runtime_dir]
+              if (hermes_ghapp_broker_enabled | bool)
+              else ['/home/hermes/.config/gh:' ~ hermes_terminal_backend_container_home ~ '/.config/gh:Z']
+            )
+        }}
   tasks:
     - name: Update managed Hermes environment values
       ansible.builtin.lineinfile:
@@ -92,7 +124,20 @@
         group: "{{ hermes_user }}"
         mode: "0600"
       become: true
-      loop: "{{ hermes_env_values | dict2items | rejectattr('value', 'equalto', '') | list }}"
+      # GHAPP_BROKER_SOCKET is appended for the gateway process itself when the
+      # ghapp broker is enabled, so the in-process github_app_* plugin tools
+      # also mint through the broker instead of needing key material.
+      loop: >-
+        {{
+          (
+            hermes_env_values
+            | combine(
+                {'GHAPP_BROKER_SOCKET': hermes_ghapp_broker_socket}
+                if (hermes_ghapp_broker_enabled | bool) else {}
+              )
+          )
+          | dict2items | rejectattr('value', 'equalto', '') | list
+        }}
       no_log: true
       notify:
         - Restart the Hermes gateway user unit
@@ -367,6 +412,19 @@
           - ("--user=" ~ hermes_terminal_backend_container_uid ~ ":" ~ hermes_terminal_backend_container_gid) in hermes_merged_config.terminal.docker_extra_args
           - "'/home/hermes/agent-repos:/workspace:Z' in hermes_merged_config.terminal.docker_volumes"
           - ('/home/hermes/.agents/skills:' ~ hermes_terminal_backend_container_home ~ '/.agents/skills:Z') in hermes_merged_config.terminal.docker_volumes
+
+    - name: Assert the ghapp broker terminal wiring
+      ansible.builtin.assert:
+        that:
+          - hermes_merged_config.terminal.docker_env.GHAPP_BROKER_SOCKET == hermes_ghapp_broker_socket
+          - "'GH_TOKEN' not in hermes_merged_config.terminal.docker_forward_env"
+          - (hermes_ghapp_broker_runtime_dir ~ ':' ~ hermes_ghapp_broker_runtime_dir) in hermes_merged_config.terminal.docker_volumes
+          - hermes_merged_config.terminal.docker_volumes | select('search', '/.config/gh:') | length == 0
+        fail_msg: >-
+          hermes_ghapp_broker_enabled is true but the terminal config still
+          carries the legacy GH_TOKEN/gh-config wiring or lacks the broker
+          socket mount/env.
+      when: hermes_ghapp_broker_enabled | bool
 
     - name: Ensure the nftables drop-in directory exists
       ansible.builtin.file:

--- a/playbooks/hermes/setup-hermes.yml
+++ b/playbooks/hermes/setup-hermes.yml
@@ -24,6 +24,18 @@
     # installer would otherwise leave a non-functional Chromium in ~/.cache. Flip
     # to false only after running that admin step out of band.
     hermes_install_skip_browser: true
+    # Default broker minting policy (deny-not-clamp). Override with
+    # hermes_ghapp_policy. Scratch repos only until go-live widens it.
+    hermes_ghapp_policy_default:
+      allowed_repos:
+        - david-igou/hermes_github_app_plugin
+        - igou-io/igou-infrastructure
+      max_permissions:
+        contents: write
+        pull_requests: write
+        issues: write
+      default_permissions:
+        contents: read
   tasks:
     - name: Own the Hermes state mount to the hermes user
       ansible.builtin.file:
@@ -117,15 +129,26 @@
     # applications/hermes-agent) already allows github.com/api.github.com (+
     # GitHub CIDRs) and the PyPI Fastly edges, so both the role's pip install
     # and the broker's mint calls work under the locked policy.
+    # The App identity/key default from 1Password (vault awx, the same vault
+    # and onepassword-connect-token credential the dashboard auth already uses),
+    # so a launch only needs the flag; each is still overridable via extra-vars.
+    # These lookups evaluate only when the gate is on (task-scoped vars on a
+    # skipped task are never rendered), so the live hermes run is untouched.
     - name: Deploy the ghapp GitHub App token broker
       ansible.builtin.include_role:
         name: david_igou.devhost.ghapp
       vars:
+        _hermes_ghapp_item: "{{ hermes_ghapp_op_item | default('igou-hermes-github-app') }}"
+        _hermes_ghapp_vault: "{{ hermes_ghapp_op_vault | default('awx') }}"
         ghapp_broker_enabled: true
         ghapp_broker_socket_group: "{{ hermes_user }}"
-        ghapp_broker_client_id: "{{ hermes_ghapp_client_id }}"
+        ghapp_broker_client_id: >-
+          {{ hermes_ghapp_client_id | default(lookup('community.general.onepassword',
+             _hermes_ghapp_item, field='client_id', vault=_hermes_ghapp_vault), true) }}
         ghapp_broker_app_slug: "{{ hermes_ghapp_app_slug | default('igou-hermes') }}"
-        ghapp_broker_installations: "{{ hermes_ghapp_installations }}"
-        ghapp_broker_private_key_content: "{{ hermes_ghapp_private_key }}"
-        ghapp_broker_policy: "{{ hermes_ghapp_policy }}"
+        ghapp_broker_installations: "{{ hermes_ghapp_installations | default(dict([['david-igou', lookup('community.general.onepassword', _hermes_ghapp_item, field='installation_id_david-igou', vault=_hermes_ghapp_vault)], ['igou-io', lookup('community.general.onepassword', _hermes_ghapp_item, field='installation_id_igou-io', vault=_hermes_ghapp_vault)]]), true) }}"
+        ghapp_broker_private_key_content: >-
+          {{ hermes_ghapp_private_key | default(lookup('community.general.onepassword',
+             _hermes_ghapp_item, field='private_key', vault=_hermes_ghapp_vault), true) }}
+        ghapp_broker_policy: "{{ hermes_ghapp_policy | default(hermes_ghapp_policy_default, true) }}"
       when: hermes_ghapp_broker_enabled | default(false) | bool

--- a/playbooks/hermes/setup-hermes.yml
+++ b/playbooks/hermes/setup-hermes.yml
@@ -113,10 +113,10 @@
     # as a dedicated ghbroker user and serves single-repo, permission-clamped
     # tokens over /run/ghbroker/ghbroker.sock; configure.yml (same gate) wires
     # the terminal containers to it and drops the static GH_TOKEN forward.
-    # NOTE go-live prerequisite: the live VM's OVN EgressFirewall pins external
-    # HTTPS to api.telegram.org — api.github.com must be allowed there before
-    # enabling this on hermes-hermes (the hermes-test namespace has no
-    # EgressFirewall, so the test VM is unaffected).
+    # Egress: the hermes namespace EgressFirewall (igou-openshift
+    # applications/hermes-agent) already allows github.com/api.github.com (+
+    # GitHub CIDRs) and the PyPI Fastly edges, so both the role's pip install
+    # and the broker's mint calls work under the locked policy.
     - name: Deploy the ghapp GitHub App token broker
       ansible.builtin.include_role:
         name: david_igou.devhost.ghapp

--- a/playbooks/hermes/setup-hermes.yml
+++ b/playbooks/hermes/setup-hermes.yml
@@ -106,3 +106,26 @@
             include:
               - tirith
             mode: "0755"
+
+    # ghapp GitHub App token broker (gated OFF; flip with
+    # -e hermes_ghapp_broker_enabled=true). Runs in this egress-open phase
+    # because the role pip-installs from GitHub. The broker holds the App key
+    # as a dedicated ghbroker user and serves single-repo, permission-clamped
+    # tokens over /run/ghbroker/ghbroker.sock; configure.yml (same gate) wires
+    # the terminal containers to it and drops the static GH_TOKEN forward.
+    # NOTE go-live prerequisite: the live VM's OVN EgressFirewall pins external
+    # HTTPS to api.telegram.org — api.github.com must be allowed there before
+    # enabling this on hermes-hermes (the hermes-test namespace has no
+    # EgressFirewall, so the test VM is unaffected).
+    - name: Deploy the ghapp GitHub App token broker
+      ansible.builtin.include_role:
+        name: david_igou.devhost.ghapp
+      vars:
+        ghapp_broker_enabled: true
+        ghapp_broker_socket_group: "{{ hermes_user }}"
+        ghapp_broker_client_id: "{{ hermes_ghapp_client_id }}"
+        ghapp_broker_app_slug: "{{ hermes_ghapp_app_slug | default('igou-hermes') }}"
+        ghapp_broker_installations: "{{ hermes_ghapp_installations }}"
+        ghapp_broker_private_key_content: "{{ hermes_ghapp_private_key }}"
+        ghapp_broker_policy: "{{ hermes_ghapp_policy }}"
+      when: hermes_ghapp_broker_enabled | default(false) | bool

--- a/requirements.yml
+++ b/requirements.yml
@@ -71,5 +71,5 @@ collections:
     version: v0.0.4-alpha
   - name: https://github.com/david-igou/ansible-collection-devhost.git
     type: git
-    version: 27.0.0
+    version: 27.1.0
 ...

--- a/requirements.yml
+++ b/requirements.yml
@@ -71,5 +71,5 @@ collections:
     version: v0.0.4-alpha
   - name: https://github.com/david-igou/ansible-collection-devhost.git
     type: git
-    version: 27.1.0
+    version: 27.1.2
 ...


### PR DESCRIPTION
## What

Wires the new `david_igou.devhost.ghapp` role (david-igou/ansible-collection-devhost#35) into the devenv and Hermes lifecycles for runtime-minted, single-repo, permission-scoped GitHub App tokens. **Everything is behind a default-false gate** — merged as-is, the devenv flow and the live `hermes-hermes` agent converge identically to today.

- `playbooks/devenv/bootstrap.yml` — `devenv_ghapp_enabled=true` adds the role in client/local-mint mode for the `igou` user; App identity + key arrive as launch extra-vars (`ghapp_client_id`, `ghapp_client_installations`, `ghapp_client_private_key_content` no_log).
- `playbooks/hermes/setup-hermes.yml` — `hermes_ghapp_broker_enabled=true` deploys the token broker during the egress-open phase: dedicated `ghbroker` system user owns the `igou-hermes` App key, `ghapp serve` on `/run/ghbroker/ghbroker.sock`, deny-not-clamp policy from `hermes_ghapp_policy`, journald audit.
- `playbooks/hermes/configure.yml` (same gate) — terminal containers bind-mount the broker runtime dir and get `GHAPP_BROKER_SOCKET`; the static `GH_TOKEN` forward and the mounted human `~/.config/gh` are removed; the gateway `.env` also gets `GHAPP_BROKER_SOCKET` so the `github_app_*` plugin tools go socket-backed. A gated assert locks these invariants.
- `requirements.yml` — devhost `27.0.0` → `27.1.0`.

## Egress

The hermes namespace EgressFirewall (igou-openshift `applications/hermes-agent`) already allows `github.com`/`api.github.com` + the GitHub CIDR ranges and the PyPI Fastly edges, so the role's pip install and the broker's mint calls both work under the locked policy. (An earlier revision of this PR wrongly called this a go-live blocker.)

## Merge order

1. david-igou/ansible-collection-devhost#35 merges and **release 27.1.0 is published** (first release shipping the role).
2. This PR (requirements pin resolves) → `igou-awx-ee` rebuild → AAP `aap_sync_templates`.
3. e2e validation via the kubevirt molecule scenario (in progress) exercising a test devenv VM (local-mint) and a test hermes VM (broker) on ocp.igou.systems.

## Testing

`ansible-playbook --syntax-check` and `ansible-lint` pass on all three playbooks with the devhost ghapp build installed locally (the repo-wide lint needs the 27.1.0 release for the pinned requirement, hence the merge order). The underlying role has a green molecule scenario (ubuntu-24 + centos-stream-10, converge/idempotence/verify incl. live broker socket smoke tests); the ghapp package itself was live-validated from the devcontainer against both real installations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV