### PR TITLE
feat(truenas): manage RBAC privileges and user-linked API keys in configure_users

### DIFF
--- a/docs/truenas-operations.md
+++ b/docs/truenas-operations.md
@@ -111,7 +111,46 @@ ansible-playbook playbooks/truenas/configure_users.yml \
 ```
 
 The role is idempotent. Removing a user from the list does NOT delete it
-from TrueNAS (use the UI for deletes).
+from TrueNAS (use the UI for deletes, or set `state: absent` on the entry).
+
+### Privileges (role-based access) and user-linked API keys
+
+`configure_users.yml` also manages TrueNAS RBAC privileges and user-linked
+API keys. The `arensb.truenas` collection has no modules for `privilege.*` /
+`api_key.*`, so these are `midclt call` tasks
+(`playbooks/truenas/tasks/truenas_privilege.yml` and `truenas_api_key.yml`)
+with query-first idempotency.
+
+Driven by two group vars in `igou-inventory/group_vars/truenas.yml`:
+
+```yaml
+truenas_privileges:
+  - name: democratic-csi   # bound to local groups, grants roles
+    web_shell: false
+    local_groups:          # group names; resolved to gids at runtime
+      - csi
+    roles:                 # catalog: midclt call privilege.roles
+      - DATASET_WRITE
+      # ...
+
+truenas_api_keys:
+  - name: democratic-csi-ocp
+    username: csi          # key inherits this user's roles
+    # expires_at: <ISO-8601>  # optional
+```
+
+Notes:
+- Privileges are fully reconciled (create + update on role/group/web_shell
+  drift). Removing an entry does NOT delete the privilege on TrueNAS.
+- **API key material is printed exactly once, at creation** — store it in
+  1Password immediately; `api_key.query` never returns it again. To rotate,
+  delete the key (`midclt call api_key.delete <id>`) and re-run.
+- A user-linked key inherits the roles of its user's groups' privileges, so
+  scoping a key = scoping the user. Prefer one key per consuming
+  cluster/system so each can be revoked independently.
+- `--check` mode works: queries still run, mutations are skipped. On a
+  first run the privilege's group-existence assert is skipped too (the
+  group hasn't been created yet in a dry-run).
 
 ## NFS netboot
 

--- a/playbooks/truenas/configure_users.yml
+++ b/playbooks/truenas/configure_users.yml
@@ -1,5 +1,12 @@
 ---
-# Configure users on TrueNAS via arensb.truenas.user (non-deprecated parameters only).
+# Configure users on TrueNAS via arensb.truenas.user (non-deprecated parameters only),
+# plus role-based privileges (privilege.*) and user-linked API keys (api_key.*)
+# via midclt — no arensb.truenas module exists for those two resources.
+#
+# Variables (igou-inventory group_vars/truenas.yml):
+#   truenas_users      — list of arensb.truenas.user parameter dicts
+#   truenas_privileges — list of {name, local_groups, roles, web_shell}
+#   truenas_api_keys   — list of {name, username, expires_at?}
 - name: Configure users on TrueNAS
   hosts: truenas
   gather_facts: false
@@ -24,8 +31,49 @@
         smb: "{{ item.smb | default(omit) }}"
         ssh_authorized_keys: "{{ item.ssh_authorized_keys | default(omit) }}"
         append_pubkeys: "{{ item.append_pubkeys | default(omit) }}"
+        sudo_commands: "{{ item.sudo_commands | default(omit) }}"
         sudo_commands_nopasswd: "{{ item.sudo_commands_nopasswd | default(omit) }}"
         delete_group: "{{ item.delete_group | default(omit) }}"
       loop: "{{ truenas_users }}"
       loop_control:
         label: "{{ item.name }}"
+
+    - name: Manage role-based privileges
+      when: truenas_privileges | default([]) | length > 0
+      block:
+
+        - name: Query local groups
+          ansible.builtin.command: midclt call group.query
+          register: truenas_group_query
+          changed_when: false
+          check_mode: false
+
+        - name: Query existing privileges
+          ansible.builtin.command: midclt call privilege.query
+          register: truenas_privilege_query
+          changed_when: false
+          check_mode: false
+
+        - name: Configure privileges
+          ansible.builtin.include_tasks: tasks/truenas_privilege.yml
+          loop: "{{ truenas_privileges }}"
+          loop_control:
+            loop_var: privilege
+            label: "{{ privilege.name }}"
+
+    - name: Manage user-linked API keys
+      when: truenas_api_keys | default([]) | length > 0
+      block:
+
+        - name: Query existing API keys
+          ansible.builtin.command: midclt call api_key.query
+          register: truenas_api_key_query
+          changed_when: false
+          check_mode: false
+
+        - name: Configure API keys
+          ansible.builtin.include_tasks: tasks/truenas_api_key.yml
+          loop: "{{ truenas_api_keys }}"
+          loop_control:
+            loop_var: api_key
+            label: "{{ api_key.name }}"

--- a/playbooks/truenas/tasks/truenas_api_key.yml
+++ b/playbooks/truenas/tasks/truenas_api_key.yml
@@ -1,0 +1,44 @@
+---
+# Ensure one user-linked TrueNAS API key exists.
+#
+# The key material is returned by the API ONLY at creation time. It is
+# displayed once so it can be stored in 1Password; it cannot be recovered
+# afterwards. To rotate, delete the key (UI or `midclt call api_key.delete`)
+# and re-run this playbook.
+#
+# Expects:
+#   api_key               — one truenas_api_keys entry:
+#                             name       (required) key name
+#                             username   (required) linked local user
+#                             expires_at (optional) ISO-8601 expiry
+#   truenas_api_key_query — registered `midclt call api_key.query`
+
+- name: Resolve current state for API key {{ api_key.name }}
+  ansible.builtin.set_fact:
+    _api_key_current: >-
+      {{ truenas_api_key_query.stdout | from_json
+         | selectattr('name', '==', api_key.name) | list }}
+
+- name: Create API key {{ api_key.name }}
+  ansible.builtin.command:
+    argv:
+      - midclt
+      - call
+      - api_key.create
+      - >-
+        {{ ({'name': api_key.name, 'username': api_key.username}
+            | combine({'expires_at': api_key.expires_at}
+                      if api_key.expires_at is defined else {})) | to_json }}
+  when: _api_key_current | length == 0
+  register: _api_key_create
+  changed_when: true
+  no_log: true
+
+- name: Show once (store in 1Password NOW) API key {{ api_key.name }}
+  ansible.builtin.debug:
+    msg: >-
+      New TrueNAS API key '{{ api_key.name }}'
+      (user {{ api_key.username }}):
+      {{ (_api_key_create.stdout | from_json).key }}
+      — this is the only time it is shown; it is unrecoverable afterwards.
+  when: _api_key_create is not skipped

--- a/playbooks/truenas/tasks/truenas_privilege.yml
+++ b/playbooks/truenas/tasks/truenas_privilege.yml
@@ -1,0 +1,71 @@
+---
+# Ensure one TrueNAS role-based privilege matches its declared state.
+#
+# Expects:
+#   privilege               — one truenas_privileges entry:
+#                               name         (required) privilege name
+#                               local_groups (required) local group names
+#                               roles        (required) role names
+#                                            (catalog: midclt call privilege.roles)
+#                               web_shell    (optional) default false
+#   truenas_group_query     — registered `midclt call group.query`
+#   truenas_privilege_query — registered `midclt call privilege.query`
+
+- name: Resolve current state for privilege {{ privilege.name }}
+  ansible.builtin.set_fact:
+    _privilege_gids: >-
+      {{ truenas_group_query.stdout | from_json
+         | selectattr('group', 'in', privilege.local_groups)
+         | map(attribute='gid') | sort }}
+    _privilege_current: >-
+      {{ truenas_privilege_query.stdout | from_json
+         | selectattr('name', '==', privilege.name) | list }}
+
+# Skipped in check mode: groups declared via truenas_users (create_group)
+# won't exist yet on a first-run dry-run because nothing was created.
+- name: Assert local groups exist for privilege {{ privilege.name }}
+  ansible.builtin.assert:
+    that:
+      - _privilege_gids | length == privilege.local_groups | length
+    fail_msg: >-
+      Not all of {{ privilege.local_groups }} exist on TrueNAS. Declare the
+      group via truenas_users (create_group: true) or create it first.
+    quiet: true
+  when: not ansible_check_mode
+
+- name: Build desired payload for privilege {{ privilege.name }}
+  ansible.builtin.set_fact:
+    _privilege_payload: >-
+      {{ {'name': privilege.name,
+          'local_groups': _privilege_gids,
+          'ds_groups': [],
+          'roles': privilege.roles | sort,
+          'web_shell': privilege.web_shell | default(false) | bool} }}
+
+- name: Create privilege {{ privilege.name }}
+  ansible.builtin.command:
+    argv:
+      - midclt
+      - call
+      - privilege.create
+      - "{{ _privilege_payload | to_json }}"
+  when: _privilege_current | length == 0
+  changed_when: true
+
+- name: Update privilege {{ privilege.name }}
+  ansible.builtin.command:
+    argv:
+      - midclt
+      - call
+      - privilege.update
+      - "{{ _privilege_current[0].id }}"
+      - "{{ _privilege_payload | to_json }}"
+  when:
+    - _privilege_current | length == 1
+    - >-
+      (_privilege_current[0].roles | sort != _privilege_payload.roles)
+      or (_privilege_current[0].local_groups | map(attribute='gid') | sort
+          != _privilege_payload.local_groups)
+      or (_privilege_current[0].web_shell | bool
+          != _privilege_payload.web_shell | bool)
+  changed_when: true


### PR DESCRIPTION
## Why

democratic-csi authenticates to `truenas.igou.systems` as root-equivalent today: its API key (`democratic`, id 7, no expiry) is linked to `truenas_admin` (FULL_ADMIN + web shell), and its SSH credential is `truenas_admin` with `NOPASSWD: ALL` sudo. TrueNAS 25.10.1 supports user-linked API keys scoped by role-based privileges, so a dedicated least-privilege service account is now cleanly expressible — but the `arensb.truenas` collection has no modules for `privilege.*` / `api_key.*`.

## What

Extends `playbooks/truenas/configure_users.yml`:

- **`sudo_commands`** — wires the previously unmapped user parameter (only `sudo_commands_nopasswd` was mapped).
- **Privileges** (`truenas_privileges` group var) — reconciles TrueNAS RBAC privileges via `midclt privilege.create/update`, query-first with drift detection on roles / local groups / web_shell. Group names are resolved to gids at runtime with an existence assert.
- **User-linked API keys** (`truenas_api_keys` group var) — creates keys via `midclt api_key.create` when absent. Key material is `no_log` on create and displayed exactly once for 1Password capture (it is unrecoverable afterwards; rotate by deleting + re-running).
- Runbook section in `docs/truenas-operations.md`.

Companion inventory PR declares the `csi` account, `democratic-csi` privilege, and per-cluster keys: igou-io/igou-inventory#70.

## Validation

- `ansible-lint --profile=production`: pass; `yamllint`: pass
- `ansible-playbook --check` against live `truenas.igou.systems` with the companion group vars: user reports changed, queries run, privilege/key creates correctly gated, first-run check-mode group assert skips as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014j4ZctV7svH1yRynopCcCA
