### PR TITLE
feat(grafana-kiosk): boot-to-dashboard Pi Zero 2 W kiosk + 512MB molecule scenario

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -20,3 +20,8 @@ exclude_paths:
   - molecule/ghapp-e2e/create.yml
   - molecule/ghapp-e2e/destroy.yml
   - molecule/ghapp-e2e/prepare.yml
+  # grafana-kiosk provisioner shims: same david_igou.molecule_provisioners
+  # situation as ghapp-e2e above. converge/verify/prepare_mock stay linted.
+  - molecule/grafana-kiosk/create.yml
+  - molecule/grafana-kiosk/destroy.yml
+  - molecule/grafana-kiosk/prepare.yml

--- a/molecule/grafana-kiosk/collections.yml
+++ b/molecule/grafana-kiosk/collections.yml
@@ -1,0 +1,6 @@
+---
+# Test-only dependency, resolved by molecule's dependency step (kept out of
+# the main requirements.yml so it never lands in EE images).
+collections:
+  - name: david_igou.molecule_provisioners
+    version: 0.0.4-alpha

--- a/molecule/grafana-kiosk/converge.yml
+++ b/molecule/grafana-kiosk/converge.yml
@@ -1,0 +1,3 @@
+---
+- name: Converge the grafana-kiosk setup play
+  ansible.builtin.import_playbook: ../../playbooks/grafana-kiosk/setup-kiosk.yaml

--- a/molecule/grafana-kiosk/create.yml
+++ b/molecule/grafana-kiosk/create.yml
@@ -1,0 +1,3 @@
+---
+- name: Provision molecule instances
+  ansible.builtin.import_playbook: david_igou.molecule_provisioners.create

--- a/molecule/grafana-kiosk/destroy.yml
+++ b/molecule/grafana-kiosk/destroy.yml
@@ -1,0 +1,3 @@
+---
+- name: Destroy molecule instances
+  ansible.builtin.import_playbook: david_igou.molecule_provisioners.destroy

--- a/molecule/grafana-kiosk/inventory/group_vars/grafana_kiosk.yml
+++ b/molecule/grafana-kiosk/inventory/group_vars/grafana_kiosk.yml
@@ -1,0 +1,10 @@
+---
+# Converge vars for the kiosk play inside molecule containers: mock Grafana
+# upstream (started by prepare.yml) + a dummy token so no 1Password access
+# is needed in CI.
+kiosk_grafana_url: http://127.0.0.1:3000
+kiosk_grafana_token: molecule-dummy-token
+kiosk_dashboard_path: /d/mock/dashboard?orgId=1
+# Molecule guests (containers AND headless qemu VMs) have no DRM/display -
+# leave the browser unit enabled-but-stopped; verify runs headless smokes.
+kiosk_start_browser: false

--- a/molecule/grafana-kiosk/inventory/group_vars/molecule.yml
+++ b/molecule/grafana-kiosk/inventory/group_vars/molecule.yml
@@ -1,0 +1,40 @@
+---
+mp_backend: "{{ lookup('env', 'PROVISIONER') | default('podman', true) }}"
+
+# Both backends pin the Pi Zero 2 W memory envelope: 512MB RAM plus a 512MB
+# swap allowance, mirroring the zram swap the play configures on the real
+# board (memory.max stays 512m; dpkg/browsers can spill to swap like they
+# would to zram). Converge and the browser smokes all run inside that cap.
+#
+# NOTE: in the igou devcontainer use PROVISIONER=docker - nested rootless
+# podman there has no cgroup delegation, so it cannot boot systemd containers
+# and silently ignores --memory. Docker runs host-side and enforces both.
+mp_defaults:
+  podman:
+    image: "docker.io/geerlingguy/docker-{{ lookup('env', 'MOLECULE_DISTRO') | default('debian12', true) }}-ansible:latest"
+    command: /sbin/init
+    privileged: false
+    systemd: always
+    cgroupns: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    extra_opts:
+      - --memory=512m
+      - --memory-swap=1g
+  docker:
+    image: "docker.io/geerlingguy/docker-{{ lookup('env', 'MOLECULE_DISTRO') | default('debian12', true) }}-ansible:latest"
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    memory: 512m
+    memory_swap: 1g
+  # Real VMs: the closest analog to the Pi - 512MiB of actual RAM, and the
+  # metal-only play paths (zram swap, sysctls) genuinely execute. Browser
+  # smokes then run against real memory pressure with zram active.
+  qemu:
+    image: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
+    ssh_user: debian
+    cpus: 2
+    memory: 512

--- a/molecule/grafana-kiosk/inventory/hosts.yml
+++ b/molecule/grafana-kiosk/inventory/hosts.yml
@@ -1,0 +1,25 @@
+---
+all:
+  children:
+    molecule:
+      hosts:
+        # All container settings come from mp_defaults (group_vars); the
+        # empty backend blocks mark which backends each host supports.
+        kiosk-cog:
+          kiosk_stack: cog
+          mp:
+            podman: {}
+            docker: {}
+            qemu: {}
+        kiosk-chromium:
+          kiosk_stack: chromium
+          mp:
+            podman: {}
+            docker: {}
+            qemu: {}
+    # The setup play's default hosts pattern; the real igou-inventory adds
+    # the same group around kiosk.igou.systems.
+    grafana_kiosk:
+      hosts:
+        kiosk-cog:
+        kiosk-chromium:

--- a/molecule/grafana-kiosk/molecule.yml
+++ b/molecule/grafana-kiosk/molecule.yml
@@ -1,0 +1,48 @@
+---
+# Grafana kiosk scenario: converges BOTH browser stacks (cog + chromium)
+# inside podman containers hard-capped at the Pi Zero 2 W's 512MB, then
+# smoke-tests real browser rendering inside that memory envelope.
+#
+# Provisioning is delegated to david_igou.molecule_provisioners
+# (inventory-driven; see inventory/hosts.yml for the instances and
+# inventory/group_vars/ for the memory caps and kiosk vars).
+prerun: false
+
+ansible:
+  cfg:
+    defaults:
+      # molecule generates its own ansible.cfg, so restate collection/role
+      # resolution paths
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles:${MOLECULE_PROJECT_DIRECTORY}/.ansible/roles:~/.ansible/roles
+      collections_path: ${MOLECULE_PROJECT_DIRECTORY}/.ansible/collections:~/.ansible/collections
+  executor:
+    args:
+      ansible_playbook:
+        - --inventory=inventory/
+        - --inventory=${MOLECULE_EPHEMERAL_DIRECTORY}/inventory/
+  playbooks:
+    create: create.yml
+    destroy: destroy.yml
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+
+dependency:
+  name: galaxy
+  options:
+    requirements-file: collections.yml
+
+scenario:
+  name: grafana-kiosk
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy
+
+verifier:
+  name: ansible

--- a/molecule/grafana-kiosk/prepare.yml
+++ b/molecule/grafana-kiosk/prepare.yml
@@ -1,0 +1,70 @@
+---
+- name: Prepare molecule instances
+  ansible.builtin.import_playbook: david_igou.molecule_provisioners.prepare
+
+- name: Stand up a mock Grafana upstream
+  hosts: molecule
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Install the mock Grafana server
+      ansible.builtin.copy:
+        dest: /usr/local/bin/mock-grafana
+        content: |
+          #!/usr/bin/env python3
+          """Mock Grafana: 200 JSON for every GET, echoing the Authorization
+          header back so verify can prove nginx injected the SA token."""
+          import json
+          from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+          class Handler(BaseHTTPRequestHandler):
+              def do_GET(self):
+                  body = json.dumps({
+                      "path": self.path,
+                      "authorization": self.headers.get("Authorization", ""),
+                  }).encode()
+                  self.send_response(200)
+                  self.send_header("Content-Type", "application/json")
+                  self.send_header("Content-Length", str(len(body)))
+                  self.end_headers()
+                  self.wfile.write(body)
+
+              def log_message(self, *args):
+                  pass
+
+
+          HTTPServer(("127.0.0.1", 3000), Handler).serve_forever()
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Install the mock Grafana unit
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/mock-grafana.service
+        content: |
+          [Unit]
+          Description=Mock Grafana for molecule verify
+
+          [Service]
+          ExecStart=/usr/local/bin/mock-grafana
+          Restart=always
+
+          [Install]
+          WantedBy=multi-user.target
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Start mock Grafana
+      ansible.builtin.systemd_service:
+        name: mock-grafana.service
+        enabled: true
+        state: started
+        daemon_reload: true
+
+    - name: Wait for mock Grafana to listen
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 3000
+        timeout: 30

--- a/molecule/grafana-kiosk/prepare.yml
+++ b/molecule/grafana-kiosk/prepare.yml
@@ -1,70 +1,9 @@
 ---
+# Pure import shim (excluded from ansible-lint: the collection playbook is
+# pinned in this scenario's collections.yml, not installed in the lint env).
+# The mock-Grafana play lives in prepare_mock.yml, which stays linted.
 - name: Prepare molecule instances
   ansible.builtin.import_playbook: david_igou.molecule_provisioners.prepare
 
-- name: Stand up a mock Grafana upstream
-  hosts: molecule
-  become: true
-  gather_facts: false
-  tasks:
-    - name: Install the mock Grafana server
-      ansible.builtin.copy:
-        dest: /usr/local/bin/mock-grafana
-        content: |
-          #!/usr/bin/env python3
-          """Mock Grafana: 200 JSON for every GET, echoing the Authorization
-          header back so verify can prove nginx injected the SA token."""
-          import json
-          from http.server import BaseHTTPRequestHandler, HTTPServer
-
-
-          class Handler(BaseHTTPRequestHandler):
-              def do_GET(self):
-                  body = json.dumps({
-                      "path": self.path,
-                      "authorization": self.headers.get("Authorization", ""),
-                  }).encode()
-                  self.send_response(200)
-                  self.send_header("Content-Type", "application/json")
-                  self.send_header("Content-Length", str(len(body)))
-                  self.end_headers()
-                  self.wfile.write(body)
-
-              def log_message(self, *args):
-                  pass
-
-
-          HTTPServer(("127.0.0.1", 3000), Handler).serve_forever()
-        owner: root
-        group: root
-        mode: "0755"
-
-    - name: Install the mock Grafana unit
-      ansible.builtin.copy:
-        dest: /etc/systemd/system/mock-grafana.service
-        content: |
-          [Unit]
-          Description=Mock Grafana for molecule verify
-
-          [Service]
-          ExecStart=/usr/local/bin/mock-grafana
-          Restart=always
-
-          [Install]
-          WantedBy=multi-user.target
-        owner: root
-        group: root
-        mode: "0644"
-
-    - name: Start mock Grafana
-      ansible.builtin.systemd_service:
-        name: mock-grafana.service
-        enabled: true
-        state: started
-        daemon_reload: true
-
-    - name: Wait for mock Grafana to listen
-      ansible.builtin.wait_for:
-        host: 127.0.0.1
-        port: 3000
-        timeout: 30
+- name: Stand up the mock Grafana upstream
+  ansible.builtin.import_playbook: prepare_mock.yml

--- a/molecule/grafana-kiosk/prepare_mock.yml
+++ b/molecule/grafana-kiosk/prepare_mock.yml
@@ -1,0 +1,67 @@
+---
+- name: Stand up a mock Grafana upstream
+  hosts: molecule
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Install the mock Grafana server
+      ansible.builtin.copy:
+        dest: /usr/local/bin/mock-grafana
+        content: |
+          #!/usr/bin/env python3
+          """Mock Grafana: 200 JSON for every GET, echoing the Authorization
+          header back so verify can prove nginx injected the SA token."""
+          import json
+          from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+          class Handler(BaseHTTPRequestHandler):
+              def do_GET(self):
+                  body = json.dumps({
+                      "path": self.path,
+                      "authorization": self.headers.get("Authorization", ""),
+                  }).encode()
+                  self.send_response(200)
+                  self.send_header("Content-Type", "application/json")
+                  self.send_header("Content-Length", str(len(body)))
+                  self.end_headers()
+                  self.wfile.write(body)
+
+              def log_message(self, *args):
+                  pass
+
+
+          HTTPServer(("127.0.0.1", 3000), Handler).serve_forever()
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Install the mock Grafana unit
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/mock-grafana.service
+        content: |
+          [Unit]
+          Description=Mock Grafana for molecule verify
+
+          [Service]
+          ExecStart=/usr/local/bin/mock-grafana
+          Restart=always
+
+          [Install]
+          WantedBy=multi-user.target
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Start mock Grafana
+      ansible.builtin.systemd_service:
+        name: mock-grafana.service
+        enabled: true
+        state: started
+        daemon_reload: true
+
+    - name: Wait for mock Grafana to listen
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 3000
+        timeout: 30

--- a/molecule/grafana-kiosk/verify.yml
+++ b/molecule/grafana-kiosk/verify.yml
@@ -1,0 +1,78 @@
+---
+- name: Verify the grafana-kiosk convergence
+  hosts: grafana_kiosk
+  become: true
+  gather_facts: false
+
+  vars:
+    _verify_proxy: http://127.0.0.1:8480
+    _verify_unit: "{{ 'cog-kiosk.service' if kiosk_stack == 'cog' else 'grafana-kiosk.service' }}"
+
+  tasks:
+    - name: Fetch a dashboard URL through the proxy
+      ansible.builtin.uri:
+        url: "{{ _verify_proxy }}/d/mock/dashboard"
+        return_content: true
+      register: verify_proxy_get
+
+    - name: Assert nginx injected the SA token end to end
+      ansible.builtin.assert:
+        that:
+          - verify_proxy_get.json.authorization == 'Bearer molecule-dummy-token'
+        fail_msg: >-
+          Proxy did not inject the Authorization header:
+          {{ verify_proxy_get.json }}
+
+    - name: Stat the token-bearing nginx config
+      ansible.builtin.stat:
+        path: /etc/nginx/sites-available/grafana-kiosk.conf
+      register: verify_nginx_conf
+
+    - name: Assert the token-bearing config is root-only
+      ansible.builtin.assert:
+        that:
+          - verify_nginx_conf.stat.mode == '0600'
+          - verify_nginx_conf.stat.pw_name == 'root'
+
+    - name: Collect service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert the kiosk unit is installed and enabled
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services[_verify_unit].status == 'enabled'
+        fail_msg: >-
+          {{ _verify_unit }}:
+          {{ ansible_facts.services[_verify_unit] | default('unit not found') }}
+
+    # --- Low-resource smoke: real browser rendering inside the 512MB cgroup.
+    # Headless because containers have no DRM/X; the memory ceiling is what
+    # is under test (an OOM kill fails the task).
+
+    - name: Render a screenshot with headless Chromium through the proxy
+      ansible.builtin.command:
+        cmd: >-
+          timeout 90 chromium --headless --no-sandbox --disable-gpu
+          --disable-dev-shm-usage --screenshot=/tmp/kiosk-smoke.png
+          --window-size=1280,720 {{ _verify_proxy }}/d/mock/dashboard
+      changed_when: false
+      when: kiosk_stack == 'chromium'
+
+    - name: Assert the Chromium screenshot rendered
+      ansible.builtin.stat:
+        path: /tmp/kiosk-smoke.png
+      register: verify_shot
+      failed_when: not verify_shot.stat.exists or verify_shot.stat.size == 0
+      when: kiosk_stack == 'chromium'
+
+    - name: Run headless cog against the proxy for 20s
+      ansible.builtin.command:
+        cmd: timeout 20 cog --platform=headless {{ _verify_proxy }}/d/mock/dashboard
+      environment:
+        XDG_RUNTIME_DIR: /tmp
+      register: verify_cog
+      changed_when: false
+      # timeout(1) rc 124 = cog was still alive after 20s of rendering; any
+      # other rc means it crashed or was OOM-killed.
+      failed_when: verify_cog.rc != 124
+      when: kiosk_stack == 'cog'

--- a/playbooks/grafana-kiosk/README.md
+++ b/playbooks/grafana-kiosk/README.md
@@ -1,0 +1,82 @@
+# grafana-kiosk
+
+Boot-to-dashboard Grafana kiosk for a Raspberry Pi Zero 2 W, provisioned from
+a stock Raspberry Pi OS **Lite** (arm64) install.
+
+> **Hardware constraint:** the original Pi Zero / Zero W (ARMv6) has no
+> working Chromium or usable WebKit on current Raspberry Pi OS. This domain
+> is for the Zero 2 W (or anything bigger).
+
+## Architecture
+
+Both browser stacks display Grafana through a **local nginx proxy**
+(`127.0.0.1:8480`) that injects `Authorization: Bearer <service-account
+token>` and forwards to the real Grafana. The token lives in exactly one
+root-only file on the Pi; the browser needs no login automation. Grafana's
+kiosk/playlist/refresh behaviors are all URL parameters, so they work in any
+browser.
+
+Two switchable stacks (`kiosk_stack`):
+
+| Stack | What runs | When |
+|---|---|---|
+| `cog` (default) | cog/WPE WebKit straight onto DRM/KMS via seatd — no X, no compositor | Lightest on 512MB. **Bench-test gate:** GPU accel through cog's DRM backend is unreliable on Pi vc4/v3d (Igalia/cog#368 closed not-planned) and Grafana-on-WPE has no public precedent — validate your dashboard renders before committing. |
+| `chromium` | minimal X11 (xinit + openbox) + [grafana/grafana-kiosk](https://github.com/grafana/grafana-kiosk) driving Chromium | Proven fallback. X11 deliberately: grafana-kiosk's Wayland autostart is broken upstream (grafana-kiosk#135). |
+
+Switching `kiosk_stack` on a converged host retires the other stack's
+service automatically.
+
+Memory/SD tuning applied on real hardware (skipped in containers): zstd zram
+(`ram / 2`) + `vm.swappiness=100`, `gpu_mem=96` + `disable_splash=1` in the
+Pi boot config, volatile capped journald. Services carry
+`RuntimeMaxSec=24h` + `Restart=always` to recycle leaking browsers daily.
+
+## Playbooks
+
+- `converge.yaml` — guard (requires `--limit`) → `linux/baseline.yaml` →
+  `linux/node_exporter.yaml` → `setup-kiosk.yaml`.
+- `setup-kiosk.yaml` — proxy, tuning, and the selected browser stack. Targets
+  `ansible_limit | default('grafana_kiosk')`.
+
+```bash
+ansible-playbook playbooks/grafana-kiosk/converge.yaml \
+  -i igou-inventory/inventory.yaml -l kiosk.igou.systems
+```
+
+## Variables (host_vars)
+
+| Var | Default | Notes |
+|---|---|---|
+| `kiosk_grafana_url` | — **required** | Upstream Grafana origin, e.g. `https://grafana.example.com` |
+| `kiosk_stack` | `cog` | `cog` or `chromium` |
+| `kiosk_dashboard_path` | `/` | e.g. `/playlists/play/<uid>` or `/d/<uid>/<slug>?orgId=1&refresh=30s` |
+| `kiosk_grafana_token` | 1Password lookup | Explicit token (CI only — prefer the op lookup) |
+| `kiosk_grafana_token_op_item` / `_op_vault` / `_op_field` | `grafana-kiosk` / `claude` / `password` | 1Password coordinates of the SA token |
+| `kiosk_proxy_listen` | `127.0.0.1:8480` | |
+| `kiosk_playlist` | `false` | grafana-kiosk playlist mode (chromium stack) |
+| `kiosk_grafana_kiosk_mode` | `full` | grafana-kiosk kiosk-mode (chromium stack) |
+| `kiosk_service_max_runtime` | `24h` | Daily browser recycle |
+| `kiosk_zram_size` | `ram / 2` | zram-generator expression |
+| `kiosk_gpu_mem` | `96` | Pi GPU memory split |
+| `kiosk_drm_video_mode` | unset | e.g. `1920x1080` (cog stack) |
+| `kiosk_chromium_packages` / `kiosk_chromium_bin` | Debian `chromium` | Override if RPi OS ships `chromium-browser` |
+| `kiosk_verify_api` | `true` | End-of-play proxy/token verification |
+
+## Prerequisites
+
+1. Grafana service account (Viewer) + token, stored in 1Password
+   (`op://claude/grafana-kiosk/password` by default).
+2. Inventory: host in the `grafana_kiosk` group with `kiosk_grafana_url` in
+   host_vars; rb5009 DHCP lease (MAC-only, no client-id) + DNS record.
+3. Pi flashed with Raspberry Pi OS Lite arm64 (Imager customization:
+   hostname, `igou` user + fleet key).
+
+## Testing
+
+`molecule test -s grafana-kiosk` converges **both stacks** in podman
+containers hard-capped at 512MB (`--memory=512m --memory-swap=512m` — the Pi
+Zero 2 W envelope), against a mock Grafana that echoes the Authorization
+header. Verify proves end-to-end token injection, unit enablement, config
+permissions, and runs real headless browser renders (Chromium screenshot,
+cog 20s survival) inside the memory cap. Provisioning uses
+`david_igou.molecule_provisioners` (see `molecule/grafana-kiosk/inventory/`).

--- a/playbooks/grafana-kiosk/converge.yaml
+++ b/playbooks/grafana-kiosk/converge.yaml
@@ -1,0 +1,31 @@
+---
+# Full convergence for the grafana kiosk Pi: linux baseline + node_exporter +
+# the kiosk proxy/browser stack.
+#
+#   ansible-playbook playbooks/grafana-kiosk/converge.yaml \
+#     -i igou-inventory/inventory.yaml -l kiosk.igou.systems
+#
+# The imported linux plays target `ansible_limit | default('all')`, so an
+# unlimited run would baseline the entire fleet. The guard play below makes
+# a missing --limit a hard error instead.
+- name: Guard - refuse to run without an explicit limit
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Require --limit so imported fleet-wide plays stay scoped
+      ansible.builtin.assert:
+        that: ansible_limit is defined
+        fail_msg: >-
+          Run this playbook with an explicit limit, e.g.
+          -l kiosk.igou.systems. The imported baseline/node_exporter
+          plays default to 'all' without one.
+
+- name: Import linux baseline
+  ansible.builtin.import_playbook: ../linux/baseline.yaml
+
+- name: Import node_exporter deployment
+  ansible.builtin.import_playbook: ../linux/node_exporter.yaml
+
+- name: Import kiosk setup
+  ansible.builtin.import_playbook: setup-kiosk.yaml

--- a/playbooks/grafana-kiosk/setup-kiosk.yaml
+++ b/playbooks/grafana-kiosk/setup-kiosk.yaml
@@ -1,0 +1,309 @@
+---
+# Grafana kiosk convergence - local auth proxy, memory/SD tuning, and the
+# browser/display stack. Provisions a Raspberry Pi Zero 2 W (or any
+# Debian-family host) from a stock Raspberry Pi OS Lite install into a
+# boot-to-dashboard Grafana kiosk.
+#
+# Browser stacks (kiosk_stack):
+#   cog      - WPE WebKit rendering straight to DRM/KMS; no X server, no
+#              compositor. Lightest option for a 512MB board. DEFAULT.
+#   chromium - minimal X11 (xinit + openbox) with grafana/grafana-kiosk
+#              driving Chromium. Proven fallback if WPE misrenders a
+#              dashboard. Switching kiosk_stack retires the other stack's
+#              service automatically.
+#
+# Both stacks browse http://127.0.0.1:<port>, where a local nginx injects
+# `Authorization: Bearer <service-account token>` and proxies to Grafana -
+# the token lives in exactly one root-only file and the browser stays dumb.
+# Grafana's kiosk/playlist/refresh features are all URL parameters, so no
+# client-side login automation is needed on either stack.
+#
+# Required in host_vars: kiosk_grafana_url (e.g. https://grafana.example.com)
+# Secrets: the Grafana service-account token resolves from 1Password on the
+# controller (kiosk_grafana_token_op_*); CI/molecule passes an explicit
+# kiosk_grafana_token instead.
+- name: Grafana kiosk convergence - proxy, tuning, browser stack
+  hosts: "{{ ansible_limit | default('grafana_kiosk') }}"
+  become: true
+  gather_facts: true
+
+  vars:
+    # Effective values; inventory overrides the un-prefixed names (play vars
+    # outrank inventory, hence the default() merge pattern).
+    _kiosk_stack: "{{ kiosk_stack | default('cog') }}"
+    _kiosk_user: "{{ kiosk_user | default('kiosk') }}"
+    _kiosk_proxy_listen: "{{ kiosk_proxy_listen | default('127.0.0.1:8480') }}"
+    _kiosk_proxy_base: "http://{{ _kiosk_proxy_listen }}"
+    # Dashboard or playlist path, e.g. '/playlists/play/<uid>' or
+    # '/d/<uid>/<slug>?orgId=1&refresh=30s'. The cog stack appends Grafana's
+    # kiosk URL param itself; grafana-kiosk adds it via kiosk-mode.
+    _kiosk_dashboard_path: "{{ kiosk_dashboard_path | default('/') }}"
+    _kiosk_cog_url: >-
+      {{ _kiosk_proxy_base ~ _kiosk_dashboard_path
+         ~ ('&kiosk' if '?' in _kiosk_dashboard_path else '?kiosk') }}
+    # Explicit token wins (molecule/CI); otherwise resolve from 1Password on
+    # the controller. The inline-if keeps the lookup lazy so container runs
+    # never touch 1Password.
+    _kiosk_grafana_token: >-
+      {{ kiosk_grafana_token
+         if kiosk_grafana_token is defined
+         else lookup('community.general.onepassword',
+                     kiosk_grafana_token_op_item | default('grafana-kiosk'),
+                     field=kiosk_grafana_token_op_field | default('password'),
+                     vault=kiosk_grafana_token_op_vault | default('claude')) }}
+    # Chromium leaks on live dashboards (OOM within 6-8h on 512MB boards is
+    # widely reported); RuntimeMaxSec + Restart=always recycles the whole
+    # browser session daily before it gets there.
+    _kiosk_service_max_runtime: "{{ kiosk_service_max_runtime | default('24h') }}"
+    _kiosk_zram_size: "{{ kiosk_zram_size | default('ram / 2') }}"
+    _kiosk_gpu_mem: "{{ kiosk_gpu_mem | default(96) }}"
+    _kiosk_unit: "{{ 'cog-kiosk.service' if _kiosk_stack == 'cog' else 'grafana-kiosk.service' }}"
+    _kiosk_other_unit: "{{ 'grafana-kiosk.service' if _kiosk_stack == 'cog' else 'cog-kiosk.service' }}"
+    # Containers (molecule) have no kernel knobs, DRM, or display: install
+    # and enable everything, but skip zram/sysctl and service starts.
+    _kiosk_is_container: >-
+      {{ ansible_virtualization_type | default('')
+         in ['container', 'podman', 'docker', 'lxc', 'containerd'] }}
+    # Whether to start (and verify) the browser service. Defaults to "not a
+    # container", but headless guests without DRM/display (molecule qemu VMs,
+    # a Pi staged without a monitor) set kiosk_start_browser: false - the
+    # unit stays enabled and starts on next boot with a display attached.
+    _kiosk_start_browser: "{{ kiosk_start_browser | default(not _kiosk_is_container) }}"
+    # grafana-kiosk release pinning (chromium stack). Upstream publishes no
+    # checksums file, so sha256s are computed from the release assets and
+    # pinned here per version/arch. Extend the map when bumping the version.
+    _kiosk_gk_version: "{{ kiosk_grafana_kiosk_version | default('1.0.12') }}"
+    _kiosk_gk_arch: >-
+      {{ {'x86_64': 'amd64',
+          'aarch64': 'arm64',
+          'armv7l': 'armv7'}[ansible_architecture] }}
+    _kiosk_gk_checksums:
+      "1.0.12":
+        arm64: 8a3a8553d98ac91563677b3660c4d962bb5582c5d4f9c5cb3a0742cae8e49e47
+        amd64: 3bd8f535149e98b7ef72110fa1020963d5da0b97602cd232a0766f0554905696
+        armv7: cdc139752a48d4b4e197db3fcca9ca34af6de027ed8072ca1aadeb613c2e255d
+
+  tasks:
+    - name: Validate kiosk configuration
+      ansible.builtin.assert:
+        that:
+          - kiosk_grafana_url is defined
+          - _kiosk_stack in ['cog', 'chromium']
+        fail_msg: >-
+          Set kiosk_grafana_url (e.g. https://grafana.example.com) in
+          host_vars, and kiosk_stack to 'cog' or 'chromium'.
+
+    # video/input are static base groups and render normally comes from
+    # udev, but molecule's slim containers lack it - ensure all three.
+    - name: Ensure display/input groups exist
+      ansible.builtin.group:
+        name: "{{ item }}"
+        state: present
+        system: true
+      loop:
+        - video
+        - render
+        - input
+
+    - name: Create the kiosk user
+      ansible.builtin.user:
+        name: "{{ _kiosk_user }}"
+        groups:
+          - video
+          - render
+          - input
+        append: true
+        shell: /usr/sbin/nologin
+        create_home: true
+        password_lock: true
+        system: false
+        state: present
+
+    - name: Install proxy and tuning packages
+      ansible.builtin.apt:
+        name:
+          - nginx-light
+          - systemd-zram-generator
+          - fonts-dejavu-core
+        state: present
+        install_recommends: false
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Create journald drop-in directory
+      ansible.builtin.file:
+        path: /etc/systemd/journald.conf.d
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Keep journald off the SD card (volatile, capped)
+      ansible.builtin.copy:
+        dest: /etc/systemd/journald.conf.d/50-grafana-kiosk.conf
+        content: |
+          # Managed by playbooks/grafana-kiosk/setup-kiosk.yaml
+          [Journal]
+          Storage=volatile
+          RuntimeMaxUse=32M
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart journald
+
+    - name: Configure zram swap (zstd)
+      ansible.builtin.template:
+        src: templates/zram-generator.conf.j2
+        dest: /etc/systemd/zram-generator.conf
+        owner: root
+        group: root
+        mode: "0644"
+      notify: Restart zram swap
+
+    # Activate zram now, not at end-of-play handler time: the browser stack
+    # install below unpacks Chromium-sized debs, and a first converge on a
+    # 512MB board needs the swap headroom already in place.
+    - name: Activate zram swap
+      ansible.builtin.systemd_service:
+        name: systemd-zram-setup@zram0.service
+        state: started
+        daemon_reload: true
+      when: not _kiosk_is_container
+
+    # Own sysctl file: devsec os_hardening (linux baseline) writes its own
+    # and merges baseline_sysctl_overwrite separately - no collision.
+    - name: Pair sysctls with zram (swap aggressively into compressed RAM)
+      ansible.posix.sysctl:
+        name: "{{ item.name }}"
+        value: "{{ item.value }}"
+        sysctl_file: /etc/sysctl.d/85-grafana-kiosk.conf
+        sysctl_set: true
+        state: present
+      loop:
+        - name: vm.swappiness
+          value: "100"
+        - name: vm.page-cluster
+          value: "0"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not _kiosk_is_container
+
+    - name: Check for Raspberry Pi firmware config
+      ansible.builtin.stat:
+        path: /boot/firmware/config.txt
+      register: _kiosk_bootconf
+
+    - name: Tune Pi boot config (gpu_mem, no splash)
+      ansible.builtin.blockinfile:
+        path: /boot/firmware/config.txt
+        marker: "# {mark} ANSIBLE MANAGED - grafana-kiosk"
+        block: |
+          gpu_mem={{ _kiosk_gpu_mem }}
+          disable_splash=1
+      when: _kiosk_bootconf.stat.exists
+
+    - name: Template the auth-injecting Grafana proxy (holds the SA token)
+      ansible.builtin.template:
+        src: templates/grafana-proxy.conf.j2
+        dest: /etc/nginx/sites-available/grafana-kiosk.conf
+        owner: root
+        group: root
+        mode: "0600"
+      no_log: true
+      notify: Reload nginx
+
+    - name: Enable the proxy site
+      ansible.builtin.file:
+        src: /etc/nginx/sites-available/grafana-kiosk.conf
+        dest: /etc/nginx/sites-enabled/grafana-kiosk.conf
+        state: link
+      notify: Reload nginx
+
+    - name: Remove the default nginx site
+      ansible.builtin.file:
+        path: /etc/nginx/sites-enabled/default
+        state: absent
+      notify: Reload nginx
+
+    - name: Enable and start nginx
+      ansible.builtin.systemd_service:
+        name: nginx.service
+        enabled: true
+        state: started
+
+    - name: Include browser stack tasks - {{ _kiosk_stack }}
+      ansible.builtin.include_tasks: "stack_tasks/_stack_{{ _kiosk_stack }}.yml"
+
+    # Clean stack switching: if the other stack was deployed before, retire
+    # its service so two browsers never fight over the display.
+    - name: Check whether the other stack was previously deployed
+      ansible.builtin.stat:
+        path: "/etc/systemd/system/{{ _kiosk_other_unit }}"
+      register: _kiosk_other_stat
+
+    - name: Retire the other stack's service
+      ansible.builtin.systemd_service:
+        name: "{{ _kiosk_other_unit }}"
+        enabled: false
+        state: stopped
+      when: _kiosk_other_stat.stat.exists
+
+    - name: Apply pending restarts before verifying
+      ansible.builtin.meta: flush_handlers
+
+    # Verification goes through the proxy, so a 200 proves nginx, upstream
+    # reachability, and token injection end to end. /api/search requires
+    # auth, so it fails on a bad or missing token.
+    - name: Verify the proxy reaches Grafana (/api/health)
+      ansible.builtin.uri:
+        url: "{{ _kiosk_proxy_base }}/api/health"
+        status_code: 200
+      register: _kiosk_health
+      retries: 5
+      delay: 3
+      until: _kiosk_health.status == 200
+      when: kiosk_verify_api | default(true)
+
+    - name: Verify the injected token is accepted (/api/search)
+      ansible.builtin.uri:
+        url: "{{ _kiosk_proxy_base }}/api/search?limit=1"
+        status_code: 200
+      when: kiosk_verify_api | default(true)
+
+    - name: Collect service facts
+      ansible.builtin.service_facts:
+      when: _kiosk_start_browser | bool
+
+    - name: Verify the kiosk service is active
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services[_kiosk_unit].state == 'running'
+        fail_msg: >-
+          {{ _kiosk_unit }} is not running:
+          {{ ansible_facts.services[_kiosk_unit] | default('unit not found') }}
+      when: _kiosk_start_browser | bool
+
+  handlers:
+    - name: Restart journald
+      ansible.builtin.systemd_service:
+        name: systemd-journald.service
+        state: restarted
+
+    - name: Restart zram swap
+      ansible.builtin.systemd_service:
+        name: systemd-zram-setup@zram0.service
+        state: restarted
+        daemon_reload: true
+      when: not _kiosk_is_container
+
+    - name: Reload nginx
+      ansible.builtin.systemd_service:
+        name: nginx.service
+        state: reloaded
+
+    - name: Restart kiosk service
+      ansible.builtin.systemd_service:
+        name: "{{ _kiosk_unit }}"
+        state: restarted
+        daemon_reload: true
+      when: _kiosk_start_browser | bool

--- a/playbooks/grafana-kiosk/stack_tasks/_stack_chromium.yml
+++ b/playbooks/grafana-kiosk/stack_tasks/_stack_chromium.yml
@@ -1,0 +1,122 @@
+---
+# Chromium browser stack: minimal X11 session driven by grafana/grafana-kiosk.
+# xinit owns the X server + session; when grafana-kiosk or Chromium dies the
+# session exits and systemd restarts the whole thing - one supervision point.
+#
+# X11 rather than Wayland deliberately: grafana-kiosk's Wayland autostart is
+# broken upstream (grafana/grafana-kiosk#135) and X11 + openbox is the
+# lighter, battle-tested path on 512MB boards.
+# install_recommends off keeps the footprint 512MB-sane (chromium's
+# recommends OOM-killed dpkg under the molecule memory cap); the modesetting
+# X driver is built into xserver-xorg-core, and libinput is added explicitly
+# for emergency keyboard access.
+- name: Install Chromium and the minimal X11 stack
+  ansible.builtin.apt:
+    name: "{{ kiosk_chromium_packages | default(_kiosk_chromium_default_packages) }}"
+    state: present
+    install_recommends: false
+  vars:
+    # Raspberry Pi OS may ship the browser as 'chromium-browser'; override
+    # kiosk_chromium_packages + kiosk_chromium_bin in host_vars if so.
+    _kiosk_chromium_default_packages:
+      - chromium
+      - xserver-xorg-core
+      - xserver-xorg-input-libinput
+      - xserver-xorg-legacy
+      - xinit
+      - x11-xserver-utils
+      - openbox
+      - unclutter
+
+# xserver-xorg-legacy lets the non-root kiosk user start X from a systemd
+# service (a Lite image has no logind graphical session to delegate from).
+- name: Allow non-root X startup
+  ansible.builtin.copy:
+    dest: /etc/X11/Xwrapper.config
+    content: |
+      # Managed by playbooks/grafana-kiosk/setup-kiosk.yaml
+      allowed_users=anybody
+      needs_root_rights=yes
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Create the grafana-kiosk release cache directory
+  ansible.builtin.file:
+    path: /opt/grafana-kiosk
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+# Versioned filename: bumping kiosk_grafana_kiosk_version downloads the new
+# asset and refreshes /usr/local/bin on the next run.
+- name: Download the grafana-kiosk release binary (sha256-verified)
+  ansible.builtin.get_url:
+    url: "https://github.com/grafana/grafana-kiosk/releases/download/v{{ _kiosk_gk_version }}/grafana-kiosk.linux.{{ _kiosk_gk_arch }}"
+    dest: "/opt/grafana-kiosk/grafana-kiosk-v{{ _kiosk_gk_version }}.linux.{{ _kiosk_gk_arch }}"
+    checksum: "sha256:{{ _kiosk_gk_checksums[_kiosk_gk_version][_kiosk_gk_arch] }}"
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Install grafana-kiosk into /usr/local/bin
+  ansible.builtin.copy:
+    src: "/opt/grafana-kiosk/grafana-kiosk-v{{ _kiosk_gk_version }}.linux.{{ _kiosk_gk_arch }}"
+    dest: /usr/local/bin/grafana-kiosk
+    remote_src: true
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart kiosk service
+
+- name: Create the grafana-kiosk config directory
+  ansible.builtin.file:
+    path: /etc/grafana-kiosk
+    state: directory
+    owner: root
+    group: "{{ _kiosk_user }}"
+    mode: "0750"
+
+- name: Template the grafana-kiosk config
+  ansible.builtin.template:
+    src: templates/grafana-kiosk-config.yaml.j2
+    dest: /etc/grafana-kiosk/config.yaml
+    owner: root
+    group: "{{ _kiosk_user }}"
+    mode: "0640"
+  notify: Restart kiosk service
+
+- name: Install the Chromium memory-diet wrapper
+  ansible.builtin.template:
+    src: templates/kiosk-browser.sh.j2
+    dest: /usr/local/bin/kiosk-browser
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart kiosk service
+
+- name: Install the X session script
+  ansible.builtin.template:
+    src: templates/kiosk-session.sh.j2
+    dest: /usr/local/bin/kiosk-session
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart kiosk service
+
+- name: Template the grafana-kiosk unit
+  ansible.builtin.template:
+    src: templates/grafana-kiosk.service.j2
+    dest: /etc/systemd/system/grafana-kiosk.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart kiosk service
+
+- name: Enable the grafana-kiosk service
+  ansible.builtin.systemd_service:
+    name: grafana-kiosk.service
+    enabled: true
+    state: "{{ 'started' if _kiosk_start_browser else omit }}"
+    daemon_reload: true

--- a/playbooks/grafana-kiosk/stack_tasks/_stack_cog.yml
+++ b/playbooks/grafana-kiosk/stack_tasks/_stack_cog.yml
@@ -1,0 +1,38 @@
+---
+# cog/WPE browser stack: WebKit rendering straight onto DRM/KMS. No X server
+# and no Wayland compositor - cog becomes DRM master on seat0 via seatd.
+#
+# Bench-test gate (see README): GPU acceleration through cog's DRM backend is
+# unreliable on Pi vc4/v3d (Igalia/cog#368) - expect software rendering, and
+# validate the actual dashboard renders before committing to this stack.
+- name: Install cog and seat management
+  ansible.builtin.apt:
+    name:
+      - cog
+      - seatd
+    state: present
+    install_recommends: false
+
+# Debian's seatd grants seat access to the 'video' group; the kiosk user is
+# a member (see setup-kiosk.yaml).
+- name: Enable seatd
+  ansible.builtin.systemd_service:
+    name: seatd.service
+    enabled: true
+    state: "{{ omit if _kiosk_is_container else 'started' }}"
+
+- name: Template the cog kiosk unit
+  ansible.builtin.template:
+    src: templates/cog-kiosk.service.j2
+    dest: /etc/systemd/system/cog-kiosk.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart kiosk service
+
+- name: Enable the cog kiosk service
+  ansible.builtin.systemd_service:
+    name: cog-kiosk.service
+    enabled: true
+    state: "{{ 'started' if _kiosk_start_browser else omit }}"
+    daemon_reload: true

--- a/playbooks/grafana-kiosk/templates/cog-kiosk.service.j2
+++ b/playbooks/grafana-kiosk/templates/cog-kiosk.service.j2
@@ -1,0 +1,33 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Grafana kiosk (cog/WPE WebKit on DRM)
+Wants=network-online.target
+After=network-online.target nginx.service seatd.service
+Requires=seatd.service
+Conflicts=getty@tty1.service
+After=getty@tty1.service
+
+[Service]
+User={{ _kiosk_user }}
+Group={{ _kiosk_user }}
+SupplementaryGroups=video render input
+# PAM session on tty1 gives cog seat0 and a runtime dir; seatd hands it DRM.
+PAMName=login
+TTYPath=/dev/tty1
+StandardInput=tty
+StandardOutput=journal
+StandardError=journal
+Environment=XDG_SEAT=seat0
+Environment=LIBSEAT_BACKEND=seatd
+{% if kiosk_drm_video_mode | default('') %}
+Environment=COG_PLATFORM_DRM_VIDEO_MODE={{ kiosk_drm_video_mode }}
+{% endif %}
+ExecStart=/usr/bin/cog --platform=drm --webprocess-failure=restart-exit "{{ _kiosk_cog_url }}"
+Restart=always
+RestartSec=5
+# Daily recycle: browsers leak on live dashboards; Restart=always brings the
+# session straight back.
+RuntimeMaxSec={{ _kiosk_service_max_runtime }}
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/grafana-kiosk/templates/grafana-kiosk-config.yaml.j2
+++ b/playbooks/grafana-kiosk/templates/grafana-kiosk-config.yaml.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+general:
+  kiosk-mode: {{ kiosk_grafana_kiosk_mode | default('full') }}
+  autofit: {{ kiosk_autofit | default(true) | lower }}
+  lxde: false
+  page-load-delay-ms: {{ kiosk_page_load_delay_ms | default(3000) }}
+target:
+  # Auth happens in the local nginx proxy; grafana-kiosk just navigates.
+  login-method: anon
+  URL: {{ _kiosk_proxy_base }}{{ _kiosk_dashboard_path }}
+  playlist: {{ kiosk_playlist | default(false) | lower }}

--- a/playbooks/grafana-kiosk/templates/grafana-kiosk.service.j2
+++ b/playbooks/grafana-kiosk/templates/grafana-kiosk.service.j2
@@ -1,0 +1,26 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Grafana kiosk (grafana-kiosk + Chromium on X11)
+Wants=network-online.target
+After=network-online.target nginx.service
+Conflicts=getty@tty1.service
+After=getty@tty1.service
+
+[Service]
+User={{ _kiosk_user }}
+Group={{ _kiosk_user }}
+PAMName=login
+TTYPath=/dev/tty1
+StandardInput=tty
+StandardOutput=journal
+StandardError=journal
+Environment=KIOSK_BROWSER_PATH=/usr/local/bin/kiosk-browser
+# xinit owns X + the session; when either dies systemd restarts both.
+ExecStart=/usr/bin/xinit /usr/local/bin/kiosk-session -- :0 vt1 -nocursor
+Restart=always
+RestartSec=5
+# Daily recycle: Chromium leaks on live dashboards (OOM in 6-8h on 512MB).
+RuntimeMaxSec={{ _kiosk_service_max_runtime }}
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/grafana-kiosk/templates/grafana-proxy.conf.j2
+++ b/playbooks/grafana-kiosk/templates/grafana-proxy.conf.j2
@@ -1,0 +1,29 @@
+# {{ ansible_managed }}
+# Local auth-injecting proxy for the Grafana kiosk. The browser talks to
+# {{ _kiosk_proxy_listen }} and never sees the service-account token; the
+# token lives only in this root-only file.
+
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  ''      close;
+}
+
+server {
+  listen {{ _kiosk_proxy_listen }};
+
+  location / {
+    proxy_pass {{ kiosk_grafana_url | regex_replace('/$', '') }};
+    proxy_set_header Authorization "Bearer {{ _kiosk_grafana_token }}";
+    # Grafana Live rejects websocket handshakes whose Origin mismatches
+    # root_url; present the upstream's own origin instead of 127.0.0.1.
+    proxy_set_header Origin {{ kiosk_grafana_url | regex_replace('/$', '') }};
+    # Websocket upgrade for /api/live (harmless for plain requests).
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+{% if kiosk_grafana_url.startswith('https:') %}
+    proxy_ssl_server_name on;
+{% endif %}
+    proxy_read_timeout 3600s;
+  }
+}

--- a/playbooks/grafana-kiosk/templates/kiosk-browser.sh.j2
+++ b/playbooks/grafana-kiosk/templates/kiosk-browser.sh.j2
@@ -1,0 +1,14 @@
+#!/bin/sh
+# {{ ansible_managed }}
+# Chromium wrapper for grafana-kiosk (KIOSK_BROWSER_PATH): grafana-kiosk has
+# no arbitrary-flag passthrough, so the 512MB memory-diet flags live here.
+# --no-memcheck suppresses Chromium's blocking "less than 1GB RAM" dialog.
+exec {{ kiosk_chromium_bin | default('/usr/bin/chromium') }} \
+  --no-memcheck \
+  --disable-dev-shm-usage \
+  --disk-cache-size=16777216 \
+  --aggressive-cache-discard \
+  --disable-background-timer-throttling \
+  --disable-backgrounding-occluded-windows \
+  --disable-renderer-backgrounding \
+  "$@"

--- a/playbooks/grafana-kiosk/templates/kiosk-session.sh.j2
+++ b/playbooks/grafana-kiosk/templates/kiosk-session.sh.j2
@@ -1,0 +1,10 @@
+#!/bin/sh
+# {{ ansible_managed }}
+# X session for the chromium kiosk stack, started by xinit from
+# grafana-kiosk.service. grafana-kiosk launches Chromium via the
+# KIOSK_BROWSER_PATH wrapper (set in the unit).
+xset s off
+xset -dpms
+openbox &
+unclutter -idle 1 -root &
+exec /usr/local/bin/grafana-kiosk -c /etc/grafana-kiosk/config.yaml

--- a/playbooks/grafana-kiosk/templates/zram-generator.conf.j2
+++ b/playbooks/grafana-kiosk/templates/zram-generator.conf.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+# zstd zram swap: on a 512MB board this roughly triples usable memory and
+# keeps swap off the SD card (pairs with vm.swappiness=100).
+[zram0]
+zram-size = {{ _kiosk_zram_size }}
+compression-algorithm = zstd
+swap-priority = 100


### PR DESCRIPTION
## Summary

New `playbooks/grafana-kiosk/` domain provisioning a Grafana dashboard kiosk on a **Raspberry Pi Zero 2 W** from stock Raspberry Pi OS Lite (arm64), following the upsmonitor pattern (guard play → `linux/baseline` → `linux/node_exporter` → `setup-kiosk`), plus a memory-capped molecule scenario.

### Architecture
- **Auth proxy**: both browser stacks display Grafana through a local nginx proxy (`127.0.0.1:8480`) that injects `Authorization: Bearer <service-account token>` (resolved via `community.general.onepassword` at deploy time, or an explicit var in CI). The token lives in exactly one root-only file; the browser needs no login automation. Handles the `/api/live` websocket upgrade and rewrites `Origin` so Grafana Live's origin check passes.
- **`kiosk_stack: cog` (default)**: cog/WPE WebKit rendering straight onto DRM/KMS via seatd — no X server, no compositor. Lightest option for 512MB. ⚠️ Bench-test gate before trusting on hardware: GPU accel through cog's DRM backend is unreliable on Pi vc4/v3d (Igalia/cog#368).
- **`kiosk_stack: chromium` (fallback)**: minimal X11 (xinit + openbox, `xserver-xorg-legacy` for non-root X) + [grafana/grafana-kiosk](https://github.com/grafana/grafana-kiosk) v1.0.12 (sha256-pinned per arch; upstream ships no checksums file) driving Chromium through a memory-diet wrapper. X11 deliberately — grafana-kiosk's Wayland autostart is broken upstream (grafana/grafana-kiosk#135). Switching stacks retires the other unit automatically.
- **512MB tuning**: zstd zram (activated mid-play, *before* the browser install — chromium's debs OOM-killed dpkg without it), `vm.swappiness=100`/`vm.page-cluster=0`, `gpu_mem=96` + `disable_splash=1`, volatile capped journald, `RuntimeMaxSec=24h` + `Restart=always` daily browser recycle.
- **`kiosk_start_browser` gate**: headless guests (molecule VMs/containers, a Pi staged without a monitor) converge fully with units enabled-but-stopped.

### Molecule (`molecule/grafana-kiosk/`)
Inventory-driven via `david_igou.molecule_provisioners` (pinned in a scenario-local `collections.yml`, kept out of EE images). Two instances converge **both stacks inside the Pi Zero 2 W memory envelope** (512MB cap + swap allowance mirroring zram) against a mock Grafana that echoes the Authorization header. Verify proves end-to-end token injection, unit enablement, root-only config perms, then renders real headless browsers under the cap (Chromium screenshot + cog 20s survival).

## Testing
- `ansible-lint --profile=production` + `yamllint`: 0 failures
- `PROVISIONER=docker molecule test -s grafana-kiosk`: **green** (create/prepare/converge/idempotence/verify/destroy)
- `PROVISIONER=qemu molecule test -s grafana-kiosk`: **green** — real 512MiB KVM VMs where the zram/sysctl metal paths genuinely execute; browser smokes ran under real memory pressure with zram active
- Devcontainer note: nested rootless podman has no cgroup delegation (can't boot systemd containers, silently ignores `--memory`) — use `PROVISIONER=docker` or `qemu` there (documented in the scenario)

## Follow-ups (separate PRs)
- igou-inventory: `grafana_kiosk` group + `kiosk.igou.systems` host_vars, rb5009 MAC-only DHCP lease (needs the Pi's MAC) + DNS record
- 1Password item `grafana-kiosk` (Grafana Viewer SA token)
- Hardware bench of cog-on-DRM before trusting the default stack; `kiosk_stack: chromium` is a one-var flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFcBx1EitVQkRAewjSgi8H