### PR TITLE
fix(hermes): setup-os self-creates the hermes user for fresh VMs

### DIFF
--- a/playbooks/hermes/setup-os.yml
+++ b/playbooks/hermes/setup-os.yml
@@ -74,6 +74,18 @@
           release={{ ansible_facts["distribution_release"] }}.
       become: true
 
+    # The hermes service user is normally created by linux_baseline
+    # (baseline_service_users) earlier in the convergence. Ensure it exists here
+    # too so setup-os is self-sufficient on a freshly provisioned VM (the state
+    # mount is chowned to hermes below). Idempotent no-op when baseline made it.
+    - name: Ensure the hermes service user exists
+      ansible.builtin.user:
+        name: "{{ hermes_user }}"
+        home: "{{ hermes_home }}"
+        create_home: true
+        state: present
+      become: true
+
     - name: Create xfs filesystem on the Hermes state device
       community.general.filesystem:
         fstype: xfs


### PR DESCRIPTION
From live hermes-test full-install validation: setup-os chowns the state mount to hermes, but that user is created by linux_baseline earlier in the live convergence. The isolated hermes-test VM runs setup-os standalone, so the user didn't exist and the chown failed. Ensure the user in setup-os (idempotent no-op when baseline already made it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV