### PR TITLE
fix(rk8s): generic_item item ref is uuid, not id

### DIFF
--- a/playbooks/kubernetes/publish-kubeconfig-1password.yaml
+++ b/playbooks/kubernetes/publish-kubeconfig-1password.yaml
@@ -106,7 +106,7 @@
         - name: "Upsert 1Password kubeconfig item {{ op_item_name }}"
           onepassword.connect.generic_item:
             vault_id: "{{ _op_vault_id }}"
-            id: "{{ _existing_item_id if (_existing_item_id | length > 0) else omit }}"
+            uuid: "{{ _existing_item_id if (_existing_item_id | length > 0) else omit }}"
             name: "{{ op_item_name }}"
             category: api_credential
             state: present


### PR DESCRIPTION
Follow-up to #326 — `onepassword.connect.generic_item` uses `uuid` to reference an existing item, not `id` (rejected as unsupported). Completes the idempotent kubeconfig publish.