### PR TITLE
fix(hermes): own the hermes home dir in setup-os (installer ~/.cache)

### DIFF
--- a/playbooks/hermes/setup-os.yml
+++ b/playbooks/hermes/setup-os.yml
@@ -86,6 +86,19 @@
         state: present
       become: true
 
+    # create_home does NOT re-own a home directory that already exists (e.g. one
+    # the state-disk mount created as root on a prior run before the user
+    # existed). Own the home top level explicitly so the hermes user can write
+    # ~/.cache etc. — the Hermes installer (run as hermes) needs it. recurse is
+    # off so the mounted ~/.hermes state disk keeps its own ownership.
+    - name: Ensure the hermes home directory is owned by the hermes user
+      ansible.builtin.file:
+        path: "{{ hermes_home }}"
+        state: directory
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+      become: true
+
     - name: Create xfs filesystem on the Hermes state device
       community.general.filesystem:
         fstype: xfs

--- a/playbooks/hermes/setup-os.yml
+++ b/playbooks/hermes/setup-os.yml
@@ -97,6 +97,7 @@
         state: directory
         owner: "{{ hermes_user }}"
         group: "{{ hermes_user }}"
+        mode: "0755"
       become: true
 
     - name: Create xfs filesystem on the Hermes state device


### PR DESCRIPTION
From live full-install validation: the Hermes installer failed with `Permission denied` creating `/home/hermes/.cache/uv`. `create_home` doesn't re-own an existing /home/hermes, and on a reused VM the state-disk mount had created it as root before the user existed. Own the home top level explicitly (recurse off so the mounted ~/.hermes state disk keeps its ownership).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV