### PR TITLE
fix(aap): run connect-credential bootstrap on localhost (auth from lab_aap, not awx)

### DIFF
--- a/playbooks/aap/bootstrap-connect-credential.yml
+++ b/playbooks/aap/bootstrap-connect-credential.yml
@@ -7,16 +7,22 @@
 # from the ocp-connect-bootstrap vault, and creates/updates the AAP credential
 # via infra.aap_configuration (the same collection the CaC playbooks use).
 #
+# Runs on localhost ON PURPOSE — it does NOT target the `aap` inventory group, so
+# it never loads group_vars/aap/* (whose auth.yml reads the `aap` item from the
+# awx vault). AAP API auth is read here from lab_aap instead, which the bootstrap
+# service account can read (awx cannot be, by design). All AAP work still goes
+# through infra.aap_configuration.controller_credentials — no raw API calls.
+#
 # NOT config-as-code: the credential of type "Onepassword Connect" cannot be
 # created by a CaC run, because every CaC 1Password lookup needs this credential
 # to already exist. The play OVERRIDES `controller_credentials` with just this
-# one credential (the full list in group_vars needs Connect and can't run yet).
-# Run once, and after any entity-token rotation, before aap_configure_all.
+# one credential. Run once, and after any entity-token rotation, before
+# aap_configure_all.
 #
 # Prereqs:
 #   - A 1Password SERVICE ACCOUNT token that can READ both the
-#     ocp-connect-bootstrap vault (the connect token) AND the vault holding the
-#     `aap` item (AAP host/username/password — awx today, lab_aap post Phase-3):
+#     ocp-connect-bootstrap vault (the connect token) AND lab_aap (AAP
+#     host/username/password):
 #         unset OP_CONNECT_HOST OP_CONNECT_TOKEN
 #         export OP_SERVICE_ACCOUNT_TOKEN=ops_...
 #   - The "Onepassword Connect" credential TYPE and the `igou` org already exist
@@ -24,9 +30,8 @@
 #   - infra.aap_configuration + community.general come from the igou-aap-ee-rhel9
 #     execution environment (same as the other AAP CaC plays); no local install.
 #
-# Run locally via ansible-navigator (auth resolves from group_vars/aap/auth.yml
-# against the `aap` host; the nav config passes OP_SERVICE_ACCOUNT_TOKEN into the
-# EE). ANSIBLE_INVENTORY must point at igou-inventory/inventory.yaml:
+# Run locally via ansible-navigator (the nav config passes OP_SERVICE_ACCOUNT_TOKEN
+# into the EE):
 #   export OP_SERVICE_ACCOUNT_TOKEN=ops_...
 #   make aap-bootstrap-connect
 #   # equivalently:
@@ -38,7 +43,8 @@
 #   -e op_connect_token_item=aap-connect-token -e op_connect_token_field=credential
 #
 - name: Seed the AAP Onepassword Connect credential from the bootstrap vault
-  hosts: aap
+  hosts: localhost
+  connection: local
   gather_facts: false
 
   vars:
@@ -50,6 +56,13 @@
     # run in-cluster, so the internal service also works:
     #   http://onepassword-connect.onepassword-connect.svc:8080
     op_connect_host: https://onepassword-connect-onepassword-connect.apps.ocp.igou.systems
+
+    # --- AAP controller API auth (read from lab_aap via the same SA token) ---
+    aap_auth_vault: lab_aap
+    aap_hostname: "{{ lookup('community.general.onepassword', 'aap', field='host', vault=aap_auth_vault) }}"
+    aap_username: "{{ lookup('community.general.onepassword', 'aap', field='username', vault=aap_auth_vault) }}"
+    aap_password: "{{ lookup('community.general.onepassword', 'aap', field='password', vault=aap_auth_vault) }}"
+    aap_validate_certs: true
 
     # Never echo secret inputs in job output.
     controller_configuration_credentials_secure_logging: true
@@ -74,7 +87,7 @@
         fail_msg: >-
           OP_SERVICE_ACCOUNT_TOKEN is not set. Connect is not usable during this
           bootstrap — export a service-account token that can read the
-          ocp-connect-bootstrap and the aap-auth vaults, and unset
+          ocp-connect-bootstrap and lab_aap vaults, and unset
           OP_CONNECT_HOST/OP_CONNECT_TOKEN, before running.
       run_once: true
 


### PR DESCRIPTION
Follow-up to #320. The merged play used `hosts: aap`, which loads `group_vars/aap/auth.yml` — that reads the `aap` item from the **awx** vault, but the bootstrap service account is scoped to the new vaults and can't read awx (`"awx" isn't a vault in this account`). Run on **localhost** so the aap group_vars never load, and read AAP host/user/pass from **lab_aap**. Still driven by `infra.aap_configuration.controller_credentials`; no API calls. Lint production passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)