### PR TITLE
feat(truenas): KVM VM provisioning + tagged VM bridge playbooks

### DIFF
--- a/playbooks/truenas/configure_vm_bridge.yaml
+++ b/playbooks/truenas/configure_vm_bridge.yaml
@@ -3,9 +3,9 @@
 # Additive and zero-downtime: the primary interface (enp2s0f0), its host
 # IPs, and the docker macvlan networks are never touched.
 #
-# Topology: truenas_vm_trunk_parent (enp2s0f1, 10GBase-T) is cabled to a
-# tagged-only switch trunk (crs317 sfp-sfpplus10, frame-types
-# admit-only-vlan-tagged). For each entry in truenas_vm_bridges this play
+# Topology: truenas_vm_trunk_parent (enp1s0f0) is cabled to a tagged-only
+# switch trunk (crs317 sfp-sfpplus13, frame-types admit-only-vlan-tagged;
+# 1G module for now). For each entry in truenas_vm_bridges this play
 # creates vlan<tag>@trunk and a host bridge enslaving it, with NO host
 # IPs — pure L2 for VM taps. VM<->host traffic (e.g. the democratic-csi
 # portal at 10.10.9.213) hairpins through the switch between the trunk
@@ -70,14 +70,45 @@
       ansible.builtin.set_fact:
         _trunk: "{{ _ifaces | selectattr('name', 'equalto', truenas_vm_trunk_parent) | list }}"
 
-    - name: Assert the trunk parent exists and has link (cable present)
+    - name: Assert the trunk parent exists
       ansible.builtin.assert:
-        that:
-          - _trunk | length == 1
-          - _trunk[0].state.link_state == 'LINK_STATE_UP'
+        that: _trunk | length == 1
         fail_msg: >-
-          {{ truenas_vm_trunk_parent }} is missing or has no link — cable it to
-          the tagged switch trunk port (crs317 sfp-sfpplus10) and confirm the
+          {{ truenas_vm_trunk_parent }} does not exist on this host — check
+          truenas_vm_trunk_parent in group_vars/truenas.yml.
+
+    # An unconfigured port is administratively down at boot, so a plain
+    # link_state check cannot tell "no cable" from "admin down". Bring it
+    # up ephemerally for the probe; the middleware owns (and persists) the
+    # up state once the VLAN/bridge config is committed.
+    - name: Bring the trunk parent up for the link probe (ephemeral)
+      become: true
+      ansible.builtin.command:
+        argv: [ip, link, set, dev, "{{ truenas_vm_trunk_parent }}", up]
+      changed_when: false
+
+    - name: Probe trunk link state (up to 10s)
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - interface.query
+          - '[["name", "=", "{{ truenas_vm_trunk_parent }}"]]'
+      register: _trunk_probe
+      changed_when: false
+      failed_when: false
+      retries: 5
+      delay: 2
+      until: >-
+        ((_trunk_probe.stdout | from_json | first | default({})).state
+         | default({})).link_state | default('') == 'LINK_STATE_UP'
+
+    - name: Assert the trunk parent has link (cable present)
+      ansible.builtin.assert:
+        that: (_trunk_probe.stdout | from_json | first).state.link_state == 'LINK_STATE_UP'
+        fail_msg: >-
+          {{ truenas_vm_trunk_parent }} has no link — check the cable/module to
+          the tagged switch trunk port (crs317 sfp-sfpplus13) and confirm the
           switch config is deployed before running this play.
 
     - name: Assert the trunk parent is a bare L2 port (no IPs, no DHCP/SLAAC)

--- a/playbooks/truenas/configure_vm_bridge.yaml
+++ b/playbooks/truenas/configure_vm_bridge.yaml
@@ -1,0 +1,181 @@
+---
+# Create tagged, IP-less VM bridges on the TrueNAS spare trunk port.
+# Additive and zero-downtime: the primary interface (enp2s0f0), its host
+# IPs, and the docker macvlan networks are never touched.
+#
+# Topology: truenas_vm_trunk_parent (enp2s0f1, 10GBase-T) is cabled to a
+# tagged-only switch trunk (crs317 sfp-sfpplus10, frame-types
+# admit-only-vlan-tagged). For each entry in truenas_vm_bridges this play
+# creates vlan<tag>@trunk and a host bridge enslaving it, with NO host
+# IPs — pure L2 for VM taps. VM<->host traffic (e.g. the democratic-csi
+# portal at 10.10.9.213) hairpins through the switch between the trunk
+# port and the primary port: standard two-port forwarding.
+#
+# STP is disabled on these bridges: a single-member edge bridge cannot
+# form a loop, and the Linux STP listening/learning delay (~30s) on
+# newly-attached VM tap ports can outlast an iPXE DHCP window.
+#
+# Safety: uses the TrueNAS stage -> commit(rollback) -> checkin flow, and
+# the post-commit state is verified BEFORE interface.checkin — an assert
+# failure aborts the play inside the rollback window, so TrueNAS reverts
+# the change on its own at checkin_timeout. No host IPs move, so SSH
+# stays up throughout.
+#
+# Idempotent and health-checking: a converged re-run stages nothing but
+# still asserts the trunk link, the bare-L2 invariant, and that every
+# bridge/VLAN pair exists.
+#
+# Variables (igou-inventory group_vars/truenas.yml):
+#   truenas_vm_trunk_parent — spare physical NIC cabled to the tagged trunk
+#   truenas_vm_bridges      — list of {name, vlan_name, vlan_tag}
+
+- name: Configure TrueNAS tagged VM bridges
+  hosts: truenas
+  gather_facts: false
+  become: false
+
+  tasks:
+
+    - name: Assert trunk and bridge variables are defined
+      ansible.builtin.assert:
+        that:
+          - truenas_vm_trunk_parent is defined
+          - truenas_vm_bridges | default([]) | length > 0
+        fail_msg: >-
+          truenas_vm_trunk_parent / truenas_vm_bridges are missing — define
+          them in group_vars/truenas.yml.
+
+    - name: Query current network interfaces
+      ansible.builtin.command:
+        argv: [midclt, call, interface.query]
+      register: _ifquery
+      changed_when: false
+
+    - name: Parse interface state
+      ansible.builtin.set_fact:
+        _ifaces: "{{ _ifquery.stdout | from_json }}"
+
+    - name: Compute missing VLAN sub-interfaces and bridges
+      vars:
+        _iface_names: "{{ _ifaces | map(attribute='name') | list }}"
+      ansible.builtin.set_fact:
+        _missing_vlans: "{{ truenas_vm_bridges | rejectattr('vlan_name', 'in', _iface_names) | list }}"
+        _missing_bridges: "{{ truenas_vm_bridges | rejectattr('name', 'in', _iface_names) | list }}"
+
+    - name: Note whether staging is needed
+      ansible.builtin.set_fact:
+        _changes_needed: "{{ (_missing_vlans + _missing_bridges) | length > 0 }}"
+
+    - name: Locate the trunk parent interface
+      ansible.builtin.set_fact:
+        _trunk: "{{ _ifaces | selectattr('name', 'equalto', truenas_vm_trunk_parent) | list }}"
+
+    - name: Assert the trunk parent exists and has link (cable present)
+      ansible.builtin.assert:
+        that:
+          - _trunk | length == 1
+          - _trunk[0].state.link_state == 'LINK_STATE_UP'
+        fail_msg: >-
+          {{ truenas_vm_trunk_parent }} is missing or has no link — cable it to
+          the tagged switch trunk port (crs317 sfp-sfpplus10) and confirm the
+          switch config is deployed before running this play.
+
+    - name: Assert the trunk parent is a bare L2 port (no IPs, no DHCP/SLAAC)
+      ansible.builtin.assert:
+        that:
+          - _trunk[0].aliases | length == 0
+          - not _trunk[0].ipv4_dhcp
+          - not _trunk[0].ipv6_auto
+        fail_msg: >-
+          {{ truenas_vm_trunk_parent }} has IP configuration — refusing. This
+          play only manages a bare tagged trunk; move or remove the IPs first.
+
+    - name: Refuse to run with pending uncommitted interface changes
+      ansible.builtin.command:
+        argv: [midclt, call, interface.has_pending_changes]
+      register: _pending
+      changed_when: false
+      failed_when: _pending.stdout | trim != 'false'
+      when: _changes_needed
+
+    - name: Stage VLAN sub-interfaces on the trunk
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - interface.create
+          - >-
+            {{ {'name': item.vlan_name,
+                'type': 'VLAN',
+                'description': 'VM trunk VLAN ' ~ item.vlan_tag
+                               ~ ' (' ~ truenas_vm_trunk_parent ~ ')',
+                'vlan_parent_interface': truenas_vm_trunk_parent,
+                'vlan_tag': item.vlan_tag} | to_json }}
+      loop: "{{ _missing_vlans }}"
+      loop_control:
+        label: "{{ item.vlan_name }}"
+      changed_when: true
+
+    - name: Stage IP-less bridges enslaving the VLAN sub-interfaces
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - interface.create
+          - >-
+            {{ {'name': item.name,
+                'type': 'BRIDGE',
+                'description': 'VM bridge (tagged VLAN ' ~ item.vlan_tag
+                               ~ ' via ' ~ truenas_vm_trunk_parent ~ ', no host IPs)',
+                'bridge_members': [item.vlan_name],
+                'stp': false} | to_json }}
+      loop: "{{ _missing_bridges }}"
+      loop_control:
+        label: "{{ item.name }}"
+      changed_when: true
+
+    - name: Commit staged changes (no host IPs move — SSH stays up)
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - interface.commit
+          - '{"rollback": true, "checkin_timeout": 60}'
+      changed_when: true
+      when: _changes_needed
+
+    - name: Query interfaces after commit
+      ansible.builtin.command:
+        argv: [midclt, call, interface.query]
+      register: _postquery
+      changed_when: false
+
+    - name: Assert every VM bridge and VLAN sub-interface exists
+      vars:
+        _post_names: "{{ _postquery.stdout | from_json | map(attribute='name') | list }}"
+      ansible.builtin.assert:
+        that:
+          - item.name in _post_names
+          - item.vlan_name in _post_names
+        fail_msg: >-
+          {{ item.name }}/{{ item.vlan_name }} missing after commit — aborting
+          before checkin so the pending change auto-rolls back at
+          checkin_timeout; check `midclt call interface.query` and the
+          middleware log.
+      loop: "{{ truenas_vm_bridges }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Check in — persist the verified changes
+      ansible.builtin.command:
+        argv: [midclt, call, interface.checkin]
+      changed_when: true
+      when: _changes_needed
+
+    - name: Report next steps
+      ansible.builtin.debug:
+        msg: >-
+          Tagged VM bridge(s) ready:
+          {{ truenas_vm_bridges | map(attribute='name') | list }}. Next: run
+          configure_vms.yaml. The L2 path proves itself end-to-end when a VM
+          PXE-boots (DHCP from rb5009 arrives via the trunk).

--- a/playbooks/truenas/configure_vms.yaml
+++ b/playbooks/truenas/configure_vms.yaml
@@ -1,0 +1,101 @@
+---
+# Declaratively create KVM virtual machines on TrueNAS 25.10+ ("Virtual
+# Machines" / vm.* API) from the truenas_vms list, via midclt over SSH
+# (arensb.truenas has no vm modules).
+#
+# Create-only: VMs are matched by name; existing ones are reported and
+# left untouched (no cpu/memory/device reconciliation). Each pending VM
+# is created atomically by tasks/truenas_vm_present.yml — on a mid-chain
+# device failure the partial VM is deleted so a re-run can retry. VMs are
+# NOT started — first boot is operator-attended: start the VM, open its
+# display console, and pick "ocp-node" in the iPXE pin menu to install
+# RHCOS (the pin defaults to "Boot from disk" after 30s on later boots).
+#
+# Devices per VM (boot order):
+#   1000  NIC     VIRTIO, fixed MAC, attached to truenas_vm_bridge — netboot first
+#   1001  DISK    VIRTIO zvol (created when absent)
+#   1002  DISPLAY console via the TrueNAS UI
+#
+# Variables (igou-inventory group_vars/truenas.yml):
+#   truenas_vm_bridge — host bridge for VM NICs (see configure_vm_bridge.yaml)
+#   truenas_vms       — list of {name, description?, vcpus, cores, threads,
+#                        memory_mib, bootloader?, autostart?, cpu_mode?, mac,
+#                        disk_zvol, disk_gib}
+
+- name: Configure KVM virtual machines on TrueNAS
+  hosts: truenas
+  gather_facts: false
+  become: false
+
+  tasks:
+
+    - name: Assert a VM list is defined
+      ansible.builtin.assert:
+        that: truenas_vms | default([]) | length > 0
+        fail_msg: truenas_vms is empty — define VMs in group_vars/truenas.yml
+
+    - name: Query network interfaces
+      ansible.builtin.command:
+        argv: [midclt, call, interface.query]
+      register: _ifquery
+      changed_when: false
+
+    - name: Assert the VM bridge exists
+      ansible.builtin.assert:
+        that: truenas_vm_bridge in (_ifquery.stdout | from_json | map(attribute='name') | list)
+        fail_msg: >-
+          {{ truenas_vm_bridge }} does not exist — run
+          playbooks/truenas/configure_vm_bridge.yaml first.
+
+    - name: Query existing VMs
+      ansible.builtin.command:
+        argv: [midclt, call, vm.query]
+      register: _vmquery
+      changed_when: false
+
+    - name: Index existing VM names
+      ansible.builtin.set_fact:
+        _existing_vms: "{{ _vmquery.stdout | from_json | map(attribute='name') | list }}"
+
+    - name: Split VM list into pending and existing
+      ansible.builtin.set_fact:
+        _pending_vms: "{{ truenas_vms | rejectattr('name', 'in', _existing_vms) | list }}"
+
+    - name: Report VMs already present (left untouched)
+      ansible.builtin.debug:
+        msg: "{{ truenas_vms | map(attribute='name') | select('in', _existing_vms) | list }}"
+
+    - name: Query existing zvols backing pending VM disks
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - pool.dataset.query
+          - >-
+            {{ [['id', 'in', _pending_vms | map(attribute='disk_zvol') | list],
+                ['type', '=', 'VOLUME']] | to_json }}
+      register: _zvolquery
+      changed_when: false
+      when: _pending_vms | length > 0
+
+    - name: Index existing zvols
+      ansible.builtin.set_fact:
+        _existing_zvols: >-
+          {{ (_zvolquery.stdout | default('[]')) | from_json
+             | map(attribute='id') | list }}
+
+    - name: Create pending VMs with their devices (atomic per VM)
+      ansible.builtin.include_tasks: tasks/truenas_vm_present.yml
+      loop: "{{ _pending_vms }}"
+      loop_control:
+        loop_var: vm_def
+        label: "{{ vm_def.name }}"
+
+    - name: Report summary
+      ansible.builtin.debug:
+        msg: >-
+          Created: {{ _pending_vms | map(attribute='name') | list }};
+          already present:
+          {{ truenas_vms | map(attribute='name') | select('in', _existing_vms) | list }}.
+          Start a new VM with `midclt call vm.start <id>` (or the UI) and select
+          "ocp-node" at its display console to install RHCOS.

