### PR TITLE
feat: upsmonitor playbooks - NUT netserver + nut_exporter for both rack UPSes

### DIFF
--- a/playbooks/upsmonitor/converge.yml
+++ b/playbooks/upsmonitor/converge.yml
@@ -1,0 +1,34 @@
+---
+# Full convergence for the upsmonitor Raspberry Pi: linux baseline +
+# node_exporter + NUT netserver + nut_exporter.
+#
+#   ansible-playbook playbooks/upsmonitor/converge.yml \
+#     -i igou-inventory/inventory.yaml -l upsmonitor.igou.systems
+#
+# The imported linux plays target `ansible_limit | default('all')`, so an
+# unlimited run would baseline the entire fleet. The guard play below makes
+# a missing --limit a hard error instead.
+- name: Guard - refuse to run without an explicit limit
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Require --limit so imported fleet-wide plays stay scoped
+      ansible.builtin.assert:
+        that: ansible_limit is defined
+        fail_msg: >-
+          Run this playbook with an explicit limit, e.g.
+          -l upsmonitor.igou.systems. The imported baseline/node_exporter
+          plays default to 'all' without one.
+
+- name: Import linux baseline
+  ansible.builtin.import_playbook: ../linux/baseline.yaml
+
+- name: Import node_exporter deployment
+  ansible.builtin.import_playbook: ../linux/node_exporter.yaml
+
+- name: Import NUT netserver setup
+  ansible.builtin.import_playbook: setup-nut.yml
+
+- name: Import nut_exporter setup
+  ansible.builtin.import_playbook: setup-exporter.yml

--- a/playbooks/upsmonitor/setup-exporter.yml
+++ b/playbooks/upsmonitor/setup-exporter.yml
@@ -1,0 +1,133 @@
+---
+# Upsmonitor convergence - nut_exporter phase. Installs the DRuggeri
+# nut_exporter (prebuilt GitHub-release binary, sha256-verified) as a
+# hardened systemd service reading upsd on localhost.
+#
+# One exporter instance serves every UPS: Prometheus scrapes
+# /ups_metrics?ups=<name> once per UPS (see igou-openshift
+# components/user-workload-monitoring/exporters/upsmonitor). Direct-LAN
+# scrape model, so the listen address binds beyond localhost.
+#
+# battery.runtime is NOT in the exporter's default variable set - the
+# vars_enable default below adds it (the runtime alert depends on it).
+- name: Upsmonitor convergence - nut_exporter
+  hosts: "{{ ansible_limit | default('upsmonitor.igou.systems') }}"
+  become: true
+  gather_facts: true
+
+  vars:
+    # Effective values; inventory overrides the un-prefixed names (play vars
+    # outrank inventory, hence the default() merge pattern).
+    _nut_exporter_version: "{{ nut_exporter_version | default('3.3.0') }}"
+    _nut_exporter_listen_address: "{{ nut_exporter_listen_address | default('127.0.0.1:9199') }}"
+    _nut_exporter_vars_enable: >-
+      {{ nut_exporter_vars_enable | default([
+           'battery.charge',
+           'battery.runtime',
+           'battery.voltage',
+           'battery.voltage.nominal',
+           'input.voltage',
+           'input.voltage.nominal',
+           'input.frequency',
+           'output.voltage',
+           'ups.load',
+           'ups.realpower.nominal',
+           'ups.status',
+         ]) }}
+    _nut_exporter_arch: >-
+      {{ {'x86_64': 'linux-amd64',
+          'aarch64': 'linux-arm64',
+          'armv7l': 'linux-arm'}[ansible_architecture] }}
+    _nut_exporter_asset: "nut_exporter-v{{ _nut_exporter_version }}-{{ _nut_exporter_arch }}"
+    _nut_exporter_base: "https://github.com/DRuggeri/nut_exporter/releases/download/v{{ _nut_exporter_version }}"
+    _nut_exporter_dist: /opt/nut_exporter
+
+  tasks:
+    - name: Create the nut_exporter system user
+      ansible.builtin.user:
+        name: nut_exporter
+        system: true
+        shell: /usr/sbin/nologin
+        create_home: false
+        state: present
+
+    - name: Create the release cache directory
+      ansible.builtin.file:
+        path: "{{ _nut_exporter_dist }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    # Versioned filename: bumping nut_exporter_version downloads the new
+    # asset and refreshes /usr/local/bin on the next run.
+    - name: Download the nut_exporter release binary (sha256-verified)
+      ansible.builtin.get_url:
+        url: "{{ _nut_exporter_base }}/{{ _nut_exporter_asset }}"
+        dest: "{{ _nut_exporter_dist }}/{{ _nut_exporter_asset }}"
+        checksum: "sha256:{{ _nut_exporter_base }}/nut_exporter_{{ _nut_exporter_version }}_checksums.txt"
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Install nut_exporter into /usr/local/bin
+      ansible.builtin.copy:
+        src: "{{ _nut_exporter_dist }}/{{ _nut_exporter_asset }}"
+        dest: /usr/local/bin/nut_exporter
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0755"
+      notify: Restart nut_exporter
+
+    - name: Template the nut_exporter systemd unit
+      ansible.builtin.template:
+        src: templates/nut_exporter.service.j2
+        dest: /etc/systemd/system/nut_exporter.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart nut_exporter
+
+    - name: Enable and start nut_exporter
+      ansible.builtin.systemd_service:
+        name: nut_exporter.service
+        enabled: true
+        state: started
+        daemon_reload: true
+
+    - name: Apply any pending exporter restart before verifying
+      ansible.builtin.meta: flush_handlers
+
+    # Verification scrapes loopback; a wildcard or LAN bind still answers
+    # on 127.0.0.1 unless pinned to a foreign address.
+    - name: Scrape the exporter once per UPS
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ _nut_exporter_listen_address | regex_replace('^.*:', '') }}/ups_metrics?ups={{ item.name }}"
+        return_content: true
+      loop: "{{ nut_upses }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: setup_exporter_scrape
+      # The exporter needs a beat after restart to reach upsd.
+      retries: 5
+      delay: 3
+      until: >-
+        setup_exporter_scrape.status == 200 and
+        'network_ups_tools_ups_status' in setup_exporter_scrape.content
+
+    - name: Report scraped status flags per UPS
+      ansible.builtin.debug:
+        msg: >-
+          {{ item.item.name }} active status flags:
+          {{ item.content | regex_findall('network_ups_tools_ups_status\{flag="(OL|OB|LB|RB|FSD)"\} 1') }}
+      loop: "{{ setup_exporter_scrape.results }}"
+      loop_control:
+        label: "{{ item.item.name }}"
+
+  handlers:
+    - name: Restart nut_exporter
+      ansible.builtin.systemd_service:
+        name: nut_exporter.service
+        state: restarted
+        daemon_reload: true

--- a/playbooks/upsmonitor/setup-nut.yml
+++ b/playbooks/upsmonitor/setup-nut.yml
@@ -1,0 +1,198 @@
+---
+# Upsmonitor convergence - NUT netserver phase. Installs Network UPS Tools
+# and drives BOTH rack UPSes (APC + CyberPower) over USB HID from one Pi,
+# one nut-driver@<ups> instance per UPS, disambiguated by USB vendorid.
+#
+# MODE=netserver: upsd listens on the LAN (VLAN9) so the DRuggeri
+# nut_exporter (setup-exporter.yml) and, later, upsmon netclients on other
+# servers (TrueNAS, OpenShift nodes) can read UPS state. The Pi itself runs
+# upsmon as `primary` and powers off cleanly when the last UPS goes
+# critical.
+#
+# UPS definitions come from inventory (igou-inventory
+# host_vars/upsmonitor.igou.systems.yml, `nut_upses`). upsd account
+# passwords come from 1Password (op://claude/upsmonitor-nut) at run time —
+# never stored in the repo.
+- name: Upsmonitor convergence - NUT netserver
+  hosts: "{{ ansible_limit | default('upsmonitor.igou.systems') }}"
+  become: true
+  gather_facts: true
+
+  vars:
+    # Effective values; inventory overrides the un-prefixed names. Play vars
+    # outrank inventory, so defaults are merged here via default() instead
+    # of defining the public names as play vars.
+    _nut_listen: "{{ nut_listen | default([{'address': '0.0.0.0', 'port': 3493}]) }}"
+    _nut_pollinterval: "{{ nut_pollinterval | default(5) }}"
+    # upsd account passwords, resolved from 1Password on the controller.
+    _nut_upsmon_password: >-
+      {{ lookup('community.general.onepassword',
+         nut_op_item | default('upsmonitor-nut'),
+         field='upsmon_password', vault=nut_op_vault | default('claude')) }}
+    _nut_monitor_password: >-
+      {{ lookup('community.general.onepassword',
+         nut_op_item | default('upsmonitor-nut'),
+         field='monitor_password', vault=nut_op_vault | default('claude')) }}
+
+  tasks:
+    - name: Assert UPS definitions are present in inventory
+      ansible.builtin.assert:
+        that:
+          - nut_upses is defined
+          - nut_upses | length > 0
+        fail_msg: >-
+          nut_upses must be defined in inventory (see igou-inventory
+          host_vars/upsmonitor.igou.systems.yml).
+
+    - name: Install NUT server and client
+      ansible.builtin.apt:
+        name:
+          - nut-server
+          - nut-client
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+
+    # The nut-server package ships 62-nut-usbups.rules, but USB devices
+    # enumerated BEFORE the install keep their old root-only permissions and
+    # every driver start dies with "insufficient permissions". Re-apply the
+    # rules to already-present devices - no replug needed. Harmless no-op on
+    # an already-converged host.
+    - name: Re-apply udev rules to pre-existing USB devices
+      ansible.builtin.command: udevadm trigger --subsystem-match=usb --action=change
+      changed_when: false
+
+    - name: Set NUT mode to netserver
+      ansible.builtin.template:
+        src: templates/nut.conf.j2
+        dest: /etc/nut/nut.conf
+        owner: root
+        group: nut
+        mode: "0640"
+      notify:
+        - Resync NUT driver instances
+        - Restart NUT drivers
+        - Restart upsd
+        - Restart upsmon
+
+    - name: Define UPS driver instances (ups.conf)
+      ansible.builtin.template:
+        src: templates/ups.conf.j2
+        dest: /etc/nut/ups.conf
+        owner: root
+        group: nut
+        mode: "0640"
+      notify:
+        - Resync NUT driver instances
+        - Restart NUT drivers
+        - Restart upsd
+
+    - name: Configure upsd listeners (upsd.conf)
+      ansible.builtin.template:
+        src: templates/upsd.conf.j2
+        dest: /etc/nut/upsd.conf
+        owner: root
+        group: nut
+        mode: "0640"
+      notify:
+        - Restart upsd
+
+    - name: Configure upsd accounts (upsd.users)
+      ansible.builtin.template:
+        src: templates/upsd.users.j2
+        dest: /etc/nut/upsd.users
+        owner: root
+        group: nut
+        mode: "0640"
+      no_log: true  # rendered content carries the upsd passwords
+      notify:
+        - Restart upsd
+        - Restart upsmon
+
+    - name: Configure upsmon as primary (upsmon.conf)
+      ansible.builtin.template:
+        src: templates/upsmon.conf.j2
+        dest: /etc/nut/upsmon.conf
+        owner: root
+        group: nut
+        mode: "0640"
+      no_log: true  # MONITOR lines carry the upsmon password
+      notify:
+        - Restart upsmon
+
+    # The enumerator path unit re-runs nut-driver-enumerator.service whenever
+    # ups.conf changes, keeping nut-driver@<ups> instances in sync outside
+    # Ansible runs too.
+    - name: Enable the NUT driver enumerator path watch
+      ansible.builtin.systemd_service:
+        name: nut-driver-enumerator.path
+        enabled: true
+        state: started
+
+    - name: Enable NUT services at boot
+      ansible.builtin.systemd_service:
+        name: "{{ item }}"
+        enabled: true
+      loop:
+        - nut-server.service
+        - nut-monitor.service
+
+    - name: Apply any pending NUT restarts before verifying
+      ansible.builtin.meta: flush_handlers
+
+    - name: Ensure NUT services are running
+      ansible.builtin.systemd_service:
+        name: "{{ item }}"
+        state: started
+      loop:
+        - nut-server.service
+        - nut-monitor.service
+
+    - name: Wait for upsd to accept connections
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 3493
+        timeout: 30
+
+    - name: Query each UPS through upsd
+      ansible.builtin.command: "upsc {{ item.name }}@localhost ups.status"
+      loop: "{{ nut_upses }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: setup_nut_upsc
+      changed_when: false
+      # Drivers can take a few seconds to publish after a cold start.
+      retries: 5
+      delay: 5
+      until: setup_nut_upsc.rc == 0
+
+    - name: Report UPS statuses
+      ansible.builtin.debug:
+        msg: >-
+          {{ setup_nut_upsc.results
+             | map(attribute='item.name')
+             | zip(setup_nut_upsc.results | map(attribute='stdout'))
+             | map('join', ': ') | list }}
+
+  handlers:
+    # Handler order is definition order: regenerate driver instances from
+    # ups.conf first, then bounce drivers, then upsd, then upsmon.
+    - name: Resync NUT driver instances
+      ansible.builtin.systemd_service:
+        name: nut-driver-enumerator.service
+        state: restarted
+
+    - name: Restart NUT drivers
+      ansible.builtin.systemd_service:
+        name: nut-driver.target
+        state: restarted
+
+    - name: Restart upsd
+      ansible.builtin.systemd_service:
+        name: nut-server.service
+        state: restarted
+
+    - name: Restart upsmon
+      ansible.builtin.systemd_service:
+        name: nut-monitor.service
+        state: restarted

--- a/playbooks/upsmonitor/templates/nut.conf.j2
+++ b/playbooks/upsmonitor/templates/nut.conf.j2
@@ -1,0 +1,5 @@
+{{ ansible_managed | comment }}
+# netserver: standalone drivers + upsd serving the network, so the
+# nut_exporter and future upsmon netclients (TrueNAS, OpenShift nodes) can
+# read UPS state from this host.
+MODE=netserver

--- a/playbooks/upsmonitor/templates/nut_exporter.service.j2
+++ b/playbooks/upsmonitor/templates/nut_exporter.service.j2
@@ -1,0 +1,28 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Prometheus NUT exporter (DRuggeri)
+Wants=network-online.target
+After=network-online.target nut-server.service
+
+[Service]
+Type=simple
+User=nut_exporter
+Group=nut_exporter
+ExecStart=/usr/local/bin/nut_exporter \
+  --nut.server=127.0.0.1 \
+  --web.listen-address={{ _nut_exporter_listen_address }} \
+  --nut.vars_enable={{ _nut_exporter_vars_enable | join(',') }}
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=true
+LockPersonality=true
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/upsmonitor/templates/ups.conf.j2
+++ b/playbooks/upsmonitor/templates/ups.conf.j2
@@ -1,0 +1,32 @@
+{{ ansible_managed | comment }}
+# One section per USB UPS -> one nut-driver@<name> systemd instance.
+# Instances are matched to hardware by USB vendorid/productid (stable across
+# reboots, unlike bus/device numbers).
+maxretry = 3
+pollinterval = {{ _nut_pollinterval }}
+
+{% for ups in nut_upses %}
+[{{ ups.name }}]
+    driver = {{ ups.driver | default('usbhid-ups') }}
+    port = {{ ups.port | default('auto') }}
+    desc = "{{ ups.desc | default(ups.name) }}"
+{% if ups.vendorid is defined %}
+    vendorid = {{ ups.vendorid }}
+{% endif %}
+{% if ups.productid is defined %}
+    productid = {{ ups.productid }}
+{% endif %}
+{% if ups.serial is defined %}
+    serial = "{{ ups.serial }}"
+{% endif %}
+{% for flag in ups.flags | default([]) %}
+    {{ flag }}
+{% endfor %}
+{% for key, value in (ups.options | default({})).items() %}
+    {{ key }} = {{ value }}
+{% endfor %}
+{% for key, value in (ups.overrides | default({})).items() %}
+    override.{{ key }} = {{ value }}
+{% endfor %}
+
+{% endfor %}

--- a/playbooks/upsmonitor/templates/upsd.conf.j2
+++ b/playbooks/upsmonitor/templates/upsd.conf.j2
@@ -1,0 +1,4 @@
+{{ ansible_managed | comment }}
+{% for listen in _nut_listen %}
+LISTEN {{ listen.address }} {{ listen.port | default(3493) }}
+{% endfor %}

--- a/playbooks/upsmonitor/templates/upsd.users.j2
+++ b/playbooks/upsmonitor/templates/upsd.users.j2
@@ -1,0 +1,11 @@
+{{ ansible_managed | comment }}
+# Local upsmon (this Pi) - primary: may set FSD (forced shutdown).
+[upsmon]
+    password = {{ _nut_upsmon_password }}
+    upsmon primary
+
+# Remote upsmon netclients (TrueNAS, OpenShift nodes, ...) - secondary:
+# read state + honor FSD, no control. Also usable by read-only tooling.
+[monitor]
+    password = {{ _nut_monitor_password }}
+    upsmon secondary

--- a/playbooks/upsmonitor/templates/upsmon.conf.j2
+++ b/playbooks/upsmonitor/templates/upsmon.conf.j2
@@ -1,0 +1,22 @@
+{{ ansible_managed | comment }}
+# This Pi is the NUT primary for every monitored UPS. It is PoE-powered
+# (crs328), not fed by either UPS directly, so MINSUPPLIES 1 with both
+# UPSes at powervalue 1 means: shut the Pi down only when the LAST UPS
+# goes on-battery+low - at which point the switch feeding it is about to
+# die anyway.
+RUN_AS_USER nut
+
+{% for ups in nut_upses %}
+MONITOR {{ ups.name }}@localhost 1 upsmon {{ _nut_upsmon_password }} primary
+{% endfor %}
+
+MINSUPPLIES 1
+SHUTDOWNCMD "/sbin/shutdown -h +0"
+POLLFREQ 5
+POLLFREQALERT 5
+HOSTSYNC 15
+DEADTIME 15
+POWERDOWNFLAG /etc/killpower
+RBWARNTIME 43200
+NOCOMMWARNTIME 300
+FINALDELAY 5


### PR DESCRIPTION
New `playbooks/upsmonitor/` for the upsmonitor Pi (Raspberry Pi 4, 10.10.9.32): `converge.yml` chains the linux baseline + node_exporter, then `setup-nut.yml` (NUT 2.8.1 netserver, two usbhid-ups driver instances matched by USB vendorid - APC Back-UPS XS 1500M + CyberPower CP1500PFCRM2U with the PFC quirk set: ignorelb, charge/runtime overrides, offdelay 60, pollfreq 12) and `setup-exporter.yml` (DRuggeri nut_exporter v3.3.0 arm64, sha256-verified, hardened unit, one instance serving both UPSes on :9199 via `?ups=`).

upsd passwords resolve from `op://claude/upsmonitor-nut` at run time; upsmon runs as primary so the Pi powers off cleanly when the last UPS goes critical - and the same upsd is the hook for future secondary netclients (TrueNAS, OpenShift nodes) to shut down on outage.

**Live-validated on the Pi**: full converge green, both UPSes report OL through upsd and the exporter, idempotent re-run `changed=0`. Includes the first-install udev retrigger fix (devices enumerated pre-install keep root-only perms and every driver start fails).

Pairs with igou-inventory (host_vars) and igou-openshift (UWM scrape + alerts + Grafana dashboard) PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NQukXAsKR73sL4wRthdeX