### PR TITLE
fix(hermes): seed pip in uv venv + declarative on-VM Claude admin session

### DIFF
--- a/playbooks/hermes/admin-session.yml
+++ b/playbooks/hermes/admin-session.yml
@@ -1,0 +1,66 @@
+---
+- name: Hermes admin - persistent on-VM Claude Code session
+  # Stands up a durable, Remote-Control-enabled Claude Code session on the Hermes
+  # VM, running as the unprivileged `hermes` service user, for administering the
+  # agent from the terminal / phone / claude.ai. Survives disconnects AND reboots
+  # via a systemd --user unit + the hermes user's linger (enabled in setup-os).
+  #
+  # Prereqs (from the normal hermes convergence): the `hermes` user exists with
+  # linger enabled and the `claude` CLI on its login-shell PATH (setup-hermes
+  # installs it to ~/.local/bin; setup-os seeds the skel dotfiles that put
+  # ~/.local/bin on PATH). Run this after setup-hermes.
+  #
+  # Two things are intentionally NOT provisioned here because they are first-run,
+  # interactive, or secret — do them once by attaching to the session:
+  #     sudo -u hermes XDG_RUNTIME_DIR=/run/user/<uid> tmux attach -t {{ hermes_admin_session_name }}
+  #   1. Auth: run `/login` (claude.ai OAuth; account-bound, not a service secret).
+  #   2. First-run onboarding (theme + trust dialog) is a one-time keypress.
+  hosts: "{{ ansible_limit | default('hermes-hermes') }}"
+  become: true
+  vars:
+    hermes_user: hermes
+    hermes_home: /home/hermes
+    hermes_admin_session_name: hermes-admin
+    hermes_admin_rc_name: hermes admin
+    hermes_admin_workdir: "{{ hermes_home }}/.hermes"
+  tasks:
+    - name: Install tmux (persistent session multiplexer)
+      ansible.builtin.package:
+        name: tmux
+        state: present
+
+    - name: Resolve the hermes user's uid (for XDG_RUNTIME_DIR / the user bus)
+      ansible.builtin.command:
+        cmd: "id -u {{ hermes_user }}"
+      register: hermes_admin_uid
+      changed_when: false
+
+    - name: Ensure the hermes systemd --user unit directory exists
+      ansible.builtin.file:
+        path: "{{ hermes_home }}/.config/systemd/user"
+        state: directory
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "0755"
+
+    - name: Render the persistent Claude admin session systemd --user unit
+      ansible.builtin.template:
+        src: hermes-admin.service.j2
+        dest: "{{ hermes_home }}/.config/systemd/user/{{ hermes_admin_session_name }}.service"
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "0644"
+      register: hermes_admin_unit
+
+    - name: Enable and (re)start the Claude admin session
+      become: true
+      become_user: "{{ hermes_user }}"
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ hermes_admin_uid.stdout }}"
+        DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ hermes_admin_uid.stdout }}/bus"
+      ansible.builtin.systemd_service:
+        name: "{{ hermes_admin_session_name }}.service"
+        scope: user
+        enabled: true
+        daemon_reload: true
+        state: "{{ 'restarted' if hermes_admin_unit.changed else 'started' }}"

--- a/playbooks/hermes/setup-hermes.yml
+++ b/playbooks/hermes/setup-hermes.yml
@@ -137,6 +137,23 @@
       failed_when: hermes_on_path.rc != 0 or 'hermes' not in hermes_on_path.stdout
       when: hermes_install_agent | default(true) | bool
 
+    # The Hermes agent venv is created by `uv venv`, which does NOT seed pip.
+    # The ansible.builtin.pip task below drives the venv's own pip interpreter,
+    # so pip must exist inside the venv first — seed it with uv (the tool that
+    # built the venv; ships at ~/.hermes/bin/uv). Idempotent via `creates`.
+    # Without this, a fresh converge fails the anthropic install with
+    # "Unable to find pip in the virtualenv ... under any of these names: pip3, pip".
+    - name: Ensure pip exists in the uv-built Hermes agent venv
+      ansible.builtin.command:
+        cmd: >-
+          {{ hermes_state_mount }}/bin/uv pip install
+          --python {{ hermes_state_mount }}/hermes-agent/venv/bin/python pip
+        creates: "{{ hermes_state_mount }}/hermes-agent/venv/bin/pip"
+      become: true
+      become_user: "{{ hermes_user }}"
+      become_flags: '-i'
+      when: hermes_install_agent | default(true) | bool
+
     # The agent needs the `anthropic` client to talk to models served over the
     # Anthropic Messages API surface — which on opencode-go includes MiniMax and
     # Qwen. Without it the agent aborts at init ("The 'anthropic' package is

--- a/playbooks/hermes/templates/hermes-admin.service.j2
+++ b/playbooks/hermes/templates/hermes-admin.service.j2
@@ -1,0 +1,28 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Persistent Claude Code "{{ hermes_admin_rc_name }}" session (tmux, Remote Control) as the hermes user
+After=default.target
+
+[Service]
+# forking + KillMode=none: systemd tracks the daemonized tmux server as the main
+# PID and never reaps it. (Type=oneshot+RemainAfterExit was tried and reaped the
+# server's cgroup once ExecStart returned; systemd-run --service-type=forking
+# mis-tracked tmux's double-fork and also reaped it.)
+Type=forking
+KillMode=none
+Restart=on-failure
+RestartSec=3
+Environment=TERM=xterm-256color
+# Keep the tmux server alive even with no sessions/clients attached.
+ExecStartPre=-/usr/bin/tmux set-option -g exit-empty off
+# Window is an interactive login shell (=> ~/.local/bin on PATH so `claude`
+# resolves). send-keys then runs claude as a foreground *interactive* job (TTY =
+# the pane pty), which holds it at the /login screen instead of dropping to
+# non-interactive --print mode. --remote-control registers the session (named
+# "{{ hermes_admin_rc_name }}") with claude.ai for terminal/phone/web control.
+ExecStart=/usr/bin/tmux new-session -d -s {{ hermes_admin_session_name }} -x 220 -y 50 -c {{ hermes_admin_workdir }} /bin/bash -l
+ExecStartPost=/usr/bin/tmux send-keys -t {{ hermes_admin_session_name }} 'claude --remote-control "{{ hermes_admin_rc_name }}"' Enter
+ExecStop=/usr/bin/tmux kill-server
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Two gaps found while validating that the live hermes VM is fully reproducible from Ansible (nothing load-bearing done by hand), during a full re-converge (baseline → setup-os → setup-hermes → configure) from origin/main:

## 1. venv pip seed (real converge bug)
The Hermes agent venv is built by `uv venv`, which does **not** seed pip, but the *Ensure the anthropic client is in the Hermes agent venv* task uses `ansible.builtin.pip` (drives the venv's own pip) → a fresh converge fails: `Unable to find pip in the virtualenv ... under any of these names: pip3, pip`. Adds a preceding task seeding pip with **uv** (the tool that built the venv), idempotent via `creates: venv/bin/pip`.

**Validated:** uninstalled pip from the live venv (truly pip-less, like a fresh build) → converge re-seeded `pip 26.1.2` + installed `anthropic 0.116.0`, zero manual steps.

## 2. Declarative on-VM Claude admin session
The persistent, Remote-Control-enabled Claude Code session on the hermes VM had been set up by hand. Captured as `playbooks/hermes/admin-session.yml` (+ `templates/hermes-admin.service.j2`): tmux + a systemd `--user` unit (Type=forking, KillMode=none) holding `claude --remote-control "hermes admin"` in an interactive login-shell tmux window; durable across disconnects/reboots via linger. Auth (`/login`) and first-run onboarding remain interactive/out-of-band (account secret).

**Validated:** reproduces the live session (RC active, Claude Max).

yamllint + ansible-lint (production) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D96MwumLzMACaBTHNTRoov