### PR TITLE
feat(rpi-image): build_from_release.yml — bake fleet primitives into the official RasPiOS image

### DIFF
--- a/playbooks/rpi-image/README.md
+++ b/playbooks/rpi-image/README.md
@@ -1,39 +1,64 @@
 # rpi-image playbooks
 
-Automated Raspberry Pi OS image builds with
-[rpi-image-gen](https://github.com/raspberrypi/rpi-image-gen), replacing
-manual Raspberry Pi Imager runs. Images come out with the `igou` user
-(fleet SSH key, passwordless sudo, key-only sshd) baked in.
+Automated Raspberry Pi OS image builds. Images come out with the `igou`
+user (fleet SSH key, passwordless sudo, key-only sshd) baked in.
+
+**Two build pipelines exist; `build_from_release.yml` is the one that
+produces boot-proven images.** `build.yml` (rpi-image-gen) is retained
+for when igou-ansible#305 is root-caused — its images have never booted
+on a real Pi 4 (ACT LED dark, zero frames; rootfs content verified
+fine, boot partition suspect).
 
 State lives in `igou-inventory`: the `rpi_image_builders` group
 (rpi-builder.igou.systems — bare-metal Pi 4 8GB, RPi OS Lite Trixie
 arm64 on USB SSD) and `group_vars/rpi_image_builders.yml` (pinned
-rpi-image-gen release, image definition, publish layout).
+release/rpi-image-gen versions, image definition, publish layout).
 
 ## Playbooks
 
 | Playbook | Purpose |
 |---|---|
+| `build_from_release.yml` | **Recommended.** Fetch the pinned official RasPiOS Lite arm64 release → inject the fleet primitives directly (native arm64 chroot on the builder: user, key, key-only sshd, NOPASSWD sudo, hostname, ssh enabled, firstboot user-wizard disabled, optional extra packages) → verify (content **and** boot plausibility) → publish. Starts from an image that provably boots. |
 | `converge.yml` | Owns the build host: prerequisites, pinned rpi-image-gen checkout + `install_deps.sh`, workspace/publish dirs. Idempotent; run after changing the pin. |
-| `build.yml` | Render config → build (async, flock-serialised, logged) → verify → publish. |
+| `build.yml` | rpi-image-gen pipeline: render config → build (async, flock-serialised, logged) → verify → publish. ⚠ Produces images that do not boot on Pi 4 — igou-ansible#305. |
 | `flash.yml` | Write a published image to a USB device plugged into the builder. Dry-run unless `-e flash_confirm=true`; structurally cannot target the builder's boot SSD or backup micro SD (device-name contract + live boot-disk / mount / transport guards). |
 
 ```sh
-ansible-playbook playbooks/rpi-image/converge.yml -i ../igou-inventory/inventory.yaml
-ansible-playbook playbooks/rpi-image/build.yml -i ../igou-inventory/inventory.yaml
+ansible-playbook playbooks/rpi-image/build_from_release.yml -i ../igou-inventory/inventory.yaml
 ansible-playbook playbooks/rpi-image/flash.yml -i ../igou-inventory/inventory.yaml \
   -e flash_device=/dev/sdb -e flash_confirm=true
+# per-host image:
+ansible-playbook playbooks/rpi-image/build_from_release.yml -i ../igou-inventory/inventory.yaml \
+  -e rpi_image_config=upsmonitor -e rpi_image_hostname=upsmonitor
 ```
+
+`build_from_release.yml` needs one extra inventory pin
+(`group_vars/rpi_image_builders.yml`):
+
+```yaml
+rpi_image_release_src: >-
+  https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2026-06-19/2026-06-18-raspios-trixie-arm64-lite.img.xz
+rpi_image_release_sha256: "<sha256 from the release notes>"
+```
+
+(A local copy also works — the 2026-06-18 release already sits at
+rpi-builder:`/srv/images/rpi/raspios-lite-test/`.)
 
 ## Verify stage
 
-The produced image is loop-mounted on the builder and the build fails
-unless all of these hold:
+The image is loop-mounted on the builder and the build fails unless all
+of these hold:
 
 - `authorized_keys` for the image user contains the fleet public key
 - `/etc/sudoers.d/010_rpi-nopasswd` grants the user NOPASSWD sudo
 - sshd drop-in disables password authentication
 - ssh.service is enabled
+
+`build_from_release.yml` additionally asserts **boot plausibility** —
+the gap that let #305 ship: `start4.elf`/`fixup4.dat`/`kernel8.img`/
+`config.txt`/`cmdline.txt`/Pi 4 DTB present in the boot partition, and
+the `cmdline.txt` `root=PARTUUID` matches the image's actual disk
+identifier. (Still content-level: the real gate is booting a Pi.)
 
 ## Publish layout
 
@@ -43,20 +68,42 @@ unless all of these hold:
 ```
 
 Retention: newest `rpi_image_publish_retain` builds per config. Flash
-with `xzcat <config>.img.xz | sudo dd of=/dev/sdX bs=4M conv=fsync`.
+with `flash.yml` (or `xzcat <config>.img.xz | sudo dd of=/dev/sdX bs=4M
+conv=fsync`). The netboot pipeline
+(`playbooks/rpi_netboot/publish_to_netboot.yml`) consumes the same
+`latest` tree.
+
+## History: how the fleet Pis actually got imaged (2026-07)
+
+Captured here because it previously lived only in session notes:
+
+1. rpi-image-gen images were built and content-verified, but **never
+   booted** on the Pi 4 (#305).
+2. Raspberry Pi **Imager was not used** — the working manual fallback
+   was: flash the stock 2026-06-18 RasPiOS Lite Trixie arm64 release,
+   then headless-bootstrap it by dropping two files on the boot
+   partition: an empty `ssh` sentinel and a `userconf.txt`
+   (`igou:<crypted temp password>`), letting raspberrypi-sys-mods
+   firstboot create the user. Hostname stayed `raspberrypi`; identity
+   came from the MAC-pinned DHCP lease. That is what upsmonitor ran.
+3. `build_from_release.yml` supersedes both: same boot-proven base
+   image, but the primitives are baked offline (no firstboot, no temp
+   password window) and verified before publish.
 
 ## Notes
 
 - rpi-image-gen images are **not** Raspberry Pi OS proper: there is no
   raspberrypi-sys-mods firstboot, so Imager customization / `custom.toml`
-  does not apply to them. Bake identity at build time
-  (`-e rpi_image_hostname=...`) or lean on MAC-pinned DHCP.
+  does not apply to them. `build_from_release.yml` images ARE RasPiOS
+  proper — firstboot's user wizard is explicitly disabled (a user
+  already exists), while the SD resize firstboot is left intact.
 - Images are key-only by default. Pass `-e rpi_image_user1passhash='...'`
   (e.g. from 1Password, `openssl passwd -6`) to also bake a password —
   needed if you want console login on a device with no network.
 - Disaster recovery for the builder itself: reflash the stock Lite image
   (or a pipeline-built one), re-pin via DHCP happens automatically, then
-  run `converge.yml`.
-- AAP wiring (converge → build workflow + monthly schedule) is a
-  follow-up; both playbooks are AAP-shaped (group-targeted, no
-  interactive input).
+  run `converge.yml` (only needed for the rpi-image-gen pipeline;
+  `build_from_release.yml` needs just xz/losetup/fdisk from the stock
+  install).
+- AAP wiring (build workflow + monthly schedule) is a follow-up; the
+  playbooks are AAP-shaped (group-targeted, no interactive input).

--- a/playbooks/rpi-image/build_from_release.yml
+++ b/playbooks/rpi-image/build_from_release.yml
@@ -1,0 +1,283 @@
+---
+# Build a Raspberry Pi OS image from the OFFICIAL released Lite image
+# by injecting the fleet primitives directly into the image (user,
+# fleet ssh key, key-only sshd, NOPASSWD sudo, hostname, ssh enabled).
+# No Raspberry Pi Imager, no rpi-image-gen, no firstboot/userconf
+# dependency — the primitives are baked and verifiable before flash.
+#
+# Why this exists: rpi-image-gen images do not boot on a real Pi 4
+# (igou-ansible#305 — ACT LED dark, zero frames; content verified
+# fine). The working fallback was stock RasPiOS Lite + a manual
+# headless bootstrap (`ssh` sentinel + userconf.txt), which was never
+# automated or captured. This playbook is that procedure done properly:
+# start from the release image that provably boots and bake the same
+# primitives the rpi-image-gen pipeline promised.
+#
+#   ansible-playbook playbooks/rpi-image/build_from_release.yml \
+#     -i ../igou-inventory/inventory.yaml
+#
+# Required inventory var (group_vars/rpi_image_builders.yml):
+#   rpi_image_release_src     URL or builder-local path to the official
+#                             RasPiOS Lite arm64 .img.xz
+# Optional:
+#   rpi_image_release_sha256  pin the release checksum (get_url verify)
+# Useful overrides:
+#   -e rpi_image_hostname=foo        host-specific image
+#   -e rpi_image_config=bar          alternate config/publish name
+#   -e rpi_image_user1passhash=...   bake a password hash (else key-only)
+#
+# Stages: fetch release -> unpack -> customize (native arm64 chroot on
+# the builder) -> verify (content + boot-plausibility) -> publish.
+# Publish layout is identical to build.yml
+# (<publish_dir>/<config>/<build_id>/<config>.img.xz + SHA256SUMS +
+# latest symlink + retention), so flash.yml and
+# playbooks/rpi_netboot/publish_to_netboot.yml consume either pipeline
+# unchanged.
+
+- name: Build a Pi image from the official RasPiOS release
+  hosts: rpi_image_builders
+  become: true
+  gather_facts: false
+
+  vars:
+    rpi_image_config: "{{ rpi_image_default_config }}"
+    rpi_image_publish_config_dir: >-
+      {{ rpi_image_publish_dir }}/{{ rpi_image_config }}
+    _release_cache: "{{ rpi_image_root }}/releases"
+    _build_dir: "{{ rpi_image_root }}/release-work/{{ rpi_image_build_id }}"
+    _img: "{{ _build_dir }}/{{ rpi_image_config }}.img"
+    _mnt: "{{ _build_dir }}/mnt"
+
+  tasks:
+    # set_fact evaluates the lookup exactly once (lazy play vars re-run
+    # `date` per reference — the build.yml lesson, #297).
+    - name: Pin build id
+      ansible.builtin.set_fact:
+        rpi_image_build_id: >-
+          {{ lookup('ansible.builtin.pipe', 'date -u +%Y%m%dT%H%M%SZ') }}
+
+    - name: Assert the release source is pinned
+      ansible.builtin.assert:
+        that:
+          - rpi_image_release_src is defined
+          - rpi_image_release_src is search('\.img\.xz$')
+        fail_msg: >-
+          rpi_image_release_src must point at an official RasPiOS Lite
+          arm64 .img.xz (URL or builder-local path). Pin it in
+          igou-inventory group_vars/rpi_image_builders.yml, e.g.
+          https://downloads.raspberrypi.com/raspios_lite_arm64/images/
+          raspios_lite_arm64-<date>/<date>-raspios-trixie-arm64-lite.img.xz
+
+    - name: Ensure cache + build dirs exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - "{{ _release_cache }}"
+        - "{{ _build_dir }}"
+
+    - name: Download release image (URL source)
+      ansible.builtin.get_url:
+        url: "{{ rpi_image_release_src }}"
+        dest: "{{ _release_cache }}/{{ rpi_image_release_src | basename }}"
+        checksum: >-
+          {{ ('sha256:' ~ rpi_image_release_sha256)
+             if rpi_image_release_sha256 is defined else omit }}
+        mode: "0644"
+        timeout: 600
+      when: rpi_image_release_src is match('^https?://')
+
+    - name: Copy release image (builder-local source)
+      ansible.builtin.copy:
+        src: "{{ rpi_image_release_src }}"
+        dest: "{{ _release_cache }}/{{ rpi_image_release_src | basename }}"
+        remote_src: true
+        mode: "0644"
+      when: rpi_image_release_src is not match('^https?://')
+
+    - name: Unpack release into the build workspace
+      ansible.builtin.shell: |
+        set -o pipefail
+        xz -dc '{{ _release_cache }}/{{ rpi_image_release_src | basename }}' > '{{ _img }}'
+      args:
+        executable: /bin/bash
+        creates: "{{ _img }}"
+
+    - name: Attach image to a loop device with partition scan
+      ansible.builtin.shell: |
+        losetup --find --show --partscan '{{ _img }}'
+      register: _rpi_release_loop
+      changed_when: true
+
+    - name: Customize and verify (loop device attached)
+      block:
+        - name: Mount root (p2) then boot (p1) partitions
+          ansible.builtin.shell: |
+            set -euo pipefail
+            mkdir -p '{{ _mnt }}'
+            mount '{{ _rpi_release_loop.stdout }}p2' '{{ _mnt }}'
+            mount '{{ _rpi_release_loop.stdout }}p1' '{{ _mnt }}/boot/firmware'
+          args:
+            executable: /bin/bash
+          changed_when: true
+
+        # The builder is arm64 (bare-metal Pi 4), so this is a NATIVE
+        # chroot — no qemu-user-static, no binfmt. Everything the
+        # Imager/userconf firstboot path would do at first boot is done
+        # here, offline and assertable.
+        - name: Inject fleet primitives (native chroot)
+          ansible.builtin.shell: |
+            set -euo pipefail
+            mnt='{{ _mnt }}'
+            user='{{ rpi_image_user }}'
+
+            # user (idempotent for reruns against a dirty workspace)
+            if ! chroot "$mnt" id -u "$user" >/dev/null 2>&1; then
+              chroot "$mnt" useradd -m -s /bin/bash -G sudo,users,adm,video,plugdev "$user"
+            fi
+            {% if rpi_image_user1passhash is defined %}
+            chroot "$mnt" usermod -p '{{ rpi_image_user1passhash }}' "$user"
+            {% endif %}
+
+            # fleet key, key-only
+            install -d -m 700 "$mnt/home/$user/.ssh"
+            printf '%s\n' '{{ rpi_image_ssh_pubkey }}' > "$mnt/home/$user/.ssh/authorized_keys"
+            chmod 600 "$mnt/home/$user/.ssh/authorized_keys"
+            chroot "$mnt" chown -R "$user:$user" "/home/$user/.ssh"
+
+            # NOPASSWD sudo (same file the rpi-image-gen pipeline promised)
+            printf '%s ALL=(ALL) NOPASSWD: ALL\n' "$user" > "$mnt/etc/sudoers.d/010_rpi-nopasswd"
+            chmod 440 "$mnt/etc/sudoers.d/010_rpi-nopasswd"
+            chroot "$mnt" visudo -c >/dev/null
+
+            # key-only sshd + enable ssh directly (no /boot/firmware/ssh
+            # sentinel needed)
+            printf 'PasswordAuthentication no\nKbdInteractiveAuthentication no\nPubkeyAuthentication yes\n' \
+              > "$mnt/etc/ssh/sshd_config.d/01pubkey-only.conf"
+            chmod 644 "$mnt/etc/ssh/sshd_config.d/01pubkey-only.conf"
+            chroot "$mnt" systemctl enable ssh >/dev/null 2>&1
+
+            # A user now exists, so neuter the firstboot user wizard and
+            # any leftover headless-bootstrap files.
+            chroot "$mnt" systemctl disable userconfig >/dev/null 2>&1 || true
+            rm -f "$mnt/boot/firmware/userconf.txt" "$mnt/boot/firmware/ssh" "$mnt/boot/firmware/ssh.txt"
+
+            # hostname
+            printf '%s\n' '{{ rpi_image_hostname }}' > "$mnt/etc/hostname"
+            sed -i 's/^127\.0\.1\.1.*/127.0.1.1\t{{ rpi_image_hostname }}/' "$mnt/etc/hosts"
+
+            # NOTE: cmdline.txt (init_resize firstboot) is deliberately
+            # untouched — SD deploys want the resize; netboot staging
+            # (roles/rpi_rootfs) strips it independently.
+            echo CUSTOMIZE_OK
+          args:
+            executable: /bin/bash
+          register: _rpi_release_customize
+          changed_when: "'CUSTOMIZE_OK' in _rpi_release_customize.stdout"
+
+        - name: Bake extra packages (chroot apt, optional)
+          ansible.builtin.shell: |
+            set -euo pipefail
+            mnt='{{ _mnt }}'
+            for d in proc sys dev dev/pts; do mount --bind "/$d" "$mnt/$d"; done
+            cp /etc/resolv.conf "$mnt/etc/resolv.conf.build"
+            mv "$mnt/etc/resolv.conf" "$mnt/etc/resolv.conf.orig" 2>/dev/null || true
+            mv "$mnt/etc/resolv.conf.build" "$mnt/etc/resolv.conf"
+            trap '
+              mv -f "$mnt/etc/resolv.conf.orig" "$mnt/etc/resolv.conf" 2>/dev/null || true
+              umount -q "$mnt/dev/pts" "$mnt/dev" "$mnt/sys" "$mnt/proc" 2>/dev/null || true
+            ' EXIT
+            chroot "$mnt" apt-get update -qq
+            DEBIAN_FRONTEND=noninteractive chroot "$mnt" \
+              apt-get install -y --no-install-recommends {{ rpi_image_extra_packages | join(' ') }}
+            chroot "$mnt" apt-get clean
+            rm -rf "$mnt/var/lib/apt/lists/"*
+            echo PACKAGES_OK
+          args:
+            executable: /bin/bash
+          register: _rpi_release_packages
+          changed_when: "'PACKAGES_OK' in _rpi_release_packages.stdout"
+          when: rpi_image_extra_packages | default([]) | length > 0
+
+        # Content asserts match build.yml's verify stage, PLUS the
+        # boot-plausibility checks #305 exposed as missing: firmware
+        # files present and cmdline root PARTUUID consistent with the
+        # image's actual disk identifier.
+        - name: Verify image (content + boot plausibility)
+          ansible.builtin.shell: |
+            set -euo pipefail
+            mnt='{{ _mnt }}'
+            grep -qF '{{ rpi_image_ssh_pubkey }}' \
+              "$mnt/home/{{ rpi_image_user }}/.ssh/authorized_keys"
+            grep -qF '{{ rpi_image_user }} ALL=(ALL) NOPASSWD: ALL' \
+              "$mnt/etc/sudoers.d/010_rpi-nopasswd"
+            grep -q '^PasswordAuthentication no' \
+              "$mnt/etc/ssh/sshd_config.d/01pubkey-only.conf"
+            chroot "$mnt" /usr/bin/systemctl is-enabled ssh
+            grep -qx '{{ rpi_image_hostname }}' "$mnt/etc/hostname"
+
+            # boot plausibility (the gap behind igou-ansible#305)
+            for f in start4.elf fixup4.dat config.txt cmdline.txt kernel8.img; do
+              test -s "$mnt/boot/firmware/$f" || { echo "MISSING bootfs $f" >&2; exit 1; }
+            done
+            ls "$mnt"/boot/firmware/bcm2711-rpi-4-b.dtb >/dev/null
+
+            diskid=$(fdisk -l '{{ _img }}' | awk '/Disk identifier/ {print tolower($3)}' | sed 's/^0x//')
+            cmdline_uuid=$(grep -o 'root=PARTUUID=[0-9a-fA-F]*' "$mnt/boot/firmware/cmdline.txt" \
+                           | cut -d= -f3 | tr 'A-F' 'a-f')
+            [ "$cmdline_uuid" = "$diskid" ] || {
+              echo "PARTUUID mismatch: cmdline=$cmdline_uuid disk-id=$diskid" >&2; exit 1;
+            }
+            echo VERIFY_OK
+          args:
+            executable: /bin/bash
+          register: _rpi_release_verify
+          changed_when: false
+
+      always:
+        - name: Unmount image and detach loop device
+          ansible.builtin.shell: |
+            umount -q '{{ _mnt }}/boot/firmware' 2>/dev/null || true
+            umount -Rq '{{ _mnt }}' 2>/dev/null || true
+            losetup -d '{{ _rpi_release_loop.stdout }}' 2>/dev/null || true
+            exit 0
+          args:
+            executable: /bin/bash
+          changed_when: false
+
+    - name: Publish image {{ rpi_image_build_id }}
+      ansible.builtin.shell: |
+        set -euo pipefail
+        dest='{{ rpi_image_publish_config_dir }}/{{ rpi_image_build_id }}'
+        mkdir -p "$dest"
+        xz -T0 -c '{{ _img }}' > "$dest/{{ rpi_image_config }}.img.xz"
+        cd "$dest" && sha256sum ./*.img.xz > SHA256SUMS
+        ln -sfn "$dest" '{{ rpi_image_publish_config_dir }}/latest'
+        cd '{{ rpi_image_publish_config_dir }}'
+        ls -1d 20*/ | sort | head -n -{{ rpi_image_publish_retain }} \
+          | xargs -r rm -rf
+      args:
+        executable: /bin/bash
+      register: _rpi_release_publish
+      changed_when: true
+
+    - name: Remove build workspace
+      ansible.builtin.file:
+        path: "{{ _build_dir }}"
+        state: absent
+
+    - name: Record artifact location
+      ansible.builtin.set_stats:
+        data:
+          rpi_image_artifact: >-
+            {{ rpi_image_publish_config_dir }}/{{ rpi_image_build_id
+            }}/{{ rpi_image_config }}.img.xz
+
+    - name: Report
+      ansible.builtin.debug:
+        msg: >-
+          published {{ rpi_image_publish_config_dir }}/{{ rpi_image_build_id
+          }}/{{ rpi_image_config }}.img.xz from release
+          {{ rpi_image_release_src | basename }} (latest ->
+          {{ rpi_image_build_id }})


### PR DESCRIPTION
## Why

rpi-image-gen images **do not boot on a real Pi 4** (#305 — ACT LED dark, zero frames; rootfs content verified fine). The working fallback used on upsmonitor was manual: flash the stock RasPiOS Lite release, drop an `ssh` sentinel + `userconf.txt` on the boot partition, and let firstboot create the user. That procedure was never automated and never captured anywhere (not in #305, not on the builder — `raspios-lite-test/` holds only the bare image).

This PR is that procedure done properly, with no Raspberry Pi Imager and no rpi-image-gen.

## What

**`playbooks/rpi-image/build_from_release.yml`** — on rpi-builder:

1. Fetch the pinned **official RasPiOS Lite arm64 release** (`rpi_image_release_src`, URL or builder-local path, optional sha256 pin) — a base image that provably boots the Pi 4.
2. Unpack + loop-mount, then inject the fleet primitives **offline via native arm64 chroot** (the builder is a Pi 4, so no qemu/binfmt): `igou` user, fleet ssh key, key-only sshd drop-in, `010_rpi-nopasswd` sudoers (visudo-checked), hostname, `ssh` enabled directly, firstboot user-wizard disabled, optional `rpi_image_extra_packages` via chroot apt. No firstboot dependency, no temporary-password window. `cmdline.txt`/init_resize left intact (SD deploys want the resize; netboot staging strips it independently).
3. **Verify** — the same content asserts as `build.yml` plus the boot-plausibility checks whose absence let #305 ship: `start4.elf`/`fixup4.dat`/`kernel8.img`/`config.txt`/`cmdline.txt`/Pi 4 DTB present, and `cmdline.txt` `root=PARTUUID` == the image's actual disk identifier.
4. **Publish** to the identical `<publish_dir>/<config>/<build_id>/<config>.img.xz + SHA256SUMS + latest` layout, so `flash.yml` and `playbooks/rpi_netboot/publish_to_netboot.yml` (#338) consume either pipeline unchanged.

`build.yml` (rpi-image-gen) is retained but marked broken-on-Pi4 in the README pending #305 root-cause. The README also now captures the manual imaging history that previously lived only in session notes.

## Validation

Run **live end-to-end on rpi-builder** against the cached 2026-06-18 Trixie Lite release into a scratch config:

```
published /srv/images/rpi/release-build-test/20260710T115435Z/release-build-test.img.xz
ok=15 changed=9 failed=0 — verify (content + boot plausibility) passed
total 12m59s (11m24s of it xz -T0 recompression on the Pi 4)
```

Also: ansible-lint `--profile=production` clean, yamllint clean, syntax-check clean.

## Follow-ups

- igou-inventory: pin `rpi_image_release_src` (+ `rpi_image_release_sha256`) in `group_vars/rpi_image_builders.yml`.
- Hardware boot gate: flash the published image to a scratch card and boot a real Pi (base is stock so it should boot, but #305 taught us content-level verification isn't the final word). Then rebuild `igou-pi-lite`/`upsmonitor` configs from this pipeline.
- This is also the image source for the netboot pipeline (#335/#338): `publish_to_netboot.yml` → NFS rootfs + TFTP staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRJtRLy4xdPJzHwPWWBzXG
