### PR TITLE
fix(rpi-image): put sbin on PATH for the build task

### DIFF
--- a/playbooks/rpi-image/build.yml
+++ b/playbooks/rpi-image/build.yml
@@ -53,8 +53,12 @@
         mode: "0644"
 
     # Serialise builds (scheduled vs manual) and log to the workspace so
-    # failures are diagnosable after the fact.
+    # failures are diagnosable after the fact. sbin dirs must be on PATH:
+    # rpi-image-gen's dependency check resolves tools like mkdosfs with
+    # `command -v`, and non-login SSH sessions don't get sbin by default.
     - name: Run rpi-image-gen build (async, logged)
+      environment:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       ansible.builtin.shell: |
         set -o pipefail
         exec 200>{{ rpi_image_root }}/build.lock


### PR DESCRIPTION
First live run of #295 failed in 0.9s: `Dependency mkdosfs (dosfstools) is installed, but not found` — rpi-image-gen checks deps with `command -v` and non-login SSH sessions don't have /usr/sbin on PATH. Sets an explicit full PATH on the build task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NQukXAsKR73sL4wRthdeX