### PR TITLE
k3s install: add CSI node prerequisites (open-iscsi, nfs-common)

### DIFF
--- a/playbooks/kubernetes/install-k3s-cluster.yml
+++ b/playbooks/kubernetes/install-k3s-cluster.yml
@@ -18,6 +18,26 @@
         - "'firewalld.service' in ansible_facts.services"
         - ansible_facts.services['firewalld.service'].status != 'not-found'
 
+    # democratic-csi node plugins exec iscsiadm / mount.nfs on the host,
+    # so every node needs the iSCSI initiator and NFS client installed
+    # (igou-kubernetes components/democratic-csi).
+    - name: Install CSI node prerequisites (iSCSI initiator, NFS client)
+      ansible.builtin.apt:
+        name:
+          - open-iscsi
+          - nfs-common
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_os_family == 'Debian'
+
+    - name: Enable and start iscsid
+      ansible.builtin.systemd:
+        name: iscsid
+        enabled: true
+        state: started
+      when: ansible_os_family == 'Debian'
+
 # Refresh op://awx/<cluster>-kubeconfig after every install/update. Skips
 # with a warning when OP_CONNECT_* env is absent (local runs w/o Connect).
 - name: Publish kubeconfig to 1Password


### PR DESCRIPTION
democratic-csi node plugins exec `iscsiadm` / `mount.nfs` on the host, so every k3s node needs the iSCSI initiator and NFS client installed and `iscsid` enabled. Debian-scoped (the rk8s boards run Armbian trixie); inert on other OS families.

Companion to igou-io/igou-kubernetes#879 (rk8s democratic-csi `freenas-api-*` wiring — follow-up 5 of the scoped-`csi`-account migration, igou-openshift#366/#377/#378).

Validated: `ansible-playbook --syntax-check` + `ansible-lint --profile=production` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsKPv4Gq1Ftbc3rsBAvbvv