### PR TITLE
fix(hermes): self-heal ghapp broker venv perms on hardened hosts

### DIFF
--- a/playbooks/hermes/setup-hermes.yml
+++ b/playbooks/hermes/setup-hermes.yml
@@ -194,21 +194,45 @@
     # so a launch only needs the flag; each is still overridable via extra-vars.
     # These lookups evaluate only when the gate is on (task-scoped vars on a
     # skipped task are never rendered), so the live hermes run is untouched.
-    - name: Deploy the ghapp GitHub App token broker
-      ansible.builtin.include_role:
-        name: david_igou.devhost.ghapp
-      vars:
-        _hermes_ghapp_item: "{{ hermes_ghapp_op_item | default('igou-hermes-github-app') }}"
-        _hermes_ghapp_vault: "{{ hermes_ghapp_op_vault | default('awx') }}"
-        ghapp_broker_enabled: true
-        ghapp_broker_socket_group: "{{ hermes_user }}"
-        ghapp_broker_client_id: >-
-          {{ hermes_ghapp_client_id | default(lookup('community.general.onepassword',
-             _hermes_ghapp_item, field='client_id', vault=_hermes_ghapp_vault), true) }}
-        ghapp_broker_app_slug: "{{ hermes_ghapp_app_slug | default('igou-hermes') }}"
-        ghapp_broker_installations: "{{ hermes_ghapp_installations | default(dict([['david-igou', lookup('community.general.onepassword', _hermes_ghapp_item, field='installation_id_david-igou', vault=_hermes_ghapp_vault)], ['igou-io', lookup('community.general.onepassword', _hermes_ghapp_item, field='installation_id_igou-io', vault=_hermes_ghapp_vault)]]), true) }}"
-        ghapp_broker_private_key_content: >-
-          {{ hermes_ghapp_private_key | default(lookup('community.general.onepassword',
-             _hermes_ghapp_item, field='private_key', vault=_hermes_ghapp_vault), true) }}
-        ghapp_broker_policy: "{{ hermes_ghapp_policy | default(hermes_ghapp_policy_default, true) }}"
+    # Wrapped in block/rescue to self-heal the venv perms on hardened hosts:
+    # `python3 -m venv` honors the login umask, so on a host with umask 0077 the
+    # role creates /opt/ghapp 0700 root and the non-root broker service user
+    # cannot exec it — the role's start task then fails 203/EXEC. Fixed at source
+    # in david_igou.devhost >=27.1.3, but AWX has collection syncing disabled so
+    # the EE must be rebuilt to deliver it; this SCM-delivered rescue covers
+    # hosts still on the older EE. On a healthy host the rescue never runs.
+    - name: Deploy the ghapp GitHub App token broker (self-heal venv perms)
       when: hermes_ghapp_broker_enabled | default(false) | bool
+      block:
+        - name: Deploy the ghapp GitHub App token broker
+          ansible.builtin.include_role:
+            name: david_igou.devhost.ghapp
+          vars:
+            _hermes_ghapp_item: "{{ hermes_ghapp_op_item | default('igou-hermes-github-app') }}"
+            _hermes_ghapp_vault: "{{ hermes_ghapp_op_vault | default('awx') }}"
+            ghapp_broker_enabled: true
+            ghapp_broker_socket_group: "{{ hermes_user }}"
+            ghapp_broker_client_id: >-
+              {{ hermes_ghapp_client_id | default(lookup('community.general.onepassword',
+                 _hermes_ghapp_item, field='client_id', vault=_hermes_ghapp_vault), true) }}
+            ghapp_broker_app_slug: "{{ hermes_ghapp_app_slug | default('igou-hermes') }}"
+            ghapp_broker_installations: "{{ hermes_ghapp_installations | default(dict([['david-igou', lookup('community.general.onepassword', _hermes_ghapp_item, field='installation_id_david-igou', vault=_hermes_ghapp_vault)], ['igou-io', lookup('community.general.onepassword', _hermes_ghapp_item, field='installation_id_igou-io', vault=_hermes_ghapp_vault)]]), true) }}"
+            ghapp_broker_private_key_content: >-
+              {{ hermes_ghapp_private_key | default(lookup('community.general.onepassword',
+                 _hermes_ghapp_item, field='private_key', vault=_hermes_ghapp_vault), true) }}
+            ghapp_broker_policy: "{{ hermes_ghapp_policy | default(hermes_ghapp_policy_default, true) }}"
+      rescue:
+        - name: Make the ghapp broker venv readable/traversable by the service user
+          ansible.builtin.file:
+            path: /opt/ghapp
+            state: directory
+            mode: u=rwX,go=rX
+            recurse: true
+          become: true
+
+        - name: Restart the ghapp broker after fixing the venv perms
+          ansible.builtin.systemd_service:
+            name: ghapp-broker.service
+            state: restarted
+            enabled: true
+          become: true


### PR DESCRIPTION
Deploying the broker to the **live** hermes VM (umask 0077) failed `203/EXEC`: `python3 -m venv` created `/opt/ghapp` 0700 root, so the non-root `ghbroker` service user couldn't exec it. Fixed at source in david_igou.devhost **27.1.3**, but AWX has collection syncing disabled (the collection is EE-baked), so that needs an EE rebuild to deliver. This SCM-delivered block/rescue chmods the venv (`u=rwX,go=rX`) + restarts the service on that failure — works now, and no-ops once the EE ships 27.1.3.

Verified live: broker active, token provisioning works (agent dispatched a container and minted a real igou-hermes token via the broker under SELinux enforcing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a2wbMK9DJtGztP6Eu5bSV