### PR TITLE
fix(truenas): live-test fixes — midclt Python bools + required display password

### DIFF
--- a/playbooks/truenas/configure_vm_bridge.yaml
+++ b/playbooks/truenas/configure_vm_bridge.yaml
@@ -126,7 +126,8 @@
         argv: [midclt, call, interface.has_pending_changes]
       register: _pending
       changed_when: false
-      failed_when: _pending.stdout | trim != 'false'
+      # midclt prints Python-style booleans here ("False"), not JSON
+      failed_when: _pending.stdout | trim | lower != 'false'
       when: _changes_needed
 
     - name: Stage VLAN sub-interfaces on the trunk

--- a/playbooks/truenas/tasks/truenas_vm_present.yml
+++ b/playbooks/truenas/tasks/truenas_vm_present.yml
@@ -67,7 +67,18 @@
                 'attributes': _disk_attrs} | to_json }}
       changed_when: true
 
+    # 25.10 requires a password on DISPLAY devices. Default: a random
+    # throwaway — the display binds to 127.0.0.1 (TrueNAS UI proxy) and
+    # an admin can read it back via `midclt call vm.device.query` if
+    # direct console auth is ever needed. Override with
+    # vm_def.display_password to pin one.
     - name: Attach display console (order 1002) to VM {{ vm_def.name }}
+      vars:
+        _display_password: >-
+          {{ vm_def.display_password
+             | default(lookup('ansible.builtin.password',
+                              '/dev/null length=24 chars=ascii_letters,digits')) }}
+      no_log: true
       ansible.builtin.command:
         argv:
           - midclt
@@ -76,7 +87,8 @@
           - >-
             {{ {'vm': (_vm_create.stdout | from_json).id,
                 'order': 1002,
-                'attributes': {'dtype': 'DISPLAY'}} | to_json }}
+                'attributes': {'dtype': 'DISPLAY',
+                               'password': _display_password}} | to_json }}
       changed_when: true
 
   rescue:


### PR DESCRIPTION
Fixes found running the merged #303 playbooks live against TrueNAS 25.10.1, validated end-to-end with a temporary CentOS Stream VM on br9 (DHCP on VLAN9 through the tagged trunk, VM→host CSI-portal hairpin 0.4ms, internet OK):

- `interface.has_pending_changes` prints Python-style `False` via midclt, not JSON `false` — compare case-insensitively.
- DISPLAY devices **require a password** on 25.10 (schema claims nullable; validation disagrees). Random throwaway by default (`no_log`, recoverable via `vm.device.query`, display binds 127.0.0.1); override with `vm_def.display_password`.

Bonus: the atomic create/rescue path proved itself — two real mid-chain failures each deleted the partial VM cleanly and the retry re-attached the kept zvol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3nKd6vsaYn7mPFxfUJDXN