### PR TITLE
feat(hermes): broker-first github-auth skill so agents auth via the broker

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -146,6 +146,32 @@
         - Restart the Hermes gateway user unit
         - Restart the Hermes dashboard user unit
 
+    # When the broker is enabled, override the bundled `github-auth` skill (which
+    # tells the agent to use PATs / SSH / gh login) with a broker-first version:
+    # for any GitHub op the agent mints a scoped token from the broker socket and
+    # uses it directly. Hermes auto-loads this skill on GitHub tasks, so agent
+    # sessions authenticate via the broker without being told. Written AFTER the
+    # installer (setup-hermes), which restores the stock skill each run.
+    - name: Ensure the github-auth skill directory exists
+      ansible.builtin.file:
+        path: "{{ hermes_state_mount }}/skills/github/github-auth"
+        state: directory
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "0755"
+      become: true
+      when: hermes_ghapp_broker_enabled | default(false) | bool
+
+    - name: Install the broker-first github-auth skill (overrides the bundled one)
+      ansible.builtin.copy:
+        src: files/github-auth-broker-SKILL.md
+        dest: "{{ hermes_state_mount }}/skills/github/github-auth/SKILL.md"
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "0644"
+      become: true
+      when: hermes_ghapp_broker_enabled | default(false) | bool
+
     - name: Map legacy Hermes devenv image tag to terminal backend image tag
       ansible.builtin.set_fact:
         hermes_terminal_backend_image_tag: "{{ hermes_devenv_image_tag }}"

--- a/playbooks/hermes/files/github-auth-broker-SKILL.md
+++ b/playbooks/hermes/files/github-auth-broker-SKILL.md
@@ -1,0 +1,102 @@
+---
+name: github-auth
+description: "GitHub auth on this host: mint short-lived scoped tokens from the ghapp broker. No PAT/SSH/gh login."
+version: 2.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    tags: [GitHub, Authentication, Git, ghapp, broker, token]
+    related_skills: [github-pr-workflow, github-code-review, github-issues, github-repo-management]
+---
+
+# GitHub Authentication (ghapp token broker)
+
+On THIS host, GitHub access is provided by a **GitHub App token broker**. There
+is deliberately **no** standing GitHub credential — no personal access token, no
+SSH key, no `gh auth` login, no `~/.git-credentials`, no `GITHUB_TOKEN` in the
+environment. Do not try to create or look for any of those, and do not ask the
+user for one. For **every** GitHub operation you mint a short-lived,
+repository-scoped token from the broker and use it directly.
+
+The broker mints as the GitHub App bot identity. It enforces a repository
+allowlist and a permission ceiling: a `403`/`404` from the broker means the repo
+or permission is outside policy — report it, do not try to work around it.
+
+## The broker interface — ONE endpoint: mint a token
+
+The broker listens on the unix socket in the `GHAPP_BROKER_SOCKET` environment
+variable. It has a single endpoint, `POST /token`, that returns a token. It is
+**not** a GitHub proxy — do not POST issues/PRs/GraphQL to it. You mint a token,
+then call `https://api.github.com` (or `git`) yourself with that token.
+
+```bash
+# Mint a token scoped to ONE repo with ONLY the permission you need.
+# permissions: contents (git clone/push), issues, pull_requests -> "read" or "write".
+TOKEN=$(curl -s --unix-socket "$GHAPP_BROKER_SOCKET" \
+  -X POST http://localhost/token \
+  -H 'Content-Type: application/json' \
+  -d '{"repo":"OWNER/REPO","permissions":{"contents":"read"}}' \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+```
+
+The response JSON is `{"token":"ghs_…","expires_at":…,"repositories":[…],"permissions":{…}}`.
+The token is a `ghs_…` installation token valid for about an hour. Mint a fresh
+one per repo and per task; never cache, log, or print it.
+
+## Using the token
+
+### GitHub REST/GraphQL API — Bearer header
+
+```bash
+# Example: create an issue (needs permissions:{"issues":"write"})
+TOKEN=$(curl -s --unix-socket "$GHAPP_BROKER_SOCKET" -X POST http://localhost/token \
+  -H 'Content-Type: application/json' \
+  -d '{"repo":"OWNER/REPO","permissions":{"issues":"write"}}' \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+
+curl -s -X POST https://api.github.com/repos/OWNER/REPO/issues \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -d '{"title":"...","body":"..."}'
+```
+
+Any REST call follows the same shape: mint with the right permission, then send
+`Authorization: Bearer $TOKEN` to `https://api.github.com/...`.
+
+### git over HTTPS — username `x-access-token`, token as password
+
+```bash
+# Clone / fetch (needs permissions:{"contents":"read"}); push needs "write".
+TOKEN=$(curl -s --unix-socket "$GHAPP_BROKER_SOCKET" -X POST http://localhost/token \
+  -H 'Content-Type: application/json' \
+  -d '{"repo":"OWNER/REPO","permissions":{"contents":"write"}}' \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+
+git clone "https://x-access-token:${TOKEN}@github.com/OWNER/REPO.git"
+# For an existing checkout, set the remote the same way before push:
+#   git remote set-url origin "https://x-access-token:${TOKEN}@github.com/OWNER/REPO.git"
+```
+
+Set `git config user.name "hermes-agent"` and a matching email before committing
+if they are not already configured.
+
+## Permission cheat-sheet
+
+| Task | permissions to request |
+|------|------------------------|
+| clone / fetch / read code | `{"contents":"read"}` |
+| commit & push | `{"contents":"write"}` |
+| read/create/comment issues | `{"issues":"write"}` (or `"read"`) |
+| open / review PRs | `{"pull_requests":"write"}` (plus `contents` to push the branch) |
+
+## Do NOT
+
+- Do NOT use `gh auth login`, `gh auth token`, or `gh auth status` for identity —
+  `gh` is not authenticated here. (You may still use `gh api` **only** if you set
+  `GH_TOKEN=$TOKEN` from a freshly minted broker token first.)
+- Do NOT create or read personal access tokens, SSH keys, or `~/.git-credentials`.
+- Do NOT POST GitHub resources (issues, comments, PRs, GraphQL) to the broker
+  socket — its only endpoint is `POST /token`.
+- Do NOT reuse a token across repos or paste it into files, logs, or messages.

--- a/playbooks/hermes/verify-broker-dispatch.yml
+++ b/playbooks/hermes/verify-broker-dispatch.yml
@@ -49,6 +49,28 @@
       become: true
       changed_when: false
 
+    # The github-auth skill Hermes auto-loads on GitHub tasks must be the
+    # broker-first override (configure.yml), not the stock PAT/SSH one — so agent
+    # sessions authenticate to GitHub via the broker without being told.
+    - name: Read the deployed github-auth skill
+      ansible.builtin.slurp:
+        src: "{{ hermes_state_mount }}/skills/github/github-auth/SKILL.md"
+      become: true
+      register: _github_auth_skill
+
+    - name: Assert the github-auth skill is the broker-first override
+      ansible.builtin.assert:
+        that:
+          - "'ghapp token broker' in (_github_auth_skill.content | b64decode)"
+          - "'POST /token' in (_github_auth_skill.content | b64decode)"
+          - "'GHAPP_BROKER_SOCKET' in (_github_auth_skill.content | b64decode)"
+        fail_msg: >-
+          The github-auth skill is not the broker-first override — agent sessions
+          would be told to use PATs/SSH instead of the broker.
+        success_msg: >-
+          github-auth skill is broker-first: agent sessions mint from the ghapp
+          broker for GitHub ops automatically.
+
     # Runs the Hermes agent as the hermes user (rootless podman), sourcing the
     # managed .env for OPENCODE_GO_API_KEY. The agent uses the opencode-go model
     # and dispatches a terminal container per the config.yaml terminal backend.


### PR DESCRIPTION
Makes hermes-test agent sessions authenticate to GitHub via the ghapp broker **automatically**.

**Problem:** Hermes ships a bundled `github-auth` skill that instructs the agent to use PATs / SSH / `gh auth login`. The agent auto-loads it on GitHub tasks, so on a broker host (no standing credential) it defaulted to the wrong path — asked only to 'post a comment', it fumbled trying gh/graphql instead of the broker.

**Fix:** a broker-first `github-auth` SKILL.md, installed over the bundled one by `configure.yml` when the broker is enabled (after the installer, which restores the stock skill each run). It documents the single mint endpoint (`POST /token` over `$GHAPP_BROKER_SOCKET`) and the mint→use flow for the REST API and git, and forbids PAT/SSH/gh-login. `verify-broker-dispatch` asserts the deployed skill is the broker-first override.

**Verified live on hermes-test:** with the skill in place, the agent auto-loads it (`📚 skill github-auth`) and — told only *'post a comment on issue 17'*, with no broker/token hint — autonomously minted an `issues:write` token from the broker and posted the comment as **igou-hermes[bot]**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV