### PR TITLE
feat: rpi-image playbooks (rpi-image-gen build pipeline)

### DIFF
--- a/playbooks/rpi-image/README.md
+++ b/playbooks/rpi-image/README.md
@@ -1,0 +1,59 @@
+# rpi-image playbooks
+
+Automated Raspberry Pi OS image builds with
+[rpi-image-gen](https://github.com/raspberrypi/rpi-image-gen), replacing
+manual Raspberry Pi Imager runs. Images come out with the `igou` user
+(fleet SSH key, passwordless sudo, key-only sshd) baked in.
+
+State lives in `igou-inventory`: the `rpi_image_builders` group
+(rpi-builder.igou.systems — bare-metal Pi 4 8GB, RPi OS Lite Trixie
+arm64 on USB SSD) and `group_vars/rpi_image_builders.yml` (pinned
+rpi-image-gen release, image definition, publish layout).
+
+## Playbooks
+
+| Playbook | Purpose |
+|---|---|
+| `converge.yml` | Owns the build host: prerequisites, pinned rpi-image-gen checkout + `install_deps.sh`, workspace/publish dirs. Idempotent; run after changing the pin. |
+| `build.yml` | Render config → build (async, flock-serialised, logged) → verify → publish. |
+
+```sh
+ansible-playbook playbooks/rpi-image/converge.yml -i ../igou-inventory/inventory.yaml
+ansible-playbook playbooks/rpi-image/build.yml -i ../igou-inventory/inventory.yaml
+```
+
+## Verify stage
+
+The produced image is loop-mounted on the builder and the build fails
+unless all of these hold:
+
+- `authorized_keys` for the image user contains the fleet public key
+- `/etc/sudoers.d/010_rpi-nopasswd` grants the user NOPASSWD sudo
+- sshd drop-in disables password authentication
+- ssh.service is enabled
+
+## Publish layout
+
+```
+/srv/images/rpi/<config>/<build_id>/<config>.img.xz + SHA256SUMS
+/srv/images/rpi/<config>/latest -> newest build_id
+```
+
+Retention: newest `rpi_image_publish_retain` builds per config. Flash
+with `xzcat <config>.img.xz | sudo dd of=/dev/sdX bs=4M conv=fsync`.
+
+## Notes
+
+- rpi-image-gen images are **not** Raspberry Pi OS proper: there is no
+  raspberrypi-sys-mods firstboot, so Imager customization / `custom.toml`
+  does not apply to them. Bake identity at build time
+  (`-e rpi_image_hostname=...`) or lean on MAC-pinned DHCP.
+- Images are key-only by default. Pass `-e rpi_image_user1passhash='...'`
+  (e.g. from 1Password, `openssl passwd -6`) to also bake a password —
+  needed if you want console login on a device with no network.
+- Disaster recovery for the builder itself: reflash the stock Lite image
+  (or a pipeline-built one), re-pin via DHCP happens automatically, then
+  run `converge.yml`.
+- AAP wiring (converge → build workflow + monthly schedule) is a
+  follow-up; both playbooks are AAP-shaped (group-targeted, no
+  interactive input).

--- a/playbooks/rpi-image/build.yml
+++ b/playbooks/rpi-image/build.yml
@@ -1,0 +1,133 @@
+---
+# Build, verify and publish a Raspberry Pi OS image with rpi-image-gen.
+#
+#   ansible-playbook playbooks/rpi-image/build.yml \
+#     -i ../igou-inventory/inventory.yaml
+#
+# Useful overrides:
+#   -e rpi_image_hostname=foo        host-specific image
+#   -e rpi_image_config=bar          alternate config/publish name
+#   -e rpi_image_user1passhash=...   bake a password hash (else key-only)
+#
+# Stages: render config -> build (async) -> verify (loop-mount
+# assertions against the produced image) -> publish (xz + sha256 +
+# latest symlink + retention prune). A build that fails verification
+# is not published.
+
+- name: Build a Raspberry Pi OS image with rpi-image-gen
+  hosts: rpi_image_builders
+  become: false
+  gather_facts: false
+
+  vars:
+    rpi_image_config: "{{ rpi_image_default_config }}"
+    rpi_image_build_id: >-
+      {{ lookup('ansible.builtin.pipe', 'date -u +%Y%m%dT%H%M%SZ') }}
+    rpi_image_workdir: "{{ rpi_image_root }}/rpi-image-gen/work"
+    rpi_image_publish_config_dir: >-
+      {{ rpi_image_publish_dir }}/{{ rpi_image_config }}
+
+  tasks:
+    - name: Assert pinned rpi-image-gen checkout is present
+      ansible.builtin.command: # noqa: command-instead-of-module (read-only describe)
+        cmd: git describe --tags --exact-match
+        chdir: "{{ rpi_image_root }}/rpi-image-gen"
+      register: rpi_image_gen_tag
+      changed_when: false
+      # A mismatch means the host was never converged (or the pin moved):
+      # run converge.yml first.
+      failed_when: >-
+        rpi_image_gen_tag.rc != 0
+        or rpi_image_gen_tag.stdout != rpi_image_gen_version
+
+    - name: Render image config {{ rpi_image_config }}
+      ansible.builtin.template:
+        src: templates/config.yaml.j2
+        dest: "{{ rpi_image_root }}/configs/{{ rpi_image_config }}.yaml"
+        mode: "0644"
+
+    - name: Mark build start (for artifact discovery)
+      ansible.builtin.file:
+        path: "{{ rpi_image_root }}/.build-start"
+        state: touch
+        mode: "0644"
+
+    # Serialise builds (scheduled vs manual) and log to the workspace so
+    # failures are diagnosable after the fact.
+    - name: Run rpi-image-gen build (async, logged)
+      ansible.builtin.shell: |
+        set -o pipefail
+        exec 200>{{ rpi_image_root }}/build.lock
+        flock -n 200 || { echo "another build is running" >&2; exit 75; }
+        ./rpi-image-gen build \
+          -c {{ rpi_image_root }}/configs/{{ rpi_image_config }}.yaml \
+          2>&1 | tee {{ rpi_image_root }}/logs/{{ rpi_image_build_id }}.log
+      args:
+        executable: /bin/bash
+        chdir: "{{ rpi_image_root }}/rpi-image-gen"
+      async: 7200
+      poll: 30
+      register: rpi_image_build
+      changed_when: true
+
+    - name: Locate produced image
+      ansible.builtin.command:
+        cmd: >-
+          find {{ rpi_image_workdir }} -name '{{ rpi_image_config }}.img'
+          -newer {{ rpi_image_root }}/.build-start
+      register: rpi_image_find
+      changed_when: false
+      failed_when: rpi_image_find.stdout_lines | length != 1
+
+    - name: Verify image contents (loop-mount assertions)
+      become: true
+      ansible.builtin.shell: |
+        set -euo pipefail
+        img='{{ rpi_image_find.stdout_lines[0] }}'
+        mnt=$(mktemp -d)
+        dev=$(losetup -fP --show "$img")
+        trap 'umount -q "$mnt" 2>/dev/null || true; losetup -d "$dev"; rmdir "$mnt"' EXIT
+        mount -o ro "${dev}p2" "$mnt"
+        grep -qF '{{ rpi_image_ssh_pubkey }}' \
+          "$mnt/home/{{ rpi_image_user }}/.ssh/authorized_keys"
+        grep -qF '{{ rpi_image_user }} ALL=(ALL) NOPASSWD: ALL' \
+          "$mnt/etc/sudoers.d/010_rpi-nopasswd"
+        grep -q '^PasswordAuthentication no' \
+          "$mnt/etc/ssh/sshd_config.d/01pubkey-only.conf"
+        chroot "$mnt" /usr/bin/systemctl is-enabled ssh
+        echo VERIFY_OK
+      args:
+        executable: /bin/bash
+      register: rpi_image_verify
+      changed_when: false
+
+    - name: Publish image {{ rpi_image_build_id }}
+      ansible.builtin.shell: |
+        set -euo pipefail
+        dest='{{ rpi_image_publish_config_dir }}/{{ rpi_image_build_id }}'
+        mkdir -p "$dest"
+        xz -T0 -c '{{ rpi_image_find.stdout_lines[0] }}' \
+          > "$dest/{{ rpi_image_config }}.img.xz"
+        cd "$dest" && sha256sum ./*.img.xz > SHA256SUMS
+        ln -sfn "$dest" '{{ rpi_image_publish_config_dir }}/latest'
+        cd '{{ rpi_image_publish_config_dir }}'
+        ls -1d 20*/ | sort | head -n -{{ rpi_image_publish_retain }} \
+          | xargs -r rm -rf
+      args:
+        executable: /bin/bash
+      register: rpi_image_publish
+      changed_when: true
+
+    - name: Record artifact location
+      ansible.builtin.set_stats:
+        data:
+          rpi_image_artifact: >-
+            {{ rpi_image_publish_config_dir }}/{{ rpi_image_build_id
+            }}/{{ rpi_image_config }}.img.xz
+
+    - name: Report
+      ansible.builtin.debug:
+        msg: >-
+          published {{ rpi_image_publish_config_dir }}/{{ rpi_image_build_id
+          }}/{{ rpi_image_config }}.img.xz (latest ->
+          {{ rpi_image_build_id }})

--- a/playbooks/rpi-image/converge.yml
+++ b/playbooks/rpi-image/converge.yml
@@ -1,0 +1,74 @@
+---
+# Converge the rpi-image-gen build host (rpi-builder).
+#
+# Owns everything OS-level on the builder so a reflash costs one run:
+# prerequisites, the pinned rpi-image-gen checkout, its host dependencies
+# and the workspace/publish directory layout. Pipeline vars live in
+# igou-inventory group_vars/rpi_image_builders.yml.
+#
+#   ansible-playbook playbooks/rpi-image/converge.yml \
+#     -i ../igou-inventory/inventory.yaml
+#
+# rpi-image-gen only supports Debian bookworm/trixie arm64 natively
+# (building via QEMU on x86 is unsupported upstream), hence the assert.
+
+- name: Converge the rpi-image-gen build host
+  hosts: rpi_image_builders
+  become: true
+  gather_facts: true
+
+  tasks:
+    - name: Assert supported build host (Debian >=12 arm64)
+      ansible.builtin.assert:
+        that:
+          - ansible_architecture == 'aarch64'
+          - ansible_os_family == 'Debian'
+          - ansible_distribution_major_version | int >= 12
+        fail_msg: >-
+          rpi-image-gen requires a Debian bookworm/trixie arm64 build host;
+          {{ inventory_hostname }} is
+          {{ ansible_distribution }} {{ ansible_distribution_version }}
+          {{ ansible_architecture }}
+
+    - name: Install base prerequisites
+      ansible.builtin.apt:
+        name:
+          - git
+          - xz-utils
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Create workspace and publish directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ rpi_image_build_user }}"
+        group: "{{ rpi_image_build_user }}"
+        mode: "0755"
+      loop:
+        - "{{ rpi_image_root }}"
+        - "{{ rpi_image_root }}/configs"
+        - "{{ rpi_image_root }}/logs"
+        - "{{ rpi_image_publish_dir }}"
+
+    - name: Clone rpi-image-gen at the pinned release
+      become: false
+      ansible.builtin.git:
+        repo: https://github.com/raspberrypi/rpi-image-gen.git
+        dest: "{{ rpi_image_root }}/rpi-image-gen"
+        version: "{{ rpi_image_gen_version }}"
+        force: true
+      register: rpi_image_gen_checkout
+
+    # install_deps.sh apt-installs the build toolchain (mmdebstrap,
+    # bdebstrap, genimage, podman, ...). Re-run whenever the pinned
+    # checkout moves; force with -e rpi_image_gen_force_deps=true.
+    - name: Install rpi-image-gen host dependencies
+      ansible.builtin.command:
+        cmd: ./install_deps.sh
+        chdir: "{{ rpi_image_root }}/rpi-image-gen"
+      when: >-
+        rpi_image_gen_checkout is changed
+        or (rpi_image_gen_force_deps | default(false) | bool)
+      changed_when: true

--- a/playbooks/rpi-image/templates/config.yaml.j2
+++ b/playbooks/rpi-image/templates/config.yaml.j2
@@ -1,0 +1,36 @@
+# {{ ansible_managed }}
+# rpi-image-gen config — rendered by playbooks/rpi-image/build.yml from
+# igou-inventory group_vars/rpi_image_builders.yml.
+#
+# device-user-admin (pulled in via {{ rpi_image_base_layer }} ->
+# openssh-server) creates user1 with sudo; openssh-server installs the
+# authorized_keys and (pubkey_only=y) disables password/challenge auth.
+device:
+  layer: {{ rpi_image_device_layer }}
+  hostname: {{ rpi_image_hostname }}
+  storage_type: {{ rpi_image_storage_type }}
+  user1: {{ rpi_image_user }}
+  user1sudo: nopasswd
+{% if rpi_image_user1passhash is defined %}
+  user1passhash: '{{ rpi_image_user1passhash }}'
+{% endif %}
+
+image:
+  layer: image-rpios
+  name: {{ rpi_image_config }}
+  boot_part_size: 200%
+  root_part_size: 300%
+
+ssh:
+  pubkey_user1: {{ rpi_image_ssh_pubkey }}
+  pubkey_only: y
+
+layer:
+  base: {{ rpi_image_base_layer }}
+{% if rpi_image_extra_packages | length > 0 %}
+
+packages:
+{% for pkg in rpi_image_extra_packages %}
+  - {{ pkg }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Automated Raspberry Pi OS Lite image builds on the bare-metal `rpi-builder` host, replacing manual Imager runs. Companion inventory PR: igou-io/igou-inventory#101 (rpi_image_builders group).

- `converge.yml` — host prerequisites, pinned rpi-image-gen checkout + install_deps.sh, workspace/publish dirs
- `build.yml` — render config → async flock-serialised logged build → **loop-mount verify** (fleet key in authorized_keys, NOPASSWD sudoers, PasswordAuthentication no, ssh enabled) → publish (`.img.xz` + SHA256SUMS + `latest` symlink + retention prune)
- images are key-only by default; `-e rpi_image_user1passhash` bakes a password when console login is needed

ansible-lint production profile: clean. AAP workflow + schedule wiring is a deliberate follow-up (group_vars/aap is under active change elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NQukXAsKR73sL4wRthdeX