### PR TITLE
feat(hermes): full Hermes install + verify broker from dispatched containers

### DIFF
--- a/playbooks/hermes/files/verify_broker_dispatch.py
+++ b/playbooks/hermes/files/verify_broker_dispatch.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Validate the ghapp broker from a terminal container dispatched by the Hermes
+platform's OWN terminal backend (tools.terminal_tool._create_environment +
+DockerEnvironment.execute) — the exact code path the agent uses to run a shell
+command. Reads the real `terminal:` config from the Hermes config (as written
+by configure.yml), so it exercises the production container wiring: the broker
+socket mount + GHAPP_BROKER_SOCKET. Mints a token via the broker from inside
+that container and asserts a real installation token comes back.
+
+Exit 0 on success, non-zero otherwise. Run as the hermes user with
+HERMES_DOCKER_BINARY and XDG_RUNTIME_DIR set, from a hermes-accessible cwd.
+"""
+import json
+import os
+import sys
+
+HERMES_HOME = os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
+AGENT_SRC = os.path.join(HERMES_HOME, "hermes-agent")
+sys.path.insert(0, AGENT_SRC)
+
+import yaml  # noqa: E402
+from tools.terminal_tool import _create_environment  # noqa: E402
+
+REPO = os.environ.get("GHAPP_TEST_REPO", "igou-io/igou-infrastructure")
+
+
+def load_terminal_config():
+    cfg_path = os.path.join(HERMES_HOME, "config.yaml")
+    with open(cfg_path) as fh:
+        cfg = yaml.safe_load(fh) or {}
+    term = cfg.get("terminal") or {}
+    if term.get("backend") != "docker":
+        raise SystemExit(f"terminal.backend is {term.get('backend')!r}, expected 'docker'")
+    return term
+
+
+def main():
+    term = load_terminal_config()
+    image = term["docker_image"]
+    # container_config keys consumed by _create_environment, taken verbatim from
+    # the production terminal config so the broker wiring is what configure.yml set.
+    cc = {
+        k: term[k]
+        for k in (
+            "container_cpu", "container_memory", "container_disk", "container_persistent",
+            "docker_volumes", "docker_forward_env", "docker_env", "docker_extra_args",
+        )
+        if k in term
+    }
+    env_socket = (term.get("docker_env") or {}).get("GHAPP_BROKER_SOCKET")
+    if not env_socket:
+        raise SystemExit("terminal.docker_env.GHAPP_BROKER_SOCKET is not set — broker not wired")
+
+    env = _create_environment(
+        "docker", image, term.get("cwd", "/workspace"),
+        int(term.get("timeout", 180)), container_config=cc,
+    )
+    mint = (
+        'curl -s -o /tmp/tok -w "http=%{http_code}" '
+        '--unix-socket "$GHAPP_BROKER_SOCKET" -X POST http://broker/token '
+        '-H "Content-Type: application/json" '
+        + "-d '" + json.dumps({"repo": REPO, "permissions": {"contents": "read"}}) + "'; "
+        'echo; cat /tmp/tok'
+    )
+    try:
+        result = env.execute(mint)
+        out = result.get("output", "") if isinstance(result, dict) else str(result)
+    finally:
+        try:
+            env.cleanup(force_remove=True)
+        except Exception:
+            pass
+
+    print("--- dispatched-container output ---")
+    print(out)
+    if "http=200" not in out:
+        raise SystemExit("broker mint from the Hermes-dispatched container did NOT return http=200")
+    try:
+        tok = json.loads(out.split("http=200", 1)[1].strip()).get("token", "")
+    except Exception:
+        tok = ""
+    if not tok.startswith("gh"):
+        raise SystemExit("broker response had no installation token")
+    print(f"OK: Hermes-dispatched container minted a real token ({tok[:8]}...) for {REPO}")
+
+
+if __name__ == "__main__":
+    main()

--- a/playbooks/hermes/provision-test-vm.yml
+++ b/playbooks/hermes/provision-test-vm.yml
@@ -54,6 +54,16 @@
       app: hermes-test
       app.kubernetes.io/managed-by: ansible
 
+    # Persistent state disk (-> /dev/vdb -> ~/.hermes), like the live hermes VM.
+    # A blank CDI DataVolume the deployer credential can create (no raw PVC), so
+    # setup-os's state-disk mkfs/mount works and the full Hermes convergence runs
+    # as it does in production. Attached as a plain PVC -> survives VM rebuild.
+    hermes_test_state_dv: hermes-test-state
+    hermes_test_state_size: 20Gi
+    vm_extra_pvcs:
+      - name: state
+        claim: "{{ hermes_test_state_dv }}"
+
     # NodePort for external SSH — 30023 to avoid the devenv VM's 30022.
     hermes_test_ssh_nodeport: 30023
 
@@ -74,6 +84,26 @@
       when: vm_state == "present"
 
   tasks:
+    - name: Ensure the hermes-test state DataVolume exists (blank, survives rebuild)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: cdi.kubevirt.io/v1beta1
+          kind: DataVolume
+          metadata:
+            name: "{{ hermes_test_state_dv }}"
+            namespace: "{{ vm_namespace }}"
+            labels:
+              app: hermes-test
+          spec:
+            source:
+              blank: {}
+            storage:
+              resources:
+                requests:
+                  storage: "{{ hermes_test_state_size }}"
+      when: vm_state == "present"
+
     - name: Converge the hermes-test VM
       ansible.builtin.include_role:
         name: kubevirt_vm_provision
@@ -99,6 +129,15 @@
                 targetPort: 22
                 nodePort: "{{ hermes_test_ssh_nodeport }}"
                 protocol: TCP
+
+    - name: Remove the hermes-test state DataVolume on teardown
+      kubernetes.core.k8s:
+        state: absent
+        api_version: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        name: "{{ hermes_test_state_dv }}"
+        namespace: "{{ vm_namespace }}"
+      when: vm_state == "absent"
 
     - name: Summarize hermes-test access
       ansible.builtin.debug:

--- a/playbooks/hermes/setup-os.yml
+++ b/playbooks/hermes/setup-os.yml
@@ -13,6 +13,10 @@
   # across the whole fleet - match the linux_baseline convention instead.
   hosts: "{{ ansible_limit | default('hermes-hermes') }}"
   become: true
+  # Facts are gathered in pre_tasks after the connection is proven, so a freshly
+  # provisioned VM (sshd still coming up) doesn't fail at play start. For the
+  # live hermes VM the wait returns immediately.
+  gather_facts: false
   vars:
     hermes_user: hermes
     hermes_home: /home/hermes
@@ -48,6 +52,14 @@
         baseurl: "https://mirror.stream.centos.org/SIGs/{{ centos_stream_major }}-stream/extras/$basearch/extras-common/"
         enabled: true
         gpgcheck: true
+  pre_tasks:
+    - name: Wait for the VM's SSH to come up
+      ansible.builtin.wait_for_connection:
+        timeout: 300
+
+    - name: Gather facts (after the connection is proven)
+      ansible.builtin.setup:
+
   tasks:
     - name: Validate the target is CentOS Stream {{ centos_stream_major }}
       ansible.builtin.assert:

--- a/playbooks/hermes/verify-broker-dispatch.yml
+++ b/playbooks/hermes/verify-broker-dispatch.yml
@@ -1,0 +1,60 @@
+---
+# Validate the ghapp token broker from a terminal container dispatched by the
+# Hermes platform's own terminal backend (not a hand-run podman container).
+# Runs on the converged hermes-test VM after setup-os -> setup-hermes ->
+# configure: reads the production `terminal:` config, dispatches an igou-devenv
+# container via Hermes's tools.terminal_tool, and mints a token via the broker
+# from inside it. Target with ansible_limit=hermes-test-devenv.
+- name: Verify the ghapp broker from a Hermes-dispatched terminal container
+  hosts: "{{ ansible_limit | default('hermes-test-devenv') }}"
+  gather_facts: false
+  vars:
+    hermes_user: hermes
+    hermes_home: /home/hermes
+    hermes_state_mount: "{{ hermes_home }}/.hermes"
+    hermes_verify_repo: igou-io/igou-infrastructure
+  tasks:
+    - name: Wait for SSH
+      ansible.builtin.wait_for_connection:
+        timeout: 300
+
+    - name: Resolve the hermes uid
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ hermes_user }}"
+      become: true
+
+    - name: Set hermes runtime facts
+      ansible.builtin.set_fact:
+        _hermes_uid: "{{ ansible_facts.getent_passwd[hermes_user][1] }}"
+
+    - name: Install the broker-dispatch verification script
+      ansible.builtin.copy:
+        src: files/verify_broker_dispatch.py
+        dest: "{{ hermes_state_mount }}/verify_broker_dispatch.py"
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "0755"
+      become: true
+
+    # Runs as the hermes user (rootless podman) from a hermes-owned cwd, with the
+    # podman binary and user runtime dir the Hermes gateway unit also uses. The
+    # script dispatches a container via Hermes's terminal backend and mints via
+    # the broker socket from inside it.
+    - name: Dispatch a Hermes terminal container and mint via the broker
+      ansible.builtin.command:
+        cmd: "{{ hermes_state_mount }}/hermes-agent/venv/bin/python {{ hermes_state_mount }}/verify_broker_dispatch.py"
+        chdir: "{{ hermes_state_mount }}"
+      become: true
+      become_user: "{{ hermes_user }}"
+      environment:
+        HERMES_HOME: "{{ hermes_state_mount }}"
+        HERMES_DOCKER_BINARY: /usr/bin/podman
+        XDG_RUNTIME_DIR: "/run/user/{{ _hermes_uid }}"
+        GHAPP_TEST_REPO: "{{ hermes_verify_repo }}"
+      register: _hermes_dispatch
+      changed_when: false
+
+    - name: Show the dispatch verification result
+      ansible.builtin.debug:
+        msg: "{{ _hermes_dispatch.stdout_lines | select('search', 'OK:|http=|token') | list }}"


### PR DESCRIPTION
Extends the hermes-test path (from #284/#285/#286) from broker-only to the **full Hermes convergence**, and validates the broker from inside a terminal container the **Hermes platform actually dispatches** — not a hand-run podman container.

- **provision-test-vm.yml** — attach a blank CDI state DataVolume (→ /dev/vdb → ~/.hermes) so setup-os's state-disk mkfs/mount runs as on the live hermes VM; removed on teardown.
- **setup-os.yml** — gather_facts after wait_for_connection (fresh-VM sshd race), matching setup-hermes. Live hermes: instant pass.
- **verify-broker-dispatch.yml + files/verify_broker_dispatch.py** — reads the production terminal config (as configure.yml writes it), dispatches an igou-devenv container via Hermes's own `tools.terminal_tool._create_environment` + `DockerEnvironment.execute`, and mints a token via the broker from inside it. Asserts a real installation token.

**Validated live** on the test VM: the Hermes terminal backend spawns the confined container (`container_t`, keep-id, cap-drop ALL) with `GHAPP_BROKER_SOCKET` + the socket mount, and the in-container mint returns `http=200` + a real `ghs_` token under SELinux enforcing.

Pairs with the igou-inventory full-install workflow PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV