### PR TITLE
fix(hermes): don't shadow hermes_ghapp_broker_enabled group_var in configure

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -52,7 +52,10 @@
     # shared with the broker; if SELinux blocks the socket connect on the VM,
     # resolve at the podman level (label=disable for this mount), not by
     # relabeling the system directory.
-    hermes_ghapp_broker_enabled: false
+    # NB: NOT set as a play var — play vars outrank inventory group_vars, which
+    # would shadow a group_vars override (e.g. group_vars/hermes_test.yml sets
+    # it true). Referenced as `hermes_ghapp_broker_enabled | default(false)`
+    # below, so it defaults off unless a group/host var or -e sets it.
     hermes_ghapp_broker_runtime_dir: /run/ghbroker
     hermes_ghapp_broker_socket: "{{ hermes_ghapp_broker_runtime_dir }}/ghbroker.sock"
     hermes_terminal_config:
@@ -77,12 +80,12 @@
           }
           | combine(
               {'GHAPP_BROKER_SOCKET': hermes_ghapp_broker_socket}
-              if (hermes_ghapp_broker_enabled | bool) else {}
+              if (hermes_ghapp_broker_enabled | default(false) | bool) else {}
             )
         }}
       docker_forward_env: >-
         {{
-          ([] if (hermes_ghapp_broker_enabled | bool) else ['GH_TOKEN'])
+          ([] if (hermes_ghapp_broker_enabled | default(false) | bool) else ['GH_TOKEN'])
           + ['OPENCODE_GO_API_KEY']
         }}
       docker_extra_args:
@@ -109,7 +112,7 @@
           ]
           + (
               [hermes_ghapp_broker_runtime_dir ~ ':' ~ hermes_ghapp_broker_runtime_dir]
-              if (hermes_ghapp_broker_enabled | bool)
+              if (hermes_ghapp_broker_enabled | default(false) | bool)
               else ['/home/hermes/.config/gh:' ~ hermes_terminal_backend_container_home ~ '/.config/gh:Z']
             )
         }}
@@ -133,7 +136,7 @@
             hermes_env_values
             | combine(
                 {'GHAPP_BROKER_SOCKET': hermes_ghapp_broker_socket}
-                if (hermes_ghapp_broker_enabled | bool) else {}
+                if (hermes_ghapp_broker_enabled | default(false) | bool) else {}
               )
           )
           | dict2items | rejectattr('value', 'equalto', '') | list
@@ -424,7 +427,7 @@
           hermes_ghapp_broker_enabled is true but the terminal config still
           carries the legacy GH_TOKEN/gh-config wiring or lacks the broker
           socket mount/env.
-      when: hermes_ghapp_broker_enabled | bool
+      when: hermes_ghapp_broker_enabled | default(false) | bool
 
     - name: Ensure the nftables drop-in directory exists
       ansible.builtin.file:


### PR DESCRIPTION
Same precedence bug as #286, caught by the hermes-test dispatched-container verification: configure.yml set `hermes_ghapp_broker_enabled` as a play var (default false), which outranks inventory group_vars — so `group_vars/hermes_test.yml`'s true was ignored and the terminal config never got `GHAPP_BROKER_SOCKET` + the broker socket mount. Drop the play var; use `hermes_ghapp_broker_enabled | default(false)` in the conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV