### PR TITLE
chore(deps): bump devhost to 27.1.3 (ghapp broker venv perms fix)

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -71,5 +71,5 @@ collections:
     version: v0.0.4-alpha
   - name: https://github.com/david-igou/ansible-collection-devhost.git
     type: git
-    version: 27.1.2
+    version: 27.1.3
 ...


### PR DESCRIPTION
27.1.3 makes the ghapp broker venv (/opt/ghapp) readable/traversable by the non-root `ghbroker` service user. On the hardened live hermes VM (umask 0077) `python3 -m venv` created it 0700 root, so the service died `203/EXEC Permission denied`. Unblocks the live broker rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV