### PR TITLE
fix(rk8s): make kubeconfig publish idempotent (resolve item id)

### DIFF
--- a/playbooks/kubernetes/publish-kubeconfig-1password.yaml
+++ b/playbooks/kubernetes/publish-kubeconfig-1password.yaml
@@ -82,9 +82,31 @@
           register: _op_vaults
           no_log: true
 
+        - name: Set vault id
+          ansible.builtin.set_fact:
+            _op_vault_id: "{{ (_op_vaults.json | selectattr('name', '==', op_vault) | first).id }}"
+
+        # Resolve the existing item's id and pass it to generic_item, so the
+        # upsert updates that exact item rather than relying on the module's
+        # title matching (which creates a duplicate every run on some
+        # vault/token combos). No match -> id omitted -> item is created once.
+        - name: Look up existing kubeconfig item id (idempotent update)
+          ansible.builtin.uri:
+            url: "{{ _op_connect_host }}/v1/vaults/{{ _op_vault_id }}/items?filter={{ ('title eq \"' ~ op_item_name ~ '\"') | urlencode }}"
+            headers:
+              Authorization: "Bearer {{ lookup('ansible.builtin.env', 'OP_CONNECT_TOKEN') }}"
+          delegate_to: localhost
+          register: _op_existing
+          no_log: true
+
+        - name: Set existing item id (empty when none)
+          ansible.builtin.set_fact:
+            _existing_item_id: "{{ (_op_existing.json | first).id if (_op_existing.json | default([]) | length > 0) else '' }}"
+
         - name: "Upsert 1Password kubeconfig item {{ op_item_name }}"
           onepassword.connect.generic_item:
-            vault_id: "{{ (_op_vaults.json | selectattr('name', '==', op_vault) | first).id }}"
+            vault_id: "{{ _op_vault_id }}"
+            id: "{{ _existing_item_id if (_existing_item_id | length > 0) else omit }}"
             name: "{{ op_item_name }}"
             category: api_credential
             state: present


### PR DESCRIPTION
The `onepassword.connect.generic_item` upsert relied on the module's title matching, which fails to find the existing item on some vault/token combos (the `aap` token on `lab_rk8s`) and **creates a duplicate every run**. Resolve the existing item's `id` via the Connect REST API (same pattern already used for the vault id) and pass it to `generic_item` — updates that exact item; no match → `id` omitted → created once. yamllint + syntax-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)