--- a/playbooks/truenas/tasks/truenas_vm_present.yml
+++ b/playbooks/truenas/tasks/truenas_vm_present.yml
@@ -1,0 +1,98 @@
+---
+# Create one KVM VM and its devices as an atomic unit. Included per VM by
+# configure_vms.yaml (loop_var: vm_def; consumes _existing_zvols and
+# truenas_vm_bridge from the calling play).
+#
+# On any device-attach failure the just-created VM is deleted so a re-run
+# can retry cleanly — without this, the create-only reconciliation in
+# configure_vms.yaml would skip the half-created VM by name forever. A
+# zvol created by a failed run is deliberately kept: the retry attaches it
+# as an existing volume.
+
+- name: Create VM with its devices — {{ vm_def.name }}
+  block:
+
+    - name: Create VM {{ vm_def.name }}
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - vm.create
+          - >-
+            {{ {'name': vm_def.name,
+                'description': vm_def.description | default(''),
+                'vcpus': vm_def.vcpus,
+                'cores': vm_def.cores,
+                'threads': vm_def.threads,
+                'memory': vm_def.memory_mib,
+                'bootloader': vm_def.bootloader | default('UEFI'),
+                'cpu_mode': vm_def.cpu_mode | default('HOST-PASSTHROUGH'),
+                'enable_secure_boot': false,
+                'autostart': vm_def.autostart | default(true)} | to_json }}
+      register: _vm_create
+      changed_when: true
+
+    - name: Attach NIC (boot order 1000, chains the iPXE pin) to VM {{ vm_def.name }}
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - vm.device.create
+          - >-
+            {{ {'vm': (_vm_create.stdout | from_json).id,
+                'order': 1000,
+                'attributes': {'dtype': 'NIC',
+                               'type': 'VIRTIO',
+                               'nic_attach': truenas_vm_bridge,
+                               'mac': vm_def.mac}} | to_json }}
+      changed_when: true
+
+    - name: Attach boot disk (order 1001, zvol created when absent) to VM {{ vm_def.name }}
+      vars:
+        _disk_attrs: >-
+          {{ {'dtype': 'DISK', 'type': 'VIRTIO',
+              'path': '/dev/zvol/' ~ vm_def.disk_zvol}
+             if vm_def.disk_zvol in _existing_zvols
+             else {'dtype': 'DISK', 'type': 'VIRTIO', 'create_zvol': true,
+                   'zvol_name': vm_def.disk_zvol,
+                   'zvol_volsize': vm_def.disk_gib | int * 1073741824} }}
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - vm.device.create
+          - >-
+            {{ {'vm': (_vm_create.stdout | from_json).id,
+                'order': 1001,
+                'attributes': _disk_attrs} | to_json }}
+      changed_when: true
+
+    - name: Attach display console (order 1002) to VM {{ vm_def.name }}
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - vm.device.create
+          - >-
+            {{ {'vm': (_vm_create.stdout | from_json).id,
+                'order': 1002,
+                'attributes': {'dtype': 'DISPLAY'}} | to_json }}
+      changed_when: true
+
+  rescue:
+
+    - name: Delete partially-created VM {{ vm_def.name }}
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - vm.delete
+          - "{{ (_vm_create.stdout | from_json).id }}"
+      when: _vm_create.rc | default(1) == 0
+      changed_when: true
+
+    - name: Report unrecoverable creation failure for VM {{ vm_def.name }}
+      ansible.builtin.fail:
+        msg: >-
+          VM {{ vm_def.name }} failed mid-creation; the partial VM was deleted
+          so a re-run can retry. See the first failed task above for the cause.


