### PR TITLE
nginx per-service basic auth + deny_paths; hermes ambient .netrc

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -68,6 +68,7 @@
         - "/home/hermes/agent-repos:/workspace:Z"
         - "/home/hermes/.hermes/cache/documents:/output:Z"
         - "/home/hermes/.gitconfig:{{ hermes_terminal_backend_container_home }}/.gitconfig:ro,Z"
+        - "/home/hermes/.netrc:{{ hermes_terminal_backend_container_home }}/.netrc:ro,Z"
         - "/home/hermes/.ssh:{{ hermes_terminal_backend_container_home }}/.ssh:ro,Z"
         - "/home/hermes/.kube:{{ hermes_terminal_backend_container_home }}/.kube:ro,Z"
         - "/home/hermes/.claude:{{ hermes_terminal_backend_container_home }}/.claude:Z"
@@ -97,6 +98,27 @@
       notify:
         - Restart the Hermes gateway user unit
         - Restart the Hermes dashboard user unit
+
+    # Ambient HTTP basic-auth for services agents scrape (`curl -n`; Python
+    # requests/httpx also honor .netrc). Declared as hermes_netrc_machines in
+    # group_vars/hermes.yml with 1Password lookups — the credential never
+    # appears in prompts, skills, or shell history. Always written (possibly
+    # empty) so the terminal-backend bind mount below has a valid source.
+    - name: Provision the hermes user .netrc
+      ansible.builtin.copy:
+        dest: "/home/{{ hermes_user }}/.netrc"
+        content: |-
+          # Managed by Ansible - playbooks/hermes/configure.yml
+          {% for m in hermes_netrc_machines | default([]) %}
+          machine {{ m.machine }}
+            login {{ m.login }}
+            password {{ m.password }}
+          {% endfor %}
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "0600"
+      become: true
+      no_log: true
 
     - name: Map legacy Hermes devenv image tag to terminal backend image tag
       ansible.builtin.set_fact:

--- a/playbooks/linux/templates/nginx-reverse-proxy.container.j2
+++ b/playbooks/linux/templates/nginx-reverse-proxy.container.j2
@@ -24,6 +24,10 @@ Network={{ linux_proxy_network | default('proxy') }}.network
 # playbooks/linux/acme_certificate_podman_secret.yaml - never as files on disk.
 Secret={{ linux_tls_fullchain_secret | default('igou-tls-fullchain') }},type=mount,target=/etc/nginx/ssl/fullchain.pem,mode=0444
 Secret={{ linux_tls_key_secret | default('igou-tls-key') }},type=mount,target=/etc/nginx/ssl/privkey.pem,mode=0400
+{% for secret in linux_nginx_extra_secrets | default([]) %}
+# Extra per-host secret mounts (htpasswd files etc.); see linux_nginx_extra_secrets.
+Secret={{ secret }}
+{% endfor %}
 # Reverse-proxy config templated onto the host (linux_podman_config_files).
 Volume=%h/containers/nginx/nginx.conf:/etc/nginx/nginx.conf:ro,Z
 

--- a/playbooks/linux/templates/nginx.conf.j2
+++ b/playbooks/linux/templates/nginx.conf.j2
@@ -82,6 +82,21 @@ http {
     ssl_certificate_key /etc/nginx/ssl/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers off;
+{% if svc.basic_auth is defined %}
+
+    # Whole-site HTTP basic auth. The htpasswd file is delivered as a podman
+    # secret mounted into the nginx container (linux_nginx_extra_secrets) -
+    # never as a file on the host, matching the TLS material convention.
+    auth_basic           "{{ svc.basic_auth.realm | default(svc.server_name) }}";
+    auth_basic_user_file {{ svc.basic_auth.user_file }};
+{% endif %}
+{% for path in svc.deny_paths | default([]) %}
+
+    # Denied at the edge regardless of any app-level auth.
+    location {{ path }} {
+      deny all;
+    }
+{% endfor %}
 
     location / {
       # Variable in proxy_pass forces runtime DNS re-resolution (see resolver


### PR DESCRIPTION
## What

Three template/playbook capabilities, all generic (no host specifics here — the igou-inventory companion PR declares the actual sandsoftime.igou.io usage):

- **`nginx.conf.j2`**: render a per-service `basic_auth` block (`realm` + `user_file`), and **implement `deny_paths`** — inventory has declared `deny_paths: [/api/admin/]` for sandsoftime.igou.io all along, but the template never rendered it, so the documented edge-deny of the admin API was a silent no-op. Fixed as part of this change.
- **`nginx-reverse-proxy.container.j2`**: render a `linux_nginx_extra_secrets` list as additional `Secret=` mounts, so htpasswd files are delivered as podman secrets exactly like the TLS material (never files on the host).
- **`hermes/configure.yml`**: provision `/home/hermes/.netrc` (0600) from a new `hermes_netrc_machines` var (1Password lookups, `no_log`), and bind-mount it read-only into the agent terminal-backend containers. Agents then authenticate to basic-auth-protected services with plain `curl -n` — the credential never appears in prompts, skill files, or shell history. The file is always written (possibly empty) so the bind mount has a valid source.

## Why

Putting sandsoftime.igou.io behind whole-site basic auth while keeping it trivially scrapeable by Hermes. Credential lives in 1Password (`sands-of-time-basic-auth` in the **claude** vault; already created).

## Companion PR

igou-io/igou-inventory — declares the vhost `basic_auth`, the `sands-of-time-htpasswd` podman secret, and the hermes netrc entry.

## Notes for review

- Rendered the nginx template locally with a sandsoftime-like service entry — `auth_basic`, the deny location, and the proxy block all render correctly; services without `basic_auth`/`deny_paths` render byte-identical to before.
- The 1P lookups reference `vault='claude'` — verify the AWX Connect token can read that vault (the item was created via the devcontainer's Connect token, which can).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y46xQZaWmUvoy9PRQWE2nA