### PR TITLE
fix(hermes): seed skel dotfiles so the hermes CLI is on PATH

### DIFF
--- a/playbooks/hermes/setup-hermes.yml
+++ b/playbooks/hermes/setup-hermes.yml
@@ -115,6 +115,21 @@
       changed_when: false
       when: hermes_install_agent | default(true) | bool
 
+    # Guardrail: prove `hermes` resolves by name in the hermes user's LOGIN shell
+    # (not just via the absolute path above). This catches the missing-dotfiles /
+    # PATH regression where ~/.local/bin never gets added to PATH. -lc forces a
+    # login shell so ~/.bash_profile -> ~/.bashrc -> ~/.local/bin apply.
+    - name: Verify the hermes CLI is on the hermes user login-shell PATH
+      ansible.builtin.command:
+        cmd: bash -lc 'command -v hermes'
+      become: true
+      become_user: "{{ hermes_user }}"
+      become_flags: '-i'
+      register: hermes_on_path
+      changed_when: false
+      failed_when: hermes_on_path.rc != 0 or 'hermes' not in hermes_on_path.stdout
+      when: hermes_install_agent | default(true) | bool
+
     # tirith (pre-exec command scanner) is a GitHub-released binary that Hermes
     # normally auto-downloads on demand - but that needs the network, so it MUST be
     # fetched here in the egress window: at runtime (egress locked) the on-demand

--- a/playbooks/hermes/setup-os.yml
+++ b/playbooks/hermes/setup-os.yml
@@ -100,6 +100,27 @@
         mode: "0755"
       become: true
 
+    # useradd only populates /etc/skel into a NEW home. Because /home/hermes can
+    # pre-exist (the state-disk mount creates it before the user is created),
+    # skel is skipped and the user ends up with no ~/.bash_profile / ~/.bashrc —
+    # so a login shell never adds ~/.local/bin to PATH and the Hermes CLI
+    # (installed there by setup-hermes) is not found by name. Seed the skel
+    # dotfiles if absent (force:false keeps any existing customisations). The
+    # skel .bashrc adds ~/.local/bin:~/bin and .bash_profile sources .bashrc.
+    - name: Ensure the hermes user has the /etc/skel login shell dotfiles
+      ansible.builtin.copy:
+        src: "/etc/skel/{{ item }}"
+        dest: "{{ hermes_home }}/{{ item }}"
+        remote_src: true
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "0644"
+        force: false
+      loop:
+        - .bash_profile
+        - .bashrc
+      become: true
+
     - name: Create xfs filesystem on the Hermes state device
       community.general.filesystem:
         fstype: xfs


### PR DESCRIPTION
The hermes user had no ~/.bash_profile / ~/.bashrc — useradd only copies /etc/skel into a *new* home, but /home/hermes pre-exists (the state-disk mount creates it as root before the user is created), so skel is skipped. Without those dotfiles a login shell never adds ~/.local/bin to PATH, so `hermes` isn't found by name (everything worked only because the gateway unit and tests call it by absolute path).

- **setup-os**: seed /etc/skel/.bash_profile + .bashrc into the hermes home if absent (force:false). skel .bashrc adds ~/.local/bin:~/bin; .bash_profile sources .bashrc.
- **setup-hermes**: guardrail that asserts `hermes` resolves in the hermes user LOGIN shell, catching this regression at convergence.

Verified live on the hermes-test VM: after seeding the dotfiles, login PATH gains ~/.local/bin, `command -v hermes` resolves, `hermes --version` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV