### PR TITLE
feat(windows): add playbooks/windows with 10 common Windows use cases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ Playbooks are organized by infrastructure domain under `playbooks/`:
 - `truenas/` - storage configuration
 - `terraform/` - plan/apply workflows
 - `linux/`, `rhel/` - system-level operations
+- `windows/` - Windows host automation (WinRM/SSH): app provisioning, users, updates, IIS, AD join
 - `aap/`, `awx/` - automation platform configuration
 - `armbian/` - ARM SBC fleet lifecycle (image build, provisioning, boot modes)
 - Root-level playbooks for common ops (system-update, system-reboot)

--- a/playbooks/windows/README.md
+++ b/playbooks/windows/README.md
@@ -1,0 +1,126 @@
+# Windows playbooks
+
+Common Windows automation use cases built on the current (2026) Windows
+collection landscape. Each playbook is deliberately small, heavily
+commented, and driven by a handful of `windows_*` variables — they are
+meant to be read as much as run.
+
+Full design rationale: see the pull request that introduced this
+directory (a local copy lives in `docs/superpowers/specs/`, which is
+not tracked in git).
+
+## Playbooks
+
+| Playbook | Use case |
+|---|---|
+| `ping_and_facts.yaml` | Connectivity smoke test + system summary. **Run this first.** |
+| `provision_test_machine.yaml` | Flagship: test user + configurable applications + RDP, for agent-driven app testing on OpenShift Virtualization VMs |
+| `install_applications.yaml` | Declarative application management with Chocolatey |
+| `manage_local_users.yaml` | Local users and groups |
+| `install_updates.yaml` | Windows Update with optional reboot-until-clean loop |
+| `configure_firewall.yaml` | Firewall profiles + declarative rule list |
+| `manage_services.yaml` | Service state and startup mode |
+| `create_scheduled_task.yaml` | Scheduled tasks (Windows cron) |
+| `deploy_iis_website.yaml` | IIS role + app pool + site + serve-check (Server editions only) |
+| `join_domain.yaml` | Active Directory join/leave via microsoft.ad |
+
+All plays target `hosts: "{{ ansible_limit | default('windows') }}"` — pass
+`-e ansible_limit=<host-or-group>` or create a `windows` group (below).
+
+## Collections used
+
+Pinned in the repo-root `requirements.yml`
+(`ansible-galaxy collection install -r requirements.yml`):
+
+| Collection | Used for | Notes |
+|---|---|---|
+| `ansible.windows` | core modules (`win_user`, `win_service`, `win_updates`, ...) | the supported core collection |
+| `community.windows` | `win_firewall_rule`, `win_scheduled_task` | maintenance mode — no new modules land here |
+| `microsoft.ad` | domain join, AD objects | replaces the removed `win_domain*` modules |
+| `microsoft.iis` | IIS sites/app pools | replaces the deprecated `community.windows.win_iis_*` |
+| `chocolatey.chocolatey` | application packages | bootstraps Chocolatey from the internet on first use |
+
+The `igou-aap-ee-rhel9` execution environment already ships
+`ansible.windows`/`community.windows` and the `pywinrm`/`pypsrp` Python
+libraries; the other EEs carry the Python libraries too.
+
+## Connecting to Windows
+
+No `windows` group exists in `igou-inventory` yet. When adding one, put the
+connection plumbing in `igou-inventory/group_vars/windows.yml` following the
+repo convention (per-group connection vars, per-host `ansible_host`).
+
+WinRM over HTTPS with NTLM — works out of the box for standalone/workgroup
+hosts:
+
+```yaml
+---
+# igou-inventory/group_vars/windows.yml
+ansible_connection: winrm
+ansible_port: 5986
+ansible_winrm_transport: ntlm
+# Lab only: Windows generates a self-signed cert for the HTTPS listener
+ansible_winrm_server_cert_validation: ignore
+ansible_user: Administrator
+ansible_password: "{{ lookup('community.general.onepassword', 'windows-administrator', field='password', vault='lab_agents') }}"
+```
+
+Alternative — native SSH (ansible-core ≥ 2.18, needs Win32-OpenSSH in the
+guest with PowerShell as the default shell): key auth, no certificate
+plumbing:
+
+```yaml
+---
+ansible_connection: ssh
+ansible_shell_type: powershell
+ansible_user: Administrator
+```
+
+Once hosts are domain-joined, switch `ansible_winrm_transport` to
+`kerberos` (required for anything double-hop, e.g. AD management from a
+member server).
+
+## Windows VMs on OpenShift Virtualization
+
+Ansible can only take over once the guest has a WinRM/SSH listener and a
+known credential. For KubeVirt/OpenShift Virtualization Windows VMs:
+
+1. **VirtIO + guest agent** — attach the `virtio-win` container disk;
+   install the drivers and `guest-agent\qemu-ga-x86_64.msi` (without the
+   agent, OpenShift can't report the VM's IP or shut it down gracefully).
+2. **First-boot bootstrap** — either a **sysprep answer file**
+   (`autounattend.xml`/`unattend.xml` in a Secret, mounted via the
+   KubeVirt `sysprep` volume) or **cloudbase-init** in the golden image.
+   Use it to set the Administrator password and enable the WinRM HTTPS
+   listener (or install OpenSSH).
+3. **Hand-off** — run `ping_and_facts.yaml` to prove connectivity, then
+   `provision_test_machine.yaml` to create the test user and applications
+   the agent will exercise.
+
+The `sysprep`/golden-image pipeline itself is out of scope here — see the
+design spec for the planned follow-up.
+
+## Running
+
+```bash
+# Prove connectivity
+ansible-navigator run playbooks/windows/ping_and_facts.yaml \
+  -i igou-inventory/inventory.yaml -e ansible_limit=<host>
+
+# Provision an application test machine
+ansible-navigator run playbooks/windows/provision_test_machine.yaml \
+  -i igou-inventory/inventory.yaml -e ansible_limit=<host> \
+  -e windows_test_user_password='<secret>' \
+  -e '{"windows_test_apps": [{"name": "firefox"}, {"name": "vlc"}]}'
+```
+
+## Conventions
+
+- Variables are prefixed `windows_` and documented in each playbook header.
+- Passwords arrive via extra_vars (ideally a
+  `community.general.onepassword` lookup) and the tasks that handle them
+  set `no_log: true`.
+- No `become:` — privilege comes from the connection user; Windows
+  `runas` escalation is a separate mechanism you rarely need.
+- Reboots are opt-in (`install_updates.yaml`) or module-managed where a
+  reboot is inherent to the operation (`join_domain.yaml`).

--- a/playbooks/windows/configure_firewall.yaml
+++ b/playbooks/windows/configure_firewall.yaml
@@ -1,0 +1,69 @@
+---
+# Configure the Windows Defender Firewall: profile state plus a declarative
+# list of rules.
+#
+# Two different modules cooperate here, and mixing them up is a classic
+# beginner trap:
+#   * ansible.windows.win_firewall        - turns whole PROFILES on or off
+#                                           (Domain / Private / Public)
+#   * community.windows.win_firewall_rule - manages INDIVIDUAL rules
+#
+# Targeting: pass ansible_limit=<host-or-group>. Defaults to the 'windows'
+# inventory group.
+#
+# Variables:
+#   windows_firewall_profiles - profiles to ensure are enabled
+#                               (default: all three)
+#   windows_firewall_rules    - list of rules. Each entry:
+#                                 name:      display name        (required)
+#                                 direction: in|out              (default in)
+#                                 action:    allow|block         (default allow)
+#                                 protocol:  tcp|udp|icmpv4|...  (default tcp)
+#                                 localport: port or range       (optional;
+#                                            not used for icmp)
+#                                 profiles:  list                (optional)
+#                                 state:     present|absent      (default present)
+#                               The defaults below allow ping and WinRM over
+#                               HTTPS — the two rules a lab Windows VM
+#                               almost always needs.
+#
+# Run:
+#   ansible-navigator run playbooks/windows/configure_firewall.yaml \
+#     -i igou-inventory/inventory.yaml -e ansible_limit=<host>
+- name: Configure the Windows firewall
+  hosts: "{{ ansible_limit | default('windows') }}"
+  gather_facts: false
+
+  vars:
+    windows_firewall_profiles:
+      - Domain
+      - Private
+      - Public
+    windows_firewall_rules:
+      - name: Allow ICMP ping (managed by Ansible)
+        protocol: icmpv4
+      - name: Allow WinRM over HTTPS (managed by Ansible)
+        protocol: tcp
+        localport: "5986"
+
+  tasks:
+    # Keep the firewall ON and punch explicit holes — disabling profiles to
+    # "make things work" is the anti-pattern this playbook exists to avoid.
+    - name: Ensure firewall profiles are enabled
+      ansible.windows.win_firewall:
+        profiles: "{{ windows_firewall_profiles }}"
+        state: enabled
+
+    - name: Ensure firewall rules match the desired state
+      community.windows.win_firewall_rule:
+        name: "{{ item.name }}"
+        direction: "{{ item.direction | default('in') }}"
+        action: "{{ item.action | default('allow') }}"
+        protocol: "{{ item.protocol | default('tcp') }}"
+        localport: "{{ item.localport | default(omit) }}"
+        profiles: "{{ item.profiles | default(omit) }}"
+        state: "{{ item.state | default('present') }}"
+        enabled: true
+      loop: "{{ windows_firewall_rules }}"
+      loop_control:
+        label: "{{ item.name }}"

--- a/playbooks/windows/create_scheduled_task.yaml
+++ b/playbooks/windows/create_scheduled_task.yaml
@@ -1,0 +1,75 @@
+---
+# Create (or remove) a Windows scheduled task — the Windows equivalent of a
+# cron job.
+#
+# The default task below runs a PowerShell one-liner every day at 03:00 as
+# SYSTEM. Swap the action and trigger via variables for your own jobs; run
+# 'Get-ScheduledTask' or check Task Scheduler under the path '\Ansible\' to
+# see the result.
+#
+# Targeting: pass ansible_limit=<host-or-group>. Defaults to the 'windows'
+# inventory group.
+#
+# Variables:
+#   windows_task_name        - task name (default 'nightly-cleanup')
+#   windows_task_description - free text shown in Task Scheduler
+#   windows_task_command     - executable to run
+#                              (default: powershell.exe)
+#   windows_task_arguments   - arguments for the executable; the default
+#                              clears the user temp directory
+#   windows_task_start_time  - daily run time as an ISO date-time; only the
+#                              time-of-day part matters for a daily trigger
+#                              (default 2026-01-01T03:00:00)
+#   windows_task_state       - present|absent (default present)
+#
+# Run:
+#   ansible-navigator run playbooks/windows/create_scheduled_task.yaml \
+#     -i igou-inventory/inventory.yaml -e ansible_limit=<host>
+- name: Manage a Windows scheduled task
+  hosts: "{{ ansible_limit | default('windows') }}"
+  gather_facts: false
+
+  vars:
+    windows_task_name: nightly-cleanup
+    windows_task_description: Clear the temp directory every night (managed by Ansible)
+    windows_task_command: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+    windows_task_arguments: >-
+      -NoProfile -Command "Remove-Item -Path $env:TEMP\* -Recurse -Force
+      -ErrorAction SilentlyContinue"
+    windows_task_start_time: "2026-01-01T03:00:00"
+    windows_task_state: present
+
+  tasks:
+    # Tasks are grouped under the '\Ansible\' folder in Task Scheduler so
+    # everything Ansible manages is easy to find (and to clean up).
+    - name: Ensure the scheduled task matches the desired state
+      community.windows.win_scheduled_task:
+        name: "{{ windows_task_name }}"
+        path: \Ansible
+        description: "{{ windows_task_description }}"
+        actions:
+          - path: "{{ windows_task_command }}"
+            arguments: "{{ windows_task_arguments }}"
+        # A 'daily' trigger fires every day at the time-of-day part of
+        # start_boundary. Other trigger types: boot, logon, weekly, ...
+        triggers:
+          - type: daily
+            start_boundary: "{{ windows_task_start_time }}"
+        username: SYSTEM
+        run_level: highest
+        enabled: true
+        state: "{{ windows_task_state }}"
+
+    - name: Confirm the task is registered
+      community.windows.win_scheduled_task_stat:
+        path: \Ansible
+        name: "{{ windows_task_name }}"
+      register: windows_task_stat
+      when: windows_task_state == 'present'
+
+    - name: Show the task status
+      ansible.builtin.debug:
+        msg: >-
+          Task '{{ windows_task_name }}' exists:
+          {{ windows_task_stat.task_exists | default(false) }}
+      when: windows_task_state == 'present'

--- a/playbooks/windows/deploy_iis_website.yaml
+++ b/playbooks/windows/deploy_iis_website.yaml
@@ -1,0 +1,102 @@
+---
+# Install IIS and deploy a simple website, end to end.
+#
+# Demonstrates the standard IIS pattern with the modern microsoft.iis
+# collection (the old community.windows win_iis_* modules are deprecated):
+#   1. install the Web-Server role (ansible.windows.win_feature)
+#   2. create an application pool    (microsoft.iis.web_app_pool)
+#   3. create the site + binding     (microsoft.iis.website)
+#   4. verify it actually serves     (ansible.windows.win_uri)
+#
+# Targeting: pass ansible_limit=<host-or-group>. Defaults to the 'windows'
+# inventory group. NOTE: the Web-Server role only exists on Windows SERVER
+# editions — this play will fail on Windows 10/11 clients.
+#
+# Variables:
+#   windows_iis_site_name     - site name (default 'demo-site')
+#   windows_iis_site_port     - HTTP port to bind (default 8080)
+#   windows_iis_site_path     - physical path (default C:\inetpub\demo-site)
+#   windows_iis_app_pool      - application pool name (default 'demo-pool')
+#   windows_iis_index_content - HTML served as index.html; replace with
+#                               win_copy of your real content
+#
+# Run:
+#   ansible-navigator run playbooks/windows/deploy_iis_website.yaml \
+#     -i igou-inventory/inventory.yaml -e ansible_limit=<server>
+- name: Install IIS and deploy a website
+  hosts: "{{ ansible_limit | default('windows') }}"
+  gather_facts: false
+
+  vars:
+    windows_iis_site_name: demo-site
+    windows_iis_site_port: 8080
+    windows_iis_site_path: C:\inetpub\demo-site
+    windows_iis_app_pool: demo-pool
+    windows_iis_index_content: |
+      <html>
+        <head><title>Deployed by Ansible</title></head>
+        <body><h1>It works!</h1><p>Served by IIS, deployed by Ansible.</p></body>
+      </html>
+
+  tasks:
+    - name: Install the IIS Web-Server role
+      ansible.windows.win_feature:
+        name: Web-Server
+        state: present
+        include_management_tools: true
+      register: windows_iis_feature
+
+    # Role installation sometimes needs a restart before IIS is usable;
+    # win_feature tells us via reboot_required rather than rebooting itself.
+    - name: Reboot if the role installation requires it
+      ansible.windows.win_reboot:
+      when: windows_iis_feature.reboot_required
+
+    # A dedicated app pool isolates the site from everything else running
+    # in IIS — one bad app can't take down its neighbours.
+    - name: Create the application pool
+      microsoft.iis.web_app_pool:
+        name: "{{ windows_iis_app_pool }}"
+        state: started
+
+    - name: Create the site directory
+      ansible.windows.win_file:
+        path: "{{ windows_iis_site_path }}"
+        state: directory
+
+    - name: Deploy the site content
+      ansible.windows.win_copy:
+        content: "{{ windows_iis_index_content }}"
+        dest: "{{ windows_iis_site_path }}\\index.html"
+
+    # bindings.set is authoritative: the site ends up with exactly this
+    # binding list. Use bindings.add / bindings.remove for incremental edits.
+    - name: Create the website
+      microsoft.iis.website:
+        name: "{{ windows_iis_site_name }}"
+        physical_path: "{{ windows_iis_site_path }}"
+        application_pool: "{{ windows_iis_app_pool }}"
+        bindings:
+          set:
+            - ip: '*'
+              port: "{{ windows_iis_site_port | int }}"
+        state: started
+
+    # Don't just trust module green — request the page from the host itself
+    # and fail the play if IIS isn't actually serving our content.
+    - name: Verify the site responds
+      ansible.windows.win_uri:
+        url: "http://localhost:{{ windows_iis_site_port }}/"
+        return_content: true
+        status_code:
+          - 200
+      register: windows_iis_check
+      retries: 3
+      delay: 5
+      until: windows_iis_check is succeeded
+
+    - name: Show the verification result
+      ansible.builtin.debug:
+        msg: >-
+          {{ windows_iis_site_name }} is serving on port
+          {{ windows_iis_site_port }} (HTTP {{ windows_iis_check.status_code }})

--- a/playbooks/windows/install_applications.yaml
+++ b/playbooks/windows/install_applications.yaml
@@ -1,0 +1,69 @@
+---
+# Install, upgrade, or remove applications with Chocolatey.
+#
+# Chocolatey is the de-facto package manager for Windows and the easiest way
+# to keep application installs declarative. The first run bootstraps
+# Chocolatey itself from https://community.chocolatey.org, so targets need
+# outbound HTTPS (or point windows_choco_source at an internal feed).
+#
+# Targeting: pass ansible_limit=<host-or-group>. Defaults to the 'windows'
+# inventory group.
+#
+# Variables:
+#   windows_apps         - list of packages. Each entry:
+#                            name:    chocolatey package id   (required)
+#                            version: exact version to pin    (optional)
+#                            state:   present|latest|absent   (optional,
+#                                     default present)
+#                          Pinning a version keeps runs deterministic;
+#                          'latest' upgrades on every run when the feed has
+#                          something newer.
+#   windows_choco_source - alternate package feed URL, e.g. an internal
+#                          Nexus/ProGet repository (optional)
+#
+# Run:
+#   ansible-navigator run playbooks/windows/install_applications.yaml \
+#     -i igou-inventory/inventory.yaml -e ansible_limit=<host> \
+#     -e '{"windows_apps": [{"name": "vlc"}, {"name": "firefox", "state": "latest"}]}'
+- name: Manage applications with Chocolatey
+  hosts: "{{ ansible_limit | default('windows') }}"
+  gather_facts: false
+
+  vars:
+    windows_apps:
+      - name: git
+      - name: 7zip
+      - name: notepadplusplus
+
+  tasks:
+    # Registering an internal feed first (when configured) means even the
+    # Chocolatey bootstrap and every package come from your own server.
+    - name: Point Chocolatey at an internal package feed
+      chocolatey.chocolatey.win_chocolatey_source:
+        name: internal
+        source: "{{ windows_choco_source }}"
+        priority: 1
+        state: present
+      when: windows_choco_source is defined
+
+    - name: Ensure each application is in its desired state
+      chocolatey.chocolatey.win_chocolatey:
+        name: "{{ item.name }}"
+        version: "{{ item.version | default(omit) }}"
+        state: "{{ item.state | default('present') }}"
+      loop: "{{ windows_apps }}"
+      loop_control:
+        label: "{{ item.name }} ({{ item.state | default('present') }})"
+
+    # win_chocolatey_facts populates ansible_facts.chocolatey with installed
+    # packages, sources, and config — handy proof of what a run left behind.
+    - name: Collect the resulting package inventory
+      chocolatey.chocolatey.win_chocolatey_facts:
+
+    - name: Show installed Chocolatey packages
+      ansible.builtin.debug:
+        msg: >-
+          {{ ansible_facts.chocolatey.packages
+             | map(attribute='package')
+             | sort
+             | join(', ') }}

--- a/playbooks/windows/install_updates.yaml
+++ b/playbooks/windows/install_updates.yaml
@@ -1,0 +1,63 @@
+---
+# Install Windows Updates, optionally rebooting until the host is clean.
+#
+# The canonical Windows patching pattern: win_updates searches, downloads,
+# and installs updates; with reboot: true it also reboots and re-checks in a
+# loop until no more updates apply (some updates only appear after a prior
+# one is installed and the host restarted).
+#
+# Targeting: pass ansible_limit=<host-or-group>. Defaults to the 'windows'
+# inventory group. Reboots are OFF by default so a scheduled run never
+# surprise-restarts a machine — turn them on per run.
+#
+# Variables:
+#   windows_updates_categories - update categories to install. The default
+#                                mirrors the module default (critical +
+#                                security + rollups). Use ["*"] for
+#                                everything, including drivers and feature
+#                                packs.
+#   windows_updates_reboot     - reboot and re-check until clean
+#                                (default false)
+#   windows_updates_reboot_timeout - seconds to wait for each reboot
+#                                (default 1200)
+#
+# Run (patch + reboot cycle):
+#   ansible-navigator run playbooks/windows/install_updates.yaml \
+#     -i igou-inventory/inventory.yaml -e ansible_limit=<host> \
+#     -e windows_updates_reboot=true
+- name: Install Windows Updates
+  hosts: "{{ ansible_limit | default('windows') }}"
+  gather_facts: false
+
+  vars:
+    windows_updates_categories:
+      - CriticalUpdates
+      - SecurityUpdates
+      - UpdateRollups
+    windows_updates_reboot: false
+    windows_updates_reboot_timeout: 1200
+
+  tasks:
+    - name: Search for and install updates
+      ansible.windows.win_updates:
+        category_names: "{{ windows_updates_categories }}"
+        state: installed
+        reboot: "{{ windows_updates_reboot }}"
+        reboot_timeout: "{{ windows_updates_reboot_timeout }}"
+      register: windows_updates_result
+
+    - name: Report what happened
+      ansible.builtin.debug:
+        msg:
+          - "Updates found:     {{ windows_updates_result.found_update_count | default(0) }}"
+          - "Updates installed: {{ windows_updates_result.installed_update_count | default(0) }}"
+          - "Reboot required:   {{ windows_updates_result.reboot_required | default(false) }}"
+
+    # With windows_updates_reboot=false a run can leave the host waiting for
+    # a restart. Surface that loudly instead of leaving it to be discovered.
+    - name: Warn when a reboot is still pending
+      ansible.builtin.debug:
+        msg: >-
+          A reboot is required to finish installing updates. Re-run with
+          -e windows_updates_reboot=true, or reboot the host manually.
+      when: windows_updates_result.reboot_required | default(false)

--- a/playbooks/windows/join_domain.yaml
+++ b/playbooks/windows/join_domain.yaml
@@ -1,0 +1,80 @@
+---
+# Join a Windows host to an Active Directory domain (or move it back to a
+# workgroup).
+#
+# Uses microsoft.ad.membership — the supported replacement for the removed
+# ansible.windows.win_domain_membership module. The same collection also
+# builds domains from scratch (microsoft.ad.domain / domain_controller) and
+# manages directory content (microsoft.ad.user / group / ou).
+#
+# Targeting: pass ansible_limit=<host-or-group>. Defaults to the 'windows'
+# inventory group.
+#
+# Variables:
+#   windows_domain_state          - domain|workgroup (default domain)
+#   windows_domain_name           - DNS name of the AD domain, e.g.
+#                                   ad.igou.systems (required when joining)
+#   windows_domain_admin_user     - account allowed to join machines, e.g.
+#                                   join-svc@ad.igou.systems (required when
+#                                   joining)
+#   windows_domain_admin_password - REQUIRED when joining. Pass via
+#                                   extra_vars from a 1Password lookup —
+#                                   never from a file in git.
+#   windows_domain_ou_path        - OU for the computer object, e.g.
+#                                   OU=TestVMs,DC=ad,DC=igou,DC=systems
+#                                   (optional)
+#   windows_domain_hostname       - rename the host while joining (optional)
+#   windows_workgroup_name        - workgroup to join when leaving the
+#                                   domain (default WORKGROUP)
+#
+# The host must be able to resolve the domain's DNS records — point it at
+# the domain controller with ansible.windows.win_dns_client first if needed.
+#
+# Run:
+#   ansible-navigator run playbooks/windows/join_domain.yaml \
+#     -i igou-inventory/inventory.yaml -e ansible_limit=<host> \
+#     -e windows_domain_name=ad.example.com \
+#     -e windows_domain_admin_user=join-svc@ad.example.com \
+#     -e windows_domain_admin_password=<secret>
+- name: Manage Active Directory domain membership
+  hosts: "{{ ansible_limit | default('windows') }}"
+  gather_facts: false
+
+  vars:
+    windows_domain_state: domain
+    windows_workgroup_name: WORKGROUP
+
+  tasks:
+    - name: Make sure join credentials were provided
+      ansible.builtin.assert:
+        that:
+          - windows_domain_name is defined
+          - windows_domain_admin_user is defined
+          - windows_domain_admin_password is defined
+        fail_msg: >-
+          Joining a domain needs windows_domain_name,
+          windows_domain_admin_user and windows_domain_admin_password —
+          see the header of this playbook.
+      when: windows_domain_state == 'domain'
+
+    # reboot: true lets the module handle the restart a join/leave always
+    # requires, and the play continues once the host is back.
+    - name: Join the Active Directory domain
+      microsoft.ad.membership:
+        dns_domain_name: "{{ windows_domain_name }}"
+        domain_admin_user: "{{ windows_domain_admin_user }}"
+        domain_admin_password: "{{ windows_domain_admin_password }}"
+        domain_ou_path: "{{ windows_domain_ou_path | default(omit) }}"
+        hostname: "{{ windows_domain_hostname | default(omit) }}"
+        state: domain
+        reboot: true
+      when: windows_domain_state == 'domain'
+
+    - name: Leave the domain for a workgroup
+      microsoft.ad.membership:
+        workgroup_name: "{{ windows_workgroup_name }}"
+        domain_admin_user: "{{ windows_domain_admin_user | default(omit) }}"
+        domain_admin_password: "{{ windows_domain_admin_password | default(omit) }}"
+        state: workgroup
+        reboot: true
+      when: windows_domain_state == 'workgroup'

--- a/playbooks/windows/manage_local_users.yaml
+++ b/playbooks/windows/manage_local_users.yaml
@@ -1,0 +1,75 @@
+---
+# Manage local Windows users and groups declaratively.
+#
+# Covers the everyday cases: create a group, create users with group
+# membership, and remove accounts that should no longer exist. For Active
+# Directory users see join_domain.yaml and the microsoft.ad collection —
+# these modules only touch the LOCAL account database.
+#
+# Targeting: pass ansible_limit=<host-or-group>. Defaults to the 'windows'
+# inventory group.
+#
+# Variables:
+#   windows_local_groups - list of groups. Each entry:
+#                            name:        group name           (required)
+#                            description: free text            (optional)
+#                            state:       present|absent       (optional,
+#                                         default present)
+#   windows_local_users  - list of users. Each entry:
+#                            name:     username                (required)
+#                            password: initial password        (required for
+#                                      state present; only set on creation)
+#                            fullname / description            (optional)
+#                            groups:   local groups to add to  (optional)
+#                            state:    present|absent          (optional,
+#                                      default present)
+#
+# Passwords should come from extra_vars or a 1Password lookup, never from a
+# file in git, e.g.:
+#   -e '{"windows_local_users": [{"name": "svc-backup",
+#        "password": "{{ lookup(''community.general.onepassword'',
+#        ''windows-svc-backup'', field=''password'', vault=''lab_agents'') }}",
+#        "groups": ["Backup Operators"]}]}'
+#
+# Run:
+#   ansible-navigator run playbooks/windows/manage_local_users.yaml \
+#     -i igou-inventory/inventory.yaml -e ansible_limit=<host>
+- name: Manage local Windows users and groups
+  hosts: "{{ ansible_limit | default('windows') }}"
+  gather_facts: false
+
+  vars:
+    windows_local_groups:
+      - name: AppTesters
+        description: Accounts used for automated application testing
+    windows_local_users: []
+
+  tasks:
+    # Groups first, so users can reference them on creation.
+    - name: Ensure local groups exist
+      ansible.windows.win_group:
+        name: "{{ item.name }}"
+        description: "{{ item.description | default(omit) }}"
+        state: "{{ item.state | default('present') }}"
+      loop: "{{ windows_local_groups }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    # update_password: on_create means Ansible sets the password only when
+    # it creates the account — reruns never clobber a rotated password.
+    # no_log keeps the passwords in the loop items out of logs and output;
+    # the loop_control label restores per-item readability.
+    - name: Ensure local users match the desired state
+      ansible.windows.win_user:
+        name: "{{ item.name }}"
+        password: "{{ item.password | default(omit) }}"
+        update_password: on_create
+        fullname: "{{ item.fullname | default(omit) }}"
+        description: "{{ item.description | default(omit) }}"
+        groups: "{{ item.groups | default(omit) }}"
+        groups_action: add
+        state: "{{ item.state | default('present') }}"
+      loop: "{{ windows_local_users }}"
+      loop_control:
+        label: "{{ item.name }}"
+      no_log: true

--- a/playbooks/windows/manage_services.yaml
+++ b/playbooks/windows/manage_services.yaml
@@ -1,0 +1,56 @@
+---
+# Manage Windows services declaratively: running state and startup mode.
+#
+# The default example below shows both directions — making sure something IS
+# running (Windows Time keeps VM clocks sane) and making sure something is
+# NOT (the Print Spooler is a common hardening target on servers).
+#
+# Targeting: pass ansible_limit=<host-or-group>. Defaults to the 'windows'
+# inventory group.
+#
+# Variables:
+#   windows_services - list of services. Each entry:
+#                        name:       service short name, e.g. W32Time
+#                                    (required — find it with
+#                                    'Get-Service | Select Name,DisplayName')
+#                        state:      started|stopped|restarted (optional)
+#                        start_mode: auto|manual|disabled|delayed (optional)
+#                      Omitted keys are left untouched, so an entry with only
+#                      start_mode changes boot behaviour without bouncing the
+#                      service now.
+#
+# Run:
+#   ansible-navigator run playbooks/windows/manage_services.yaml \
+#     -i igou-inventory/inventory.yaml -e ansible_limit=<host>
+- name: Manage Windows services
+  hosts: "{{ ansible_limit | default('windows') }}"
+  gather_facts: false
+
+  vars:
+    windows_services:
+      - name: W32Time
+        state: started
+        start_mode: auto
+      - name: Spooler
+        state: stopped
+        start_mode: disabled
+
+  tasks:
+    - name: Ensure services match the desired state
+      ansible.windows.win_service:
+        name: "{{ item.name }}"
+        state: "{{ item.state | default(omit) }}"
+        start_mode: "{{ item.start_mode | default(omit) }}"
+      loop: "{{ windows_services }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: windows_services_result
+
+    - name: Show the resulting service states
+      ansible.builtin.debug:
+        msg: >-
+          {{ windows_services_result.results
+             | map(attribute='item.name')
+             | zip(windows_services_result.results | map(attribute='state', default='unchanged'))
+             | map('join', ': ')
+             | join(', ') }}

--- a/playbooks/windows/ping_and_facts.yaml
+++ b/playbooks/windows/ping_and_facts.yaml
@@ -1,0 +1,37 @@
+---
+# Verify Ansible can talk to Windows hosts and print a short system summary.
+#
+# This is the "hello world" of Windows automation — run it first to prove
+# your connection variables (WinRM or SSH, see playbooks/windows/README.md)
+# are correct before trying anything else.
+#
+# Targeting: pass ansible_limit=<host-or-group>. Defaults to the 'windows'
+# inventory group.
+#
+# Variables: none.
+#
+# Run:
+#   ansible-navigator run playbooks/windows/ping_and_facts.yaml \
+#     -i igou-inventory/inventory.yaml -e ansible_limit=<host>
+- name: Check Windows connectivity and show system facts
+  hosts: "{{ ansible_limit | default('windows') }}"
+  gather_facts: true
+
+  tasks:
+    # win_ping is the Windows equivalent of ansible.builtin.ping: it performs
+    # a full round trip over the connection plugin, so a green result means
+    # authentication, the transport, and PowerShell execution all work.
+    - name: Verify the connection with a full round trip
+      ansible.windows.win_ping:
+
+    # gather_facts: true above already ran ansible.windows.setup for us, so
+    # every ansible_* fact below is free — no extra task needed to collect it.
+    - name: Show a short system summary
+      ansible.builtin.debug:
+        msg:
+          - "Hostname: {{ ansible_hostname }}"
+          - "OS:       {{ ansible_os_name | default('unknown') | trim }}"
+          - "Build:    {{ ansible_distribution_version | default('unknown') }}"
+          - "Arch:     {{ ansible_architecture | default('unknown') }}"
+          - "Memory:   {{ ansible_memtotal_mb | default(0) }} MB"
+          - "IPs:      {{ ansible_ip_addresses | default([]) | join(', ') }}"

--- a/playbooks/windows/provision_test_machine.yaml
+++ b/playbooks/windows/provision_test_machine.yaml
@@ -1,0 +1,152 @@
+---
+# Provision a Windows machine as a self-contained application test bed:
+# create a dedicated test user, install a configurable set of applications,
+# and (optionally) open Remote Desktop so an interactive agent can log in
+# and drive the GUI.
+#
+# Written for — but not limited to — Windows VMs running on OpenShift
+# Virtualization, where an automation agent later signs in as the test user
+# to exercise the installed applications. See README.md for how a fresh VM
+# gets its first WinRM/SSH listener (sysprep answer file or cloudbase-init);
+# this play takes over from the moment Ansible can connect.
+#
+# This play composes the building blocks shown in manage_local_users.yaml
+# and install_applications.yaml — read those two for the full option set.
+#
+# Targeting: pass ansible_limit=<host-or-group>. Defaults to the 'windows'
+# inventory group.
+#
+# Variables:
+#   windows_test_user           - test account to create (default 'apptester')
+#   windows_test_user_password  - REQUIRED. Pass via extra_vars, e.g.
+#                                 -e windows_test_user_password="{{ lookup('community.general.onepassword',
+#                                    'windows-apptester', field='password', vault='lab_agents') }}"
+#   windows_test_user_groups    - local groups for the account
+#                                 (default: Users + Remote Desktop Users)
+#   windows_test_apps           - Chocolatey packages to install; a list of
+#                                 dicts with name / version (optional) /
+#                                 state (optional, default present)
+#   windows_test_msi_packages   - extra MSI/EXE installers not available in
+#                                 Chocolatey; list of dicts with path (local
+#                                 path or URL), product_id, arguments,
+#                                 creates_path (see win_package docs).
+#                                 Default: none.
+#   windows_test_enable_rdp     - enable Remote Desktop + firewall rule so
+#                                 GUI agents can connect (default true)
+#
+# Run:
+#   ansible-navigator run playbooks/windows/provision_test_machine.yaml \
+#     -i igou-inventory/inventory.yaml -e ansible_limit=<vm-host> \
+#     -e windows_test_user_password=<secret>
+- name: Provision a Windows application test machine
+  hosts: "{{ ansible_limit | default('windows') }}"
+  gather_facts: false
+
+  vars:
+    windows_test_user: apptester
+    windows_test_user_groups:
+      - Users
+      - Remote Desktop Users
+    windows_test_apps:
+      - name: git
+      - name: 7zip
+      - name: notepadplusplus
+    windows_test_msi_packages: []
+    windows_test_enable_rdp: true
+
+  tasks:
+    # Fail fast with a clear message instead of a mid-play "undefined
+    # variable" error — passwords must come from extra_vars or a vault,
+    # never from a file checked into git.
+    - name: Make sure a password was provided for the test user
+      ansible.builtin.assert:
+        that:
+          - windows_test_user_password is defined
+        fail_msg: >-
+          Set windows_test_user_password via extra_vars (ideally from a
+          1Password lookup) — see the header of this playbook.
+
+    # --- Test user -------------------------------------------------------
+    # no_log hides the module arguments (which include the password) from
+    # logs and console output. update_password: on_create keeps the play
+    # idempotent — reruns won't reset a password the user already rotated.
+    - name: Create the application test user
+      ansible.windows.win_user:
+        name: "{{ windows_test_user }}"
+        password: "{{ windows_test_user_password }}"
+        update_password: on_create
+        password_never_expires: true
+        description: Application test account managed by Ansible
+        groups: "{{ windows_test_user_groups }}"
+        groups_action: add
+        state: present
+      no_log: true
+
+    # --- Applications ----------------------------------------------------
+    # The first win_chocolatey run bootstraps Chocolatey itself from the
+    # internet, so the VM needs outbound HTTPS (or set an internal source —
+    # see install_applications.yaml).
+    - name: Install test applications with Chocolatey
+      chocolatey.chocolatey.win_chocolatey:
+        name: "{{ item.name }}"
+        version: "{{ item.version | default(omit) }}"
+        state: "{{ item.state | default('present') }}"
+      loop: "{{ windows_test_apps }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    # win_package handles anything Chocolatey can't: vendor MSIs, EXE
+    # installers from a share or URL. product_id is what makes reruns
+    # idempotent — without it (or creates_path) the installer runs again
+    # every time.
+    - name: Install extra MSI/EXE packages
+      ansible.windows.win_package:
+        path: "{{ item.path }}"
+        product_id: "{{ item.product_id | default(omit) }}"
+        arguments: "{{ item.arguments | default(omit) }}"
+        creates_path: "{{ item.creates_path | default(omit) }}"
+        state: present
+      loop: "{{ windows_test_msi_packages }}"
+      loop_control:
+        label: "{{ item.path }}"
+
+    # --- Remote Desktop (optional) ----------------------------------------
+    # Three pieces make RDP reachable: the registry switch that allows
+    # connections, the service, and a firewall rule. The test user gets in
+    # because it is a member of "Remote Desktop Users" (see vars above).
+    - name: Allow Remote Desktop connections
+      ansible.windows.win_regedit:
+        path: HKLM:\System\CurrentControlSet\Control\Terminal Server
+        name: fDenyTSConnections
+        data: 0
+        type: dword
+      when: windows_test_enable_rdp
+
+    - name: Start the Remote Desktop service
+      ansible.windows.win_service:
+        name: TermService
+        start_mode: auto
+        state: started
+      when: windows_test_enable_rdp
+
+    - name: Open the firewall for Remote Desktop
+      community.windows.win_firewall_rule:
+        name: Remote Desktop (managed by Ansible)
+        direction: in
+        action: allow
+        protocol: tcp
+        localport: "3389"
+        profiles:
+          - domain
+          - private
+        state: present
+        enabled: true
+      when: windows_test_enable_rdp
+
+    - name: Summarize what was provisioned
+      ansible.builtin.debug:
+        msg:
+          - "Test user:  {{ windows_test_user }} (groups: {{ windows_test_user_groups | join(', ') }})"
+          - "Apps:       {{ windows_test_apps | map(attribute='name') | join(', ') }}"
+          - "Extra pkgs: {{ windows_test_msi_packages | length }}"
+          - "RDP:        {{ 'enabled' if windows_test_enable_rdp else 'left as-is' }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -70,4 +70,15 @@ collections:
   - name: https://github.com/david-igou/ansible-collection-devhost.git
     type: git
     version: 27.1.3
+  # Windows automation (playbooks/windows/)
+  - name: ansible.windows
+    version: 3.6.1
+  - name: community.windows
+    version: 3.2.0
+  - name: microsoft.ad
+    version: 1.11.0
+  - name: microsoft.iis
+    version: 1.2.0
+  - name: chocolatey.chocolatey
+    version: 1.6.0
 ...


### PR DESCRIPTION
Adds a new `playbooks/windows/` domain: ten common Windows automation use cases written to be readable for newer Ansible users, including the flagship `provision_test_machine.yaml` that sets up a Windows machine with a configurable application set and test user so automation agents can exercise applications inside OpenShift Virtualization VMs.

Full design specification below (per-playbook specs included). A local copy also lives in `docs/superpowers/specs/2026-07-10-windows-playbooks-design.md` (that path is gitignored by design).

---

# Design specification — playbooks/windows/

## Goals

1. Give the repo a `playbooks/windows/` domain covering ten common, industry-standard Windows automation use cases, written to be readable by newer Ansible users (heavy header docs, one concept per playbook, comments explain "why" not "what").
2. Provide the flagship piece: provisioning a Windows machine with a configurable application set and a dedicated test user, so automation agents can later exercise applications inside OpenShift Virtualization VMs.
3. Base every module choice on the current (mid-2026) collection landscape rather than folk knowledge — several well-known `win_*` modules have moved or been removed.

Out of scope (follow-ups listed at the end): the golden-image / sysprep pipeline that produces an Ansible-reachable Windows VM, the `windows` inventory group in `igou-inventory`, and AAP job templates.

## Research summary

Collection versions verified against the Galaxy v3 API and docs.ansible.com on 2026-07-10:

| Collection | Pin | Role in this design |
|---|---|---|
| `ansible.windows` | 3.6.1 | supported core: users, groups, services, updates, registry, features, files, reboot, `win_uri`, firewall *profiles* |
| `community.windows` | 3.2.0 | maintenance mode ("no new modules accepted") but still canonical for `win_firewall_rule`, `win_scheduled_task(_stat)` |
| `microsoft.ad` | 1.11.0 | replaces the `win_domain*` modules **removed** from ansible.windows; drops the `win_` prefix |
| `microsoft.iis` | 1.2.0 | GA replacement for the **deprecated** `community.windows.win_iis_*` modules |
| `chocolatey.chocolatey` | 1.6.0 | application packages (`win_chocolatey*`) |

Key research facts that shaped the design:

- **Deprecation map**: `win_domain`, `win_domain_membership`, `win_domain_controller` are gone from `ansible.windows` → `microsoft.ad.domain` / `membership` / `domain_controller`. All `win_iis_*` modules are deprecated → `microsoft.iis.website`, `web_app_pool`, `web_application`, `virtual_directory` (bindings are parameters of `website`, not a separate module — confirmed against `ansible-doc` for the installed 1.2.0). New playbooks must not teach the deprecated paths.
- **Firewall split**: profiles = `ansible.windows.win_firewall`; individual rules = `community.windows.win_firewall_rule`. A classic beginner trap, so one playbook demonstrates both side by side.
- **Connections**: WinRM (ntlm/kerberos/credssp), PSRP, and — since ansible-core 2.18 — first-class SSH with `ansible_shell_type: powershell`. Lab recommendation: WinRM over HTTPS + NTLM for standalone hosts, Kerberos once domain-joined (required for double-hop), SSH where Win32-OpenSSH can be baked into the image. Controller-side deps (`pywinrm`, `pypsrp`) are already present in this repo's execution environments; `igou-aap-ee-rhel9` even pre-stages `ansible.windows`/`community.windows`.
- **Idempotency traps** baked into the playbook docs: `win_package` needs `product_id`/`creates_path`; `win_chocolatey state: latest` is intentionally non-deterministic; `win_updates` default categories exclude drivers/feature packs, and updates can require reboot-and-rescan cycles; GPO silently reverts local security settings on domain-joined hosts.
- **OpenShift Virtualization**: a vanilla Windows guest is unreachable by Ansible. The entry point must be created at first boot via a KubeVirt `sysprep` volume (Secret with `autounattend.xml`/`unattend.xml`) or cloudbase-init user-data — either sets the Administrator password and enables WinRM/OpenSSH. VirtIO drivers and the qemu guest agent (both from the `virtio-win` container disk) are required for storage/network performance and for OpenShift to see the guest IP / perform graceful shutdown.

## Design decisions

| Decision | Choice | Rationale |
|---|---|---|
| Domain | new `playbooks/windows/` | no existing domain fits; mirrors `linux/`, `rhel/` |
| File extension | `.yaml` | create-playbook skill convention |
| Host targeting | `hosts: "{{ ansible_limit \| default('windows') }}"` | repo-wide AAP idiom; defaults to a (future) `windows` group so an unlimited run matches nothing today |
| Variable naming | `windows_*` prefix, documented per header | repo convention (`update_*`, `vm_*`, ...) |
| `become` | never | Windows privilege comes from the connection user; `runas` is a separate, rarely needed mechanism that confuses beginners |
| `gather_facts` | `false` except where facts are consumed | WinRM fact gathering is slow; makes the cost explicit |
| Secrets | extra_vars + `community.general.onepassword` lookup documented in headers; `no_log: true` on password-bearing tasks | matches igou-inventory convention ("never plaintext"); `no_log` + `loop_control.label` keeps loops readable without leaking |
| Structure | flat tasks in plays, no roles | teaching material: everything visible in one file |
| Defaults | every list variable ships a small, safe, working example | a newer user can read the shape of the data without chasing docs |
| Reboots | opt-in (`install_updates.yaml` defaults off) or module-managed where inherent (`join_domain.yaml`) | consistent with `system-update.yaml`'s "never mass-reboot by default" stance |
| Deprecated modules | never used | `microsoft.ad` / `microsoft.iis` from the start |
| Collection pins | added to root `requirements.yml` | keeps `ansible-lint --profile=production` resolving FQCNs; Renovate picks up updates |

## Content specification (per playbook)

1. **`ping_and_facts.yaml`** — connectivity smoke test. `win_ping` round trip + summary from gathered facts. No variables. The "run this first" entry point that validates connection plumbing.

2. **`provision_test_machine.yaml`** — *flagship: application test bed.* Composition of the user + application building blocks for the OpenShift Virtualization agent-testing workflow.
   - Inputs: `windows_test_user` (default `apptester`), `windows_test_user_password` (required, asserted with a helpful message), `windows_test_user_groups` (default includes `Remote Desktop Users`), `windows_test_apps` (Chocolatey list: name/version/state), `windows_test_msi_packages` (vendor MSI/EXE escape hatch: path/product_id/arguments/creates_path), `windows_test_enable_rdp` (default `true`).
   - Behaviour: assert secret → `win_user` (create-only password, `no_log`) → `win_chocolatey` loop → optional `win_package` loop → RDP enablement (`win_regedit` fDenyTSConnections + `win_service` TermService + `win_firewall_rule` 3389) → summary debug.
   - RDP is on by default because the target consumer is an interactive agent driving GUI applications.

3. **`install_applications.yaml`** — Chocolatey app management. `windows_apps` list (name/version/state), optional `windows_choco_source` internal feed registered *before* first install so even the Chocolatey bootstrap can come from it. Ends with `win_chocolatey_facts` + a sorted package listing as run evidence.

4. **`manage_local_users.yaml`** — local users/groups. `windows_local_groups` then `windows_local_users` (groups first so users can join them). `update_password: on_create` so reruns never clobber rotated passwords; `no_log` on the user loop with `loop_control.label` for readability.

5. **`install_updates.yaml`** — patching. `win_updates` with the module-default category set spelled out, `windows_updates_reboot` (default `false`) enabling the install→reboot→rescan loop, found/installed counts reported, loud warning task when a reboot is still pending.

6. **`configure_firewall.yaml`** — profiles + rules. Ensures profiles *enabled* (hardening stance: never disable the firewall to "make things work"), then a declarative `windows_firewall_rules` loop. Defaults allow ICMP + WinRM-HTTPS — the two rules a lab VM actually needs.

7. **`manage_services.yaml`** — service state/startup mode. `windows_services` loop where omitted keys are `omit`-ted, so an entry can manage only boot behaviour. Defaults teach both directions (W32Time started/auto, Spooler stopped/disabled).

8. **`create_scheduled_task.yaml`** — Windows cron. Single `ExecAction` task under a `\Ansible` Task Scheduler folder, daily trigger via `start_boundary`, runs as SYSTEM at highest run level. `win_scheduled_task_stat` verifies registration.

9. **`deploy_iis_website.yaml`** — web server end to end. `win_feature` Web-Server (+ conditional `win_reboot` on `reboot_required`), dedicated `web_app_pool`, content via `win_copy`, site with authoritative `bindings.set`, and a `win_uri` serve-check with retries — module green is not trusted as proof of serving. Server editions only (documented).

10. **`join_domain.yaml`** — AD membership. `microsoft.ad.membership` join (optional OU path + rename, `reboot: true`) and the reverse workgroup path, credential assert up front, DNS prerequisite documented (`win_dns_client` pointer).

Plus **`playbooks/windows/README.md`**: playbook table, connection setup (WinRM-HTTPS/NTLM and SSH variants with a ready-to-paste `group_vars/windows.yml` using the 1Password lookup pattern), collection/deprecation table, the OpenShift Virtualization bootstrap chain, run examples, and domain conventions.

Repo wiring: five pinned collections appended to `requirements.yml`; `windows/` entry added to CLAUDE.md's playbook-organization list.

## Agent-testing workflow on OpenShift Virtualization

The end-to-end flow these playbooks slot into:

```
golden image (virtio drivers + qemu-ga + WinRM/SSH enabled via
sysprep Secret or cloudbase-init)
        |  VM created on OpenShift Virtualization
        v
ping_and_facts.yaml          # gate: connection plumbing works
        v
provision_test_machine.yaml  # test user + apps + RDP
        v
agent connects (RDP/WinRM) as the test user and exercises the
configured applications; teardown = delete the VM
```

Because `windows_test_apps` / `windows_test_user*` are plain extra_vars, an AAP job template (or an agent calling the AAP API) can provision differently-flavoured test machines from the same playbook.

## Verification

- `ansible-playbook --syntax-check` — all 10 playbooks pass.
- `ansible-lint --profile=production playbooks/windows/` (same profile as pre-commit), with the five pinned collections installed: **Passed: 0 failure(s), 0 warning(s) in 10 files processed. Profile 'production' was required, and it passed.**
- `yamllint playbooks/windows/ requirements.yml` — clean.
- Runtime verification against a live Windows VM is deliberately deferred until a `windows` inventory group and a bootstrapped VM exist (follow-ups below).

## Follow-ups (not in this PR)

1. `igou-inventory`: add a `windows` group + `group_vars/windows.yml` (template in the README) and a first Windows VM host entry.
2. Golden-image pipeline: sysprep Secret (`autounattend.xml`) or cloudbase-init image build so fresh OpenShift Virtualization VMs boot Ansible-reachable; pairs with the existing CDI import tooling.
3. AAP job templates (`controller_templates` in igou-inventory) for `provision_test_machine` and `install_updates` once the group exists.
4. Optional: `microsoft.ad.offline_join` flow to domain-join VMs at first boot without DC connectivity from the provisioner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFcBx1EitVQkRAewjSgi8H
