### PR TITLE
fix(deploy_static_site): make built site world-readable via handler

### DIFF
--- a/playbooks/linux/deploy_static_site.yaml
+++ b/playbooks/linux/deploy_static_site.yaml
@@ -98,3 +98,22 @@
       environment: "{{ _rootless_env }}"
       when: _checkout is changed or (site_force_build | default(false) | bool)
       changed_when: true
+      notify: Make the built site world-readable
+
+  handlers:
+    # The site nginx container and this build run as separate rootless
+    # containers, so "root" in the Hugo builder (host uid of _run_user) is a
+    # different subuid than nginx's worker. nginx can therefore only read the
+    # output if it is world-readable. Hugo emits page HTML 0644, but pipeline
+    # assets (css/style.css, processed images) can land 0600, which nginx then
+    # 403s - the site loads unstyled. a+rX adds read to every file and traverse
+    # (+x) to directories only, matching `chmod -R a+rX` idempotently. Runs as
+    # a handler: only fires when the build task above reported a change.
+    - name: Make the built site world-readable
+      ansible.builtin.file:
+        path: "{{ _dest }}"
+        recurse: true
+        mode: a+rX
+      become: true
+      become_user: "{{ _run_user }}"
+      environment: "{{ _rootless_env }}"


### PR DESCRIPTION
## Why

The `:z` SELinux label change in #331 was **not** the actual cause of the unstyled live site. AAP job templates ran the merged `:z` revision (`175cc44`) successfully — jobs **231** (manual) and **233** (scheduled) — yet `https://igou.io/css/style.css` still returns **403** while HTML pages return **200**.

An isolated 403 on a file that *exists*, while its siblings serve fine, rules out the tree-wide SELinux relabel (that would forbid everything uniformly). It points to **Unix mode bits**: the Hugo builder and the nginx site container are **two separate rootless containers**, so nginx's worker runs as a different subuid than the builder writes as, and can only read **world-readable** files. Hugo writes page HTML `0644` (→200) but pipeline assets (`css/style.css`, processed images) can land `0600` (→403).

## What

Add a **handler**, notified by the build task, that recursively applies `a+rX` to the output dir — read for all files, traverse (`+x`) for directories only. This is the idempotent, module-native equivalent of `chmod -R a+rX`.

```yaml
- name: Make the built site world-readable
  ansible.builtin.file:
    path: "{{ _dest }}"
    recurse: true
    mode: a+rX
```

Chose `ansible.builtin.file` over `command: chmod` so it reports changed correctly and is idempotent, and a **handler** (not a `when: … is changed` task) to satisfy ansible-lint's `no-handler` rule under the production profile.

## Verification

- Confirmed `mode: a+rX` semantics: dir `700→755`, file `600→644` (no execute on files), second run `changed: false`.
- `ansible-lint` passes (production profile, 0 failures).

## Rollout

After merge, run job template 19 (`deploy_static_site`) with `site_force_build=true` so the build fires and the handler runs. To un-break the currently-live site immediately without waiting: `chmod -R a+rX /home/igou/containers/igou-io/html` on the VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)