### PR TITLE
feat(truenas): netboot fallback image device for VMs (NIC boot is impossible)

### DIFF
--- a/playbooks/truenas/configure_vms.yaml
+++ b/playbooks/truenas/configure_vms.yaml
@@ -16,6 +16,7 @@
 #   1002  DISPLAY console via the TrueNAS UI
 #   1003  NIC     VIRTIO, fixed MAC, attached to truenas_vm_bridge
 #   1004  RAW     optional netboot fallback image (netboot_image) — boot 2
+#   1005  CDROM   optional install ISO (iso, path under /mnt/) — boot 3
 #
 # NOTE (validated live on 25.10.1): the vm.* API cannot make a NIC a
 # boot device (middleware only writes libvirt boot entries for
@@ -28,10 +29,63 @@
 #   truenas_vm_bridge — host bridge for VM NICs (see configure_vm_bridge.yaml)
 #   truenas_vms       — list of {name, description?, vcpus, cores, threads,
 #                        memory_mib, bootloader?, autostart?, cpu_mode?, mac,
-#                        disk_zvol, disk_gib, netboot_image?,
+#                        disk_zvol, disk_gib, netboot_image?, iso?,
 #                        display_password?}
 #   truenas_vm_netboot_image_src — optional control-node path to the
 #                        netboot.xyz EFI disk image to stage onto the host
+#
+# ── Example invocations ────────────────────────────────────────────────
+#
+# Create every inventory-defined VM (truenas_vms in group_vars/truenas.yml,
+# e.g. truenasw1 with its netboot fallback image):
+#
+#   ansible-playbook playbooks/truenas/configure_vms.yaml \
+#     -i igou-inventory/inventory.yaml
+#
+# One-off VM that NETBOOTS via the fallback image (full chain: DHCP ->
+# rb5009 iPXE pin for its MAC -> menu/kickstart/installer). Add a
+# netboot_host_pins entry for the MAC in group_vars/all/netboot.yml and
+# deploy it (deploy_assets.yml) or the VM lands in the unpinned fallback
+# menu. Extra-vars REPLACE truenas_vms, so only the VMs listed here are
+# considered (existing ones are never touched):
+#
+#   cat > /tmp/vm.yml <<'VMEOF'
+#   truenas_vms:
+#     - name: nettest1                 # alphanumeric only
+#       vcpus: 1
+#       cores: 2
+#       threads: 1
+#       memory_mib: 4096
+#       mac: "52:54:00:0A:09:70"
+#       disk_zvol: ssd/vms/nettest1-root
+#       disk_gib: 20
+#       netboot_image: /mnt/ssd/vms/images/netboot.xyz.efi.dsk
+#   VMEOF
+#   ansible-playbook playbooks/truenas/configure_vms.yaml \
+#     -i igou-inventory/inventory.yaml -e @/tmp/vm.yml
+#
+# One-off VM installing from a LOCAL LINUX ISO already on the host
+# (blank disk boots the ISO; after install the disk boots first and the
+# ISO remains as inert fallback media):
+#
+#   cat > /tmp/vm.yml <<'VMEOF'
+#   truenas_vms:
+#     - name: isotest1
+#       vcpus: 1
+#       cores: 2
+#       threads: 1
+#       memory_mib: 4096
+#       mac: "52:54:00:0A:09:71"
+#       disk_zvol: ssd/vms/isotest1-root
+#       disk_gib: 20
+#       iso: /mnt/ssd/vms/images/CentOS-Stream-10-latest-x86_64-dvd1.iso
+#   VMEOF
+#   ansible-playbook playbooks/truenas/configure_vms.yaml \
+#     -i igou-inventory/inventory.yaml -e @/tmp/vm.yml
+#
+# VMs are never started by this play. Start one with
+# `midclt call vm.start <id>` (or the UI) and use the display console
+# for any interactive install.
 
 - name: Configure KVM virtual machines on TrueNAS
   hosts: truenas

--- a/playbooks/truenas/configure_vms.yaml
+++ b/playbooks/truenas/configure_vms.yaml
@@ -11,16 +11,27 @@
 # display console, and pick "ocp-node" in the iPXE pin menu to install
 # RHCOS (the pin defaults to "Boot from disk" after 30s on later boots).
 #
-# Devices per VM (boot order):
-#   1000  NIC     VIRTIO, fixed MAC, attached to truenas_vm_bridge — netboot first
-#   1001  DISK    VIRTIO zvol (created when absent)
+# Devices per VM:
+#   1001  DISK    VIRTIO zvol (created when absent) — boot 1
 #   1002  DISPLAY console via the TrueNAS UI
+#   1003  NIC     VIRTIO, fixed MAC, attached to truenas_vm_bridge
+#   1004  RAW     optional netboot fallback image (netboot_image) — boot 2
+#
+# NOTE (validated live on 25.10.1): the vm.* API cannot make a NIC a
+# boot device (middleware only writes libvirt boot entries for
+# CDROM/DISK/RAW), so netboot is delivered via the RAW fallback image:
+# blank disk -> netboot.xyz EFI image -> DHCP -> rb5009 TFTP pin. The
+# image is staged from the deploy_netboot_binaries build cache when
+# truenas_vm_netboot_image_src is set.
 #
 # Variables (igou-inventory group_vars/truenas.yml):
 #   truenas_vm_bridge — host bridge for VM NICs (see configure_vm_bridge.yaml)
 #   truenas_vms       — list of {name, description?, vcpus, cores, threads,
 #                        memory_mib, bootloader?, autostart?, cpu_mode?, mac,
-#                        disk_zvol, disk_gib}
+#                        disk_zvol, disk_gib, netboot_image?,
+#                        display_password?}
+#   truenas_vm_netboot_image_src — optional control-node path to the
+#                        netboot.xyz EFI disk image to stage onto the host
 
 - name: Configure KVM virtual machines on TrueNAS
   hosts: truenas
@@ -56,6 +67,31 @@
     - name: Index existing VM names
       ansible.builtin.set_fact:
         _existing_vms: "{{ _vmquery.stdout | from_json | map(attribute='name') | list }}"
+
+    - name: Stage netboot fallback images referenced by VM definitions
+      when:
+        - truenas_vm_netboot_image_src is defined
+        - truenas_vms | selectattr('netboot_image', 'defined') | list | length > 0
+      become: true
+      ansible.builtin.copy:
+        src: "{{ truenas_vm_netboot_image_src }}"
+        dest: "{{ item }}"
+        mode: '0644'
+      loop: >-
+        {{ truenas_vms | selectattr('netboot_image', 'defined')
+           | map(attribute='netboot_image') | unique | list }}
+
+    - name: Assert netboot fallback images exist on the host
+      vars:
+        _image_paths: >-
+          {{ truenas_vms | selectattr('netboot_image', 'defined')
+             | map(attribute='netboot_image') | unique | list }}
+      ansible.builtin.command:
+        argv: [test, -f, "{{ item }}"]
+      loop: "{{ _image_paths }}"
+      changed_when: false
+      register: _netboot_image_stat
+      failed_when: _netboot_image_stat.rc != 0
 
     - name: Split VM list into pending and existing
       ansible.builtin.set_fact:

--- a/playbooks/truenas/configure_vms.yaml
+++ b/playbooks/truenas/configure_vms.yaml
@@ -18,12 +18,22 @@
 #   1004  RAW     optional netboot fallback image (netboot_image) — boot 2
 #   1005  CDROM   optional install ISO (iso, path under /mnt/) — boot 3
 #
-# NOTE (validated live on 25.10.1): the vm.* API cannot make a NIC a
-# boot device (middleware only writes libvirt boot entries for
-# CDROM/DISK/RAW), so netboot is delivered via the RAW fallback image:
-# blank disk -> netboot.xyz EFI image -> DHCP -> rb5009 TFTP pin. The
-# image is staged from the deploy_netboot_binaries build cache when
-# truenas_vm_netboot_image_src is set.
+# ── Why a local netboot image instead of PXE ──────────────────────────
+# (validated live on 25.10.1) The vm.* API cannot make a NIC a boot
+# device: middleware only writes libvirt <boot order> for CDROM/DISK/RAW
+# (middlewared/plugins/vm/devices/{cdrom,storage_devices}.py), so the
+# VM firmware never runs the NIC's PXE path at all and falls to the
+# UEFI shell. On a physical host the PXE ROM would DHCP and download
+# netboot.xyz.efi from rb5009's TFTP; the RAW netboot_image is a local
+# copy of that SAME custom binary (same deploy_netboot_binaries build
+# artifact, wrapped in a bootable FAT image) standing in for the
+# un-runnable PXE ROM. From its first instruction onward the flow is
+# identical to physical netboot: DHCP against rb5009 -> next-server ->
+# chain tftp://rb5009/MAC-<hex>.ipxe -> pin/menu/installer. Only the
+# initial binary is sourced locally; every decision still lives on
+# rb5009 + the public nginx, and the copy task re-syncs the image from
+# the build cache (truenas_vm_netboot_image_src) on every run, so
+# rebuilding the binaries keeps VM and TFTP copies in lockstep.
 #
 # Variables (igou-inventory group_vars/truenas.yml):
 #   truenas_vm_bridge — host bridge for VM NICs (see configure_vm_bridge.yaml)

--- a/playbooks/truenas/tasks/truenas_vm_present.yml
+++ b/playbooks/truenas/tasks/truenas_vm_present.yml
@@ -32,7 +32,7 @@
       register: _vm_create
       changed_when: true
 
-    - name: Attach NIC (boot order 1000, chains the iPXE pin) to VM {{ vm_def.name }}
+    - name: Attach NIC (order 1003; not a boot device — see netboot note below) to VM {{ vm_def.name }}
       ansible.builtin.command:
         argv:
           - midclt
@@ -40,7 +40,7 @@
           - vm.device.create
           - >-
             {{ {'vm': (_vm_create.stdout | from_json).id,
-                'order': 1000,
+                'order': 1003,
                 'attributes': {'dtype': 'NIC',
                                'type': 'VIRTIO',
                                'nic_attach': truenas_vm_bridge,
@@ -89,6 +89,31 @@
                 'order': 1002,
                 'attributes': {'dtype': 'DISPLAY',
                                'password': _display_password}} | to_json }}
+      changed_when: true
+
+    # TrueNAS middleware only emits libvirt boot entries for disk-family
+    # devices (CDROM/DISK/RAW) — a NIC can never be a boot device, so
+    # "PXE-first" is impossible on the vm.* API. Instead, this RAW device
+    # (the custom netboot.xyz EFI disk image built by
+    # playbooks/routeros/deploy_netboot_binaries.yml) is attached AFTER
+    # the zvol in boot order: a blank disk falls through to it, giving
+    # the exact physical netboot chain (DHCP -> rb5009 TFTP pin ->
+    # menu/installer); once an OS is installed the disk boots first and
+    # the image stays as a permanent reinstall fallback.
+    - name: Attach netboot fallback image (order 1004, boots only when the disk is not bootable) to VM {{ vm_def.name }}
+      when: vm_def.netboot_image is defined
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - vm.device.create
+          - >-
+            {{ {'vm': (_vm_create.stdout | from_json).id,
+                'order': 1004,
+                'attributes': {'dtype': 'RAW',
+                               'path': vm_def.netboot_image,
+                               'type': 'AHCI',
+                               'exists': true}} | to_json }}
       changed_when: true
 
   rescue:

--- a/playbooks/truenas/tasks/truenas_vm_present.yml
+++ b/playbooks/truenas/tasks/truenas_vm_present.yml
@@ -116,6 +116,24 @@
                                'exists': true}} | to_json }}
       changed_when: true
 
+    # Optional install ISO (CDROM gets a boot entry, unlike NICs). Sits
+    # last in boot order: a blank disk falls through netboot_image (if
+    # any) and then the ISO; once an OS is installed the disk boots
+    # first. Middleware requires the path to live under /mnt/.
+    - name: Attach install ISO (order 1005, boots only when earlier devices do not) to VM {{ vm_def.name }}
+      when: vm_def.iso is defined
+      ansible.builtin.command:
+        argv:
+          - midclt
+          - call
+          - vm.device.create
+          - >-
+            {{ {'vm': (_vm_create.stdout | from_json).id,
+                'order': 1005,
+                'attributes': {'dtype': 'CDROM',
+                               'path': vm_def.iso}} | to_json }}
+      changed_when: true
+
   rescue:
 
     - name: Delete partially-created VM {{ vm_def.name }}


### PR DESCRIPTION
## Why

Live netboot testing (full unattended CentOS Stream 10 kickstart install through the real chain: custom netboot.xyz binary → rb5009 TFTP pin → mirror + kickstart → Anaconda → reboot to disk) proved a hard platform constraint: **the TrueNAS `vm.*` API cannot make a NIC a boot device.** Middleware only emits libvirt `<boot order>` for CDROM/DISK/RAW devices (`middlewared/plugins/vm/devices/{cdrom,storage_devices}.py`), so the previous "NIC order 1000 = netboot first" design silently did nothing and the VM dropped to the UEFI shell.

## What (pattern validated end-to-end on the centostest VM)

Attach the custom **netboot.xyz EFI disk image** (`deploy_netboot_binaries` build artifact — FAT12 ESP with BOOTX64.EFI, carries the rb5009 pin autoexec) as a RAW device ordered **after** the zvol:

- boot 1 = zvol disk, boot 2 = netboot image
- blank disk → falls through to the full netboot chain (identical to physical PXE)
- installed disk → boots first; the image stays attached as a permanent reinstall fallback (same steady-state semantics as the hpg5/p330 physical pins)

Changes:
- `tasks/truenas_vm_present.yml`: optional `vm_def.netboot_image` RAW device (order 1004, `exists: true`); NIC moved to order 1003, misleading "boot order" naming dropped.
- `configure_vms.yaml`: stages the image from the control-node build cache (`truenas_vm_netboot_image_src`) and asserts presence on the host before creating VMs.

Companion PR: igou-io/igou-inventory `feat/truenas-vm-netboot-fallback` (truenasw1 config + helpernode pin fixes).

## Validation
- Pattern proven live: centostest reinstalled unattended via this exact device layout (DHCP on VLAN9 via the br9 tagged trunk, CSI-portal hairpin 0.4 ms post-install).
- `--syntax-check` + `ansible-lint --profile=production`: 0 failures / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3nKd6vsaYn7mPFxfUJDXN