### PR TITLE
feat(aap): bootstrap playbook to seed the Onepassword Connect credential

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 AAP_NAV_CFG := playbooks/aap/ansible-navigator.yml
 
-.PHONY: lint yamllint syntax-check _check-inv aap-configure aap-sync-credentials aap-sync-templates
+.PHONY: lint yamllint syntax-check _check-inv aap-configure aap-sync-credentials aap-sync-templates aap-bootstrap-connect
 
 lint:
 	ansible-lint --profile=production
@@ -38,3 +38,7 @@ aap-sync-credentials: _check-inv ## Sync only AAP credentials
 aap-sync-templates: _check-inv ## Sync only AAP job templates / projects / workflows / schedules
 	ANSIBLE_NAVIGATOR_CONFIG=$(AAP_NAV_CFG) \
 	  ansible-navigator run playbooks/aap/configure-aap-templates.yml
+
+aap-bootstrap-connect: _check-inv ## Seed the Onepassword Connect credential (needs OP_SERVICE_ACCOUNT_TOKEN)
+	ANSIBLE_NAVIGATOR_CONFIG=$(AAP_NAV_CFG) \
+	  ansible-navigator run playbooks/aap/bootstrap-connect-credential.yml

--- a/playbooks/aap/bootstrap-connect-credential.yml
+++ b/playbooks/aap/bootstrap-connect-credential.yml
@@ -1,0 +1,83 @@
+---
+# Bootstrap the AAP "Onepassword Connect" credential (the aap-entity Connect
+# token) — the chicken-and-egg seed that lets config-as-code resolve 1Password
+# lookups. This is the AAP analogue of playbooks/openshift/bootstrap_gitops.yaml:
+# it authenticates to 1Password with a SERVICE ACCOUNT token (not Connect, which
+# isn't usable until this credential exists), reads the aap-entity Connect token
+# from the ocp-connect-bootstrap vault, and creates/updates the AAP credential
+# via infra.aap_configuration (the same collection the CaC playbooks use).
+#
+# NOT config-as-code: the credential of type "Onepassword Connect" cannot be
+# created by a CaC run, because every CaC 1Password lookup needs this credential
+# to already exist. The play OVERRIDES `controller_credentials` with just this
+# one credential (the full list in group_vars needs Connect and can't run yet).
+# Run once, and after any entity-token rotation, before aap_configure_all.
+#
+# Prereqs:
+#   - A 1Password SERVICE ACCOUNT token that can READ both the
+#     ocp-connect-bootstrap vault (the connect token) AND the vault holding the
+#     `aap` item (AAP host/username/password — awx today, lab_aap post Phase-3):
+#         unset OP_CONNECT_HOST OP_CONNECT_TOKEN
+#         export OP_SERVICE_ACCOUNT_TOKEN=ops_...
+#   - The "Onepassword Connect" credential TYPE and the `igou` org already exist
+#     in AAP (they do, from CaC).
+#   - infra.aap_configuration + community.general come from the igou-aap-ee-rhel9
+#     execution environment (same as the other AAP CaC plays); no local install.
+#
+# Run locally via ansible-navigator (auth resolves from group_vars/aap/auth.yml
+# against the `aap` host; the nav config passes OP_SERVICE_ACCOUNT_TOKEN into the
+# EE). ANSIBLE_INVENTORY must point at igou-inventory/inventory.yaml:
+#   export OP_SERVICE_ACCOUNT_TOKEN=ops_...
+#   make aap-bootstrap-connect
+#   # equivalently:
+#   ANSIBLE_NAVIGATOR_CONFIG=playbooks/aap/ansible-navigator.yml \
+#     ansible-navigator run playbooks/aap/bootstrap-connect-credential.yml
+#
+# ⚠ CONFIRM these coordinates match your ocp-connect-bootstrap layout before the
+# first run (override with -e if different):
+#   -e op_connect_token_item=aap-connect-token -e op_connect_token_field=credential
+#
+- name: Seed the AAP Onepassword Connect credential from the bootstrap vault
+  hosts: aap
+  gather_facts: false
+
+  vars:
+    # --- 1Password source of the aap-entity Connect token (bootstrap vault) ---
+    op_bootstrap_vault: ocp-connect-bootstrap
+    op_connect_token_item: aap-connect-token          # ⚠ confirm item name
+    op_connect_token_field: credential                # ⚠ confirm field (ESO's ocp-connect-token uses `credential`, not `token`)
+    # Connect host the credential injects into jobs (OP_CONNECT_HOST). AAP EEs
+    # run in-cluster, so the internal service also works:
+    #   http://onepassword-connect.onepassword-connect.svc:8080
+    op_connect_host: https://onepassword-connect-onepassword-connect.apps.ocp.igou.systems
+
+    # Never echo secret inputs in job output.
+    controller_configuration_credentials_secure_logging: true
+
+    # Override the full CaC credential list with ONLY the Connect credential.
+    controller_credentials:
+      - name: onepassword-connect-token
+        credential_type: Onepassword Connect
+        organization: igou
+        update_secrets: true
+        inputs:
+          op_connect_host: "{{ op_connect_host }}"
+          op_connect_token: >-
+            {{ lookup('community.general.onepassword', op_connect_token_item,
+                      field=op_connect_token_field, vault=op_bootstrap_vault) }}
+
+  tasks:
+    - name: Assert a 1Password service-account token is present (not Connect)
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.env', 'OP_SERVICE_ACCOUNT_TOKEN') | length > 0
+        fail_msg: >-
+          OP_SERVICE_ACCOUNT_TOKEN is not set. Connect is not usable during this
+          bootstrap — export a service-account token that can read the
+          ocp-connect-bootstrap and the aap-auth vaults, and unset
+          OP_CONNECT_HOST/OP_CONNECT_TOKEN, before running.
+      run_once: true
+
+    - name: Seed the Onepassword Connect credential
+      ansible.builtin.include_role:
+        name: infra.aap_configuration.controller_credentials


### PR DESCRIPTION
AAP-phase prerequisite for the secrets vault migration. Adds a local bootstrap play that seeds the **Onepassword Connect** credential (the `aap`-entity Connect token) into AAP — the chicken-and-egg seed that lets config-as-code resolve 1Password lookups.

Mirrors `playbooks/openshift/bootstrap_gitops.yaml`: authenticates to 1Password with a **service-account token** (Connect is unusable until this credential exists), reads the aap-entity Connect token from the `ocp-connect-bootstrap` vault, and creates/updates the credential via **`infra.aap_configuration.controller_credentials`** — overriding `controller_credentials` with just this one entry (the full CaC list needs Connect and can't run yet). No raw API calls; uses the AAP configuration collection from the `igou-aap-ee-rhel9` EE.

Run:
```
export OP_SERVICE_ACCOUNT_TOKEN=ops_...   # can read ocp-connect-bootstrap + the aap-auth vault
make aap-bootstrap-connect                # ANSIBLE_INVENTORY -> igou-inventory/inventory.yaml
```

⚠ Confirm before first run (override with `-e`): `op_connect_token_item` (default `aap-connect-token`), `op_connect_token_field` (default `credential`), `op_connect_host`.

ansible-lint production profile passes. Adds a `make aap-bootstrap-connect` target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)