### PR TITLE
feat(hermes): hermes-test broker validation scaffolding

### DIFF
--- a/playbooks/hermes/provision-test-vm.yml
+++ b/playbooks/hermes/provision-test-vm.yml
@@ -1,0 +1,109 @@
+---
+# Provision / reprovision a persistent hermes-test VM for validating the ghapp
+# token broker (and the wider Hermes convergence) via AAP, isolated from the
+# live hermes VM.
+#
+# Unlike playbooks/hermes/provision-vm.yml, this does NOT use the hermes
+# namespace's GitOps resources (the Argo-owned hermes-state PVC, the
+# EgressFirewall, the hardening VAP). It clones a generic centos-stream10 root
+# disk into the existing `devenv` namespace (which the deployer credential can
+# write and which the KubeVirt inventory already scans) and exposes SSH on a
+# NodePort distinct from the devenv VM's — so the two coexist. The discovered
+# inventory host is `hermes-test-devenv`; attach convergence vars via the static
+# `hermes_test` group + group_vars/hermes_test.yml in igou-inventory.
+#
+# Cluster API auth is ambient (K8S_AUTH_* from the virtualmachine-deployer-token
+# credential); run locally with a KUBECONFIG instead.
+#
+# Lifecycle knobs (extra_vars):
+#   rebuild=true    -> destructive reprovision (fresh VM)
+#   vm_state=absent -> tear down the VM + its NodePort service
+- name: Provision the hermes-test KubeVirt VM
+  hosts: "{{ host | default('localhost') }}"
+  connection: local
+  gather_facts: false
+  vars:
+    vm_name: hermes-test
+    vm_namespace: devenv
+    vm_state: present
+    vm_rebuild: "{{ rebuild | default(false) | bool }}"
+    vm_run_strategy: Always
+
+    # Generic clone on the default StorageClass, golden 30Gi (no resize).
+    vm_os_datasource: centos-stream10
+    vm_storage_class: ""
+    vm_root_size: 30Gi
+
+    vm_cpu_cores: 4
+    vm_memory: 8Gi
+    vm_firmware: bios
+
+    # Burst placement (casval) + versioned machine type so the autoscaler's
+    # synthetic template node matches (see playbooks/devenv/provision-vm.yml).
+    vm_machine_type: pc-q35-rhel9.6.0
+    vm_architecture: amd64
+    vm_node_selector:
+      node-role.kubernetes.io/burst: ""
+    vm_tolerations:
+      - key: workload
+        operator: Equal
+        value: burst
+        effect: NoSchedule
+
+    vm_labels:
+      app: hermes-test
+      app.kubernetes.io/managed-by: ansible
+
+    # NodePort for external SSH — 30023 to avoid the devenv VM's 30022.
+    hermes_test_ssh_nodeport: 30023
+
+    # cloud-init login user + keys. The igou public half of the AAP machine
+    # credential is baked in so AAP can converge the guest unattended; append a
+    # personal key via -e hermes_test_ssh_authorized_key='ssh-ed25519 ...'.
+    vm_admin_user: igou
+    hermes_test_ansible_pubkey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHO7UsiIgAepf5+s2z+1CbPQf2eqJo8aNK/vT9Oaf4B"
+    hermes_test_ssh_authorized_key: ""
+    hermes_test_authorized_keys: >-
+      {{ [hermes_test_ansible_pubkey]
+         + ([hermes_test_ssh_authorized_key] if (hermes_test_ssh_authorized_key | length > 0) else []) }}
+
+  pre_tasks:
+    - name: Render the hermes-test cloud-init
+      ansible.builtin.set_fact:
+        vm_cloud_init: "{{ lookup('template', 'templates/hermes-test-cloudinit.yaml.j2') }}"
+      when: vm_state == "present"
+
+  tasks:
+    - name: Converge the hermes-test VM
+      ansible.builtin.include_role:
+        name: kubevirt_vm_provision
+
+    - name: Manage the NodePort service exposing SSH
+      kubernetes.core.k8s:
+        state: "{{ vm_state }}"
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: hermes-test-ssh
+            namespace: "{{ vm_namespace }}"
+            labels:
+              app: hermes-test
+          spec:
+            type: NodePort
+            selector:
+              app: hermes-test
+            ports:
+              - name: ssh
+                port: 22
+                targetPort: 22
+                nodePort: "{{ hermes_test_ssh_nodeport }}"
+                protocol: TCP
+
+    - name: Summarize hermes-test access
+      ansible.builtin.debug:
+        msg:
+          - "hermes-test VM provisioned in the devenv namespace on the casval burst node."
+          - "SSH:  ssh -p {{ hermes_test_ssh_nodeport }} igou@<any-node-ip>"
+          - "Converge: setup-os -> setup-hermes (ansible_limit=hermes-test-devenv)."
+      when: vm_state == "present"

