### PR TITLE
fix(deploy_static_site): share Hugo output dir with :z SELinux label

### DIFF
--- a/playbooks/linux/deploy_static_site.yaml
+++ b/playbooks/linux/deploy_static_site.yaml
@@ -68,6 +68,13 @@
     # and the git task's force:true keeps tracked files canonical anyway. Hugo
     # writes the minified site over the served dir (--cleanDestinationDir
     # prunes files deleted from the source).
+    #
+    # SELinux label flags matter here: the output dir is ALSO bind-mounted by
+    # the nginx quadlet, so it is shared between two containers and MUST use the
+    # shared label ":z" (lowercase). ":Z" would stamp it with an MCS category
+    # private to this one-shot builder, which the (different) nginx container
+    # then cannot read - the site loads but every generated asset 404/403s.
+    # The source is builder-only, so its private ":Z" is correct.
     - name: Build the site with a one-shot Hugo container
       ansible.builtin.command:
         argv:
@@ -77,7 +84,7 @@
           - --volume
           - "{{ _src }}:/src:Z"
           - --volume
-          - "{{ _dest }}:/out:Z"
+          - "{{ _dest }}:/out:z"
           - "{{ _builder }}"
           - hugo
           - --minify


### PR DESCRIPTION
## Problem

igou.io renders **unstyled** in production: the HTML loads (200) but `/css/style.css` and the whole `/css/` subtree return **403 Forbidden** from nginx, while static content (HTML, `/home/` images) serves fine.

## Root cause

`deploy_static_site.yaml` builds the site in a one-shot Hugo container and mounted the **output** directory with `:Z`:

```
- "{{ _dest }}:/out:Z"
```

`:Z` applies a **private** SELinux MCS category scoped to *that* container. But `_dest` is the same directory the **nginx quadlet** bind-mounts to serve the site. As a different container, nginx cannot read files carrying the builder's private category → SELinux denies the read → **403** on generated assets. Locally everything looks correct because `hugo server` has no SELinux involved.

## Fix

Mount the shared output dir with the **shared** label `:z` (lowercase) so both the builder and nginx can read it. The `_src` mount stays `:Z` since it is builder-only. Added a comment explaining the distinction so it isn't reverted.

```diff
- - "{{ _dest }}:/out:Z"
+ - "{{ _dest }}:/out:z"
```

Because it's baked into the build, it self-heals on every deploy — no manual `restorecon` needed.

## Verification

- `ansible-lint` passes (production profile, 0 failures)
- YAML parses cleanly

## Follow-ups (not in this PR)

- The nginx quadlet in the **igou.io** repo (`deploy/igou-io.container`) should match `:z` for consistency and to avoid label thrash between container starts.
- To un-break the currently-live site, re-run this playbook with `-e site_force_build=true` (now mounts `:z`), or run `restorecon -Rv /srv/www/igou.io` on the nginx host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)