### PR DESCRIPTION
## Summary

New `playbooks/truenas/` pair for running KVM VMs on TrueNAS 25.10 via `midclt` (no Ansible collection covers `vm.*`/`interface.*`). First consumer: the **truenas-w1** OpenShift worker VM (companion PR: igou-io/igou-inventory#105).

### configure_vm_bridge.yaml
- Creates tagged, **IP-less** VM bridges (`vlan9@enp1s0f0` → `br9`) on the spare trunk port — additive and zero-downtime; the primary interface, host IPs, and docker macvlans are never touched.
- Cable check brings the trunk up ephemerally and polls for link (an unconfigured port is admin-down at boot, so raw link_state can't distinguish "no cable" from "admin down"); middleware owns the up state after commit.
- Post-commit state is verified **inside** the `interface.commit` rollback window (assert failure aborts before `interface.checkin`, so TrueNAS auto-reverts).
- STP off: single-member edge bridge can't loop, and the STP learning delay can outlast an iPXE DHCP window.
- Converged re-runs still health-check trunk link + desired state.

### configure_vms.yaml + tasks/truenas_vm_present.yml
- Create-only reconciliation from `truenas_vms` group_vars; existing VMs reported, never mutated, never started (first boot is operator-attended PXE install).
- **Atomic per-VM creation**: create + NIC/disk/display in a block; rescue deletes the partial VM so re-runs can retry (a created zvol is kept and re-attached).
- Boot order: NIC (1000) before disk (1001) so every boot chains the rb5009 iPXE pin (defaults to local disk in 30s).

## Physical link (verified live 2026-07-02)

TrueNAS **enp1s0f0** ↔ crs317 **sfp-sfpplus13**: module recognized (1G fiber LC), link-ok, autoneg 1 Gbps full-duplex, server MAC learned on the port. 1G for now — swapping in 10G modules later needs no config change.

## Validation
- All midclt payloads validated against the **live TrueNAS 25.10.1** middleware schemas (`vm.create`, `vm.device.create` dtype-in-attributes, `interface.create` VLAN/BRIDGE fields, commit/checkin semantics).
- `ansible-playbook --syntax-check` + `ansible-lint --profile=production`: 0 failures / 0 warnings.
- Fable-model review against ansible-community/ai-forge rubrics (write-content CoP practices, ansible-zen, ansible-cop-review): all findings addressed (atomic create, verify-before-checkin, zvol type filter, var asserts, ipv6_auto gate, always-run health asserts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3nKd6vsaYn7mPFxfUJDXN