### PR TITLE
fix: bootstrap-gitops Connect token field + bytes serialization

### DIFF
--- a/playbooks/openshift/hub-cluster/bootstrap_gitops.yaml
+++ b/playbooks/openshift/hub-cluster/bootstrap_gitops.yaml
@@ -88,8 +88,10 @@
                 annotations:
                   managed-by: ansible
               type: Opaque
-              stringData:
-                1password-credentials.json: "{{ lookup('community.general.onepassword_doc', 'ocp-connect-credentials', vault='ocp-connect-bootstrap', service_account_token=op_bootstrap_sa_token) }}"
+              # data + b64encode (not stringData): onepassword_doc returns bytes,
+              # which ansible-core >= 2.19 refuses to serialize to module args.
+              data:
+                1password-credentials.json: "{{ lookup('community.general.onepassword_doc', 'ocp-connect-credentials', vault='ocp-connect-bootstrap', service_account_token=op_bootstrap_sa_token) | b64encode }}"
           no_log: true
 
         - name: Seed the Connect access token Secret (for ESO)

--- a/playbooks/openshift/hub-cluster/bootstrap_gitops.yaml
+++ b/playbooks/openshift/hub-cluster/bootstrap_gitops.yaml
@@ -105,7 +105,10 @@
                   managed-by: ansible
               type: Opaque
               stringData:
-                token: "{{ lookup('community.general.onepassword', 'ocp-connect-token', field='token', vault='ocp-connect-bootstrap', service_account_token=op_bootstrap_sa_token) }}"
+                # The Connect JWT lives in the item's `credential` field (the `token`
+                # field holds an unrelated 83-char stub; verified 2026-07-03 during the
+                # cluster rebuild — the JWT has aud=com.1password.connect).
+                token: "{{ lookup('community.general.onepassword', 'ocp-connect-token', field='credential', vault='ocp-connect-bootstrap', service_account_token=op_bootstrap_sa_token) }}"
           no_log: true
 
         - name: Create Gitops ClusterRoleBinding


### PR DESCRIPTION
Two fixes to `playbooks/openshift/hub-cluster/bootstrap_gitops.yaml`, both found live during the 2026-07-03 ocp cluster rebuild when this playbook was used to re-bootstrap GitOps + the 1Password Connect/ESO secret chain from scratch:

1. **Connect JWT is in the `credential` field, not `token`.** `field='token'` on the `ocp-connect-token` item returns an 83-char stub; the real ES256 access token (aud=com.1password.connect) lives in the item's `credential` field. Seeding the stub makes every ClusterSecretStore fail auth.

2. **b64encode the credentials doc.** `community.general.onepassword_doc` returns bytes; ansible-core 2.19+ refuses to serialize bytes as module args (`Object of type bytes is not JSON serializable`). Switch the `op-credentials` Secret from `stringData` to `data` with `| b64encode`.

With both applied, the playbook brought up onepassword-connect (Valid stores), ESO, and the full app chain end-to-end on the reinstalled cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D96MwumLzMACaBTHNTRoov