### PR TITLE
fix(rk8s): read/publish rk8s kubeconfig from lab_rk8s (gap-1)

### DIFF
--- a/playbooks/kubernetes/README.md
+++ b/playbooks/kubernetes/README.md
@@ -40,12 +40,12 @@ ansible-navigator run playbooks/kubernetes/install-k3s-cluster.yml \
 After install, the imported `publish-kubeconfig-1password.yaml` play
 slurps the kubeconfig from the control-plane node
 (`/etc/rancher/k3s/k3s.yaml`), rewrites the server URL to the control
-node's FQDN, and upserts it to `op://claude/<cluster>-kubeconfig` (the
+node's FQDN, and upserts it to `op://lab_rk8s/<cluster>-kubeconfig` (the
 `kubeconfig` field is base64 — decode on use). The devcontainer loads
 it with `use rk8s` (igou-devenv `envs/rk8s.env`). Needs
 `OP_CONNECT_HOST` and `OP_CONNECT_TOKEN` in the env (AAP injects them
 via the "Onepassword Connect" credential) and a token with write access
-to the claude vault; without the env the publish step skips with a
+to the lab_rk8s vault; without the env the publish step skips with a
 warning. Re-publish on demand via the `k3s_publish_kubeconfig` AAP
 template or by running the publish playbook directly.
 
@@ -65,7 +65,7 @@ playbook handles both via `geerlingguy.containerd` and an
 
 `bootstrap-gitops.yaml` bootstraps a cluster from igou-kubernetes'
 app-of-apps layout (see `docs/bootstrap.md` there). It pulls the
-kubeconfig from `op://claude/<cluster>-kubeconfig` (published by the
+kubeconfig from `op://lab_rk8s/<cluster>-kubeconfig` (published by the
 install playbook above), installs argocd, seeds the 1Password Connect
 token secret backing the `onepassword` ClusterSecretStore, and applies
 `clusters/<cluster>` — after which argocd self-manages the cluster.

--- a/playbooks/kubernetes/bootstrap-gitops.yaml
+++ b/playbooks/kubernetes/bootstrap-gitops.yaml
@@ -29,7 +29,7 @@
     gitops_repo: https://github.com/igou-io/igou-kubernetes.git
     gitops_ref: master
     gitops_cluster: internal
-    kubeconfig_op_vault: claude
+    kubeconfig_op_vault: lab_rk8s
     kubeconfig_op_item: rk8s-kubeconfig
     connect_secret_namespace: external-secrets
     connect_secret_name: onepassword-connect-token

--- a/playbooks/kubernetes/install-k3s-cluster.yml
+++ b/playbooks/kubernetes/install-k3s-cluster.yml
@@ -38,7 +38,7 @@
         state: started
       when: ansible_os_family == 'Debian'
 
-# Refresh op://awx/<cluster>-kubeconfig after every install/update. Skips
+# Refresh op://lab_rk8s/<cluster>-kubeconfig after every install/update. Skips
 # with a warning when OP_CONNECT_* env is absent (local runs w/o Connect).
 - name: Publish kubeconfig to 1Password
   ansible.builtin.import_playbook: publish-kubeconfig-1password.yaml

--- a/playbooks/kubernetes/publish-kubeconfig-1password.yaml
+++ b/playbooks/kubernetes/publish-kubeconfig-1password.yaml
@@ -10,7 +10,7 @@
 #
 # Default vault is `claude` so the devcontainer `use` command can load it:
 # igou-devenv envs/rk8s.env points KUBECONFIG_DATA at
-# op://claude/rk8s-kubeconfig/kubeconfig (`use rk8s`). The Connect token
+# op://lab_rk8s/rk8s-kubeconfig/kubeconfig (`use rk8s`). The Connect token
 # must have write access to that vault.
 #
 # Auth: OP_CONNECT_HOST + OP_CONNECT_TOKEN env, injected by the AAP


### PR DESCRIPTION
Companion to igou-inventory#137. Moves the rk8s kubeconfig from `claude` to **`lab_rk8s`** so the `aap` Connect token (claude read-only, lab_rk8s RW) can publish it.

- `bootstrap-gitops.yaml` `kubeconfig_op_vault: claude → lab_rk8s` (the rk8s GitOps bootstrap reads it)
- `install-k3s-cluster.yml` stale `op://awx` comment → `op://lab_rk8s`
- `publish-kubeconfig-1password.yaml` rk8s example comment + README → lab_rk8s. **Default `op_vault: claude` kept** — rk8s overrides via the JT `op_vault` extra_var (igou-inventory#137), so the generic publisher still defaults to claude for any other cluster.

Item pre-copied claude→lab_rk8s. Reader repoint for the devcontainer is igou-devenv (envs/rk8s.env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)