--- a/playbooks/hermes/setup-hermes.yml
+++ b/playbooks/hermes/setup-hermes.yml
@@ -24,6 +24,10 @@
     # installer would otherwise leave a non-functional Chromium in ~/.cache. Flip
     # to false only after running that admin step out of band.
     hermes_install_skip_browser: true
+    # Install the Hermes agent + tirith scanner. Set false to converge only the
+    # base state mount and the gated ghapp broker — used by the hermes-test
+    # broker validation, where the full agent stack is not needed.
+    hermes_install_agent: true
     # Default broker minting policy (deny-not-clamp). Override with
     # hermes_ghapp_policy. Scratch repos only until go-live widens it.
     hermes_ghapp_policy_default:
@@ -63,6 +67,7 @@
       # shell so the install script gets a sane $HOME/$PATH environment.
       become_flags: '-i'
       changed_when: true   # only runs when 'creates' target is absent
+      when: hermes_install_agent | bool
 
     - name: Confirm the Hermes CLI and capture its version
       ansible.builtin.command:
@@ -72,6 +77,7 @@
       become_flags: '-i'
       register: hermes_version
       changed_when: false
+      when: hermes_install_agent | bool
 
     # tirith (pre-exec command scanner) is a GitHub-released binary that Hermes
     # normally auto-downloads on demand - but that needs the network, so it MUST be
@@ -85,9 +91,12 @@
         path: "{{ hermes_state_mount }}/bin/tirith"
       register: hermes_tirith_bin
       become: true
+      when: hermes_install_agent | bool
 
     - name: Install the tirith pre-exec command scanner from its GitHub release
-      when: not hermes_tirith_bin.stat.exists
+      when:
+        - hermes_install_agent | bool
+        - not (hermes_tirith_bin.stat.exists | default(false))
       become: true
       become_user: "{{ hermes_user }}"
       vars:

--- a/playbooks/hermes/templates/hermes-test-cloudinit.yaml.j2
+++ b/playbooks/hermes/templates/hermes-test-cloudinit.yaml.j2
@@ -1,0 +1,22 @@
+#cloud-config
+# Minimal seed for the hermes-test broker-validation VM: create the igou login
+# user with authorized SSH keys and enable the qemu-guest-agent (so the
+# kubevirt.core inventory reports the virt-launcher pod IP, which is how AAP
+# reaches the VM). The hermes service user + broker are configured afterwards by
+# Ansible over SSH (setup-os -> setup-hermes). Deliberately nothing else here.
+hostname: {{ vm_name }}
+ssh_pwauth: false
+users:
+  - default
+  - name: {{ vm_admin_user }}
+    groups:
+      - wheel
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    lock_passwd: true
+    shell: /bin/bash
+    ssh_authorized_keys:
+{% for key in hermes_test_authorized_keys %}
+      - {{ key }}
+{% endfor %}
+runcmd:
+  - ["systemctl", "enable", "--now", "qemu-guest-agent"]


### PR DESCRIPTION
Scaffolding to validate the ghapp token broker via AAP on a persistent VM, isolated from the live hermes VM.

- **`playbooks/hermes/provision-test-vm.yml`** — provisions a persistent `hermes-test` VM. Clones a generic centos-stream10 disk into the existing `devenv` namespace (no hermes-namespace GitOps deps: no state PVC, no EgressFirewall, no VAP), NodePort **30023** for SSH (coexists with the devenv VM's 30022), casval burst placement. Discovered inventory host: `hermes-test-devenv`.
- **`setup-hermes.yml`** — new `hermes_install_agent` gate (default **true**, live hermes unchanged). Set false to converge only the base state mount + the gated ghapp broker, so the broker deploys+validates on a test VM without the full Hermes agent/tirith stack.

Pairs with the igou-inventory `hermes_test` group + JT/workflow (separate PR). Validated live: provisions on casval, converges, broker mints real tokens under SELinux enforcing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV