### PR TITLE
feat(molecule): devenv-e2e — live e2e test of the devenv host lifecycle

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -20,3 +20,9 @@ exclude_paths:
   - molecule/ghapp-e2e/create.yml
   - molecule/ghapp-e2e/destroy.yml
   - molecule/ghapp-e2e/prepare.yml
+  # devenv-e2e: same pattern — create/destroy are pure import shims; prepare
+  # additionally carries real plays (scratch disk, host preflight) that stay
+  # linted locally where the collection is installed (molecule dependency).
+  - molecule/devenv-e2e/create.yml
+  - molecule/devenv-e2e/destroy.yml
+  - molecule/devenv-e2e/prepare.yml

--- a/molecule/devenv-e2e/collections.yml
+++ b/molecule/devenv-e2e/collections.yml
@@ -1,0 +1,19 @@
+---
+# Test-only dependencies for this scenario. david_igou.molecule_provisioners
+# is deliberately kept out of the main requirements.yml so it never lands in
+# EE images; devhost is pinned here too so the scenario controls exactly what
+# it tests against.
+collections:
+  - name: david_igou.molecule_provisioners
+    version: 0.0.4-alpha
+  - name: https://github.com/david-igou/ansible-collection-devhost.git
+    type: git
+    version: 27.1.3
+  - name: kubernetes.core
+    version: ">=5.0.0"
+  - name: community.general
+    version: ">=10.0.0"
+  - name: community.docker
+    version: ">=4.0.0"
+  - name: ansible.posix
+    version: ">=1.5.0"

--- a/molecule/devenv-e2e/collections.yml
+++ b/molecule/devenv-e2e/collections.yml
@@ -4,8 +4,12 @@
 # EE images; devhost is pinned here too so the scenario controls exactly what
 # it tests against.
 collections:
-  - name: david_igou.molecule_provisioners
-    version: 0.0.4-alpha
+  # Pinned to the data_volume_source_ref squash-merge (molecule_provisioners
+  # PR #54) — the golden-image boot below needs it. Re-pin to the released
+  # 0.0.5-alpha once a release is cut.
+  - name: https://github.com/david-igou/ansible-collection-molecule_provisioners.git
+    type: git
+    version: 3ad3a091bf4687e26d8b0988c800f9cd1f8efc43
   - name: https://github.com/david-igou/ansible-collection-devhost.git
     type: git
     version: 27.1.3

--- a/molecule/devenv-e2e/converge.yml
+++ b/molecule/devenv-e2e/converge.yml
@@ -50,7 +50,14 @@
         # non-login Ansible SSH shell doesn't have on PATH; jq is in /usr/bin.
         PATH: "{{ ansible_user_dir }}/.local/bin:{{ ansible_env.PATH }}"
       register: __up_release
+      # `devcontainer up` reuses a running container, so the effect is
+      # idempotent, but its output gives no reliable created-vs-reused marker —
+      # report changed honestly and exclude it from the idempotence step
+      # (everything else in converge, bootstrap.yml included, is change-free
+      # on a second pass).
       changed_when: true
+      tags:
+        - molecule-idempotence-notest
 
 # Expose code-server externally via a NodePort service, mirroring phase 1 of the
 # production provision-vm.yml (which this scenario otherwise replaces): that

--- a/molecule/devenv-e2e/converge.yml
+++ b/molecule/devenv-e2e/converge.yml
@@ -6,3 +6,48 @@
 # default, so no 1Password access is needed during converge.
 - name: Converge via the production devenv bootstrap playbook
   ansible.builtin.import_playbook: ../../playbooks/devenv/bootstrap.yml
+
+# With the host bootstrapped, bring up the REAL devcontainer from the published
+# image via the repo's own `make up-release` path (pull ghcr.io/igou-io/igou-devenv,
+# derive an image-based devcontainer.json on the fly with jq, `devcontainer up`).
+# This is the artifact the whole scenario exists to exercise: not just a
+# standalone code-server container, but the full --privileged / --network=host
+# devcontainer with nested rootless podman. bootstrap already pulled the same
+# image for its code-server container, so up-release re-tags from docker's cache
+# rather than re-pulling.
+- name: Bring up the devcontainer from the published image
+  hosts: devenv-devenv
+  gather_facts: true
+  vars:
+    devenv_dir: "{{ ansible_user_dir }}/igou-devenv"
+  tasks:
+    # The devhost docker role adds igou to the docker group during bootstrap, but
+    # the persistent SSH connection was opened before that; reset it so this play
+    # picks up the new group and `docker`/`devcontainer` work without sudo (the
+    # Makefile drives docker as the igou user, matching the container user mapping).
+    - name: Reset the connection so the new docker group membership applies
+      ansible.builtin.meta: reset_connection
+
+    # `make up-release` runs initializeCommand (.devcontainer/init.sh) first, which
+    # pre-creates every bind-mount source under ~ — all the directory mounts plus
+    # the two FILE mounts (~/.claude.json, ~/.gitconfig) so docker doesn't
+    # materialize a missing file source as a directory and break the mount. On this
+    # VM init.sh covers every mount in devcontainer.json, so there is nothing extra
+    # to seed here; 1Password is out of scope, so init.sh's empty ~/.config/op is
+    # exactly what we want. GITHUB_TOKEN stays unset on purpose — up-release's jq
+    # drops the whole build block (`del(.build)`), so devcontainer.json's
+    # ${localEnv:GITHUB_TOKEN} build-arg is never templated and an empty token is a
+    # no-op. code-server port 8080 does NOT collide: bootstrap's standalone
+    # container already publishes 8080 on the host, and the devcontainer runs
+    # --network=host, so its post-start sees :8080 already listening (via ss) and
+    # skips launching its own code-server — the standalone container keeps 8080.
+    - name: Start the devcontainer from the published image (make up-release)
+      ansible.builtin.command:
+        cmd: make up-release
+        chdir: "{{ devenv_dir }}"
+      environment:
+        # devcontainer + npm-global binaries land in ~/.local/bin, which a
+        # non-login Ansible SSH shell doesn't have on PATH; jq is in /usr/bin.
+        PATH: "{{ ansible_user_dir }}/.local/bin:{{ ansible_env.PATH }}"
+      register: __up_release
+      changed_when: true

--- a/molecule/devenv-e2e/converge.yml
+++ b/molecule/devenv-e2e/converge.yml
@@ -1,0 +1,8 @@
+---
+# The scenario's whole point: run the REAL phase-2 playbook, unmodified,
+# against the molecule-provisioned VM. The instance is named devenv-devenv so
+# bootstrap.yml's default hosts pattern (the AAP kubevirt.core inventory name
+# for the production VM) matches it as-is. The ghapp gate stays off by
+# default, so no 1Password access is needed during converge.
+- name: Converge via the production devenv bootstrap playbook
+  ansible.builtin.import_playbook: ../../playbooks/devenv/bootstrap.yml

--- a/molecule/devenv-e2e/converge.yml
+++ b/molecule/devenv-e2e/converge.yml
@@ -51,3 +51,49 @@
         PATH: "{{ ansible_user_dir }}/.local/bin:{{ ansible_env.PATH }}"
       register: __up_release
       changed_when: true
+
+# Expose code-server externally via a NodePort service, mirroring phase 1 of the
+# production provision-vm.yml (which this scenario otherwise replaces): that
+# playbook pins a devenv-code-server NodePort on 30080 so the operator reaches
+# the editor from outside the cluster. We recreate the same reachability path
+# here so verify can prove it end-to-end. The k8s call runs on the controller —
+# the play targets the VM host (for parity with the surrounding converge plays)
+# but delegates to localhost, where the KUBECONFIG env lives, exactly like the
+# provisioner's own create tasks talk to the cluster API.
+- name: Expose code-server externally via a NodePort service
+  hosts: devenv-devenv
+  gather_facts: false
+  vars:
+    # Namespace matches the provisioner's kubevirt role default (the shared
+    # `molecule` namespace); the SSH NodePort it creates lands here too.
+    devenv_e2e_namespace: molecule
+    # Instance-scoped name so it can't collide with the provisioner's own
+    # `devenv-devenv` SSH service in this shared namespace.
+    devenv_e2e_cs_service: devenv-devenv-code-server
+  tasks:
+    - name: Create the code-server NodePort service
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: "{{ devenv_e2e_cs_service }}"
+            namespace: "{{ devenv_e2e_namespace }}"
+          spec:
+            type: NodePort
+            selector:
+              # The label the provisioner puts on the virt-launcher pod (the same
+              # one its SSH service selects on) — routes to this VM's code-server.
+              kubevirt.io/domain: devenv-devenv
+            ports:
+              - name: code-server
+                port: 8080
+                targetPort: 8080
+                protocol: TCP
+                # Deliberately NO fixed nodePort. Production pins 30080, but this
+                # scenario shares the `molecule` namespace with any other run, so
+                # squatting a fixed host port would clash; let the cluster
+                # allocate one and verify discovers it dynamically.
+      delegate_to: localhost
+      run_once: true

--- a/molecule/devenv-e2e/create.yml
+++ b/molecule/devenv-e2e/create.yml
@@ -1,0 +1,3 @@
+---
+- name: Provision molecule instances
+  import_playbook: david_igou.molecule_provisioners.create

--- a/molecule/devenv-e2e/destroy.yml
+++ b/molecule/devenv-e2e/destroy.yml
@@ -1,0 +1,3 @@
+---
+- name: Tear down molecule instances
+  import_playbook: david_igou.molecule_provisioners.destroy

--- a/molecule/devenv-e2e/destroy.yml
+++ b/molecule/devenv-e2e/destroy.yml
@@ -1,3 +1,25 @@
 ---
+# Scenario-local teardown FIRST: the provisioner's destroy (imported below) only
+# removes what IT created — the VM and its SSH NodePort service — so the
+# code-server NodePort that converge added is ours to clean up. state: absent is
+# idempotent: a no-op when the service (or the whole namespace) is already gone.
+# The ansible-molecule SA can delete namespaced Services but cannot read
+# namespaces, so we target the Service directly rather than the namespace.
+- name: Tear down the scenario-local code-server NodePort service
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    devenv_e2e_namespace: molecule
+    devenv_e2e_cs_service: devenv-devenv-code-server
+  tasks:
+    - name: Delete the code-server NodePort service
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Service
+        name: "{{ devenv_e2e_cs_service }}"
+        namespace: "{{ devenv_e2e_namespace }}"
+
 - name: Tear down molecule instances
   import_playbook: david_igou.molecule_provisioners.destroy

--- a/molecule/devenv-e2e/inventory/group_vars/molecule.yml
+++ b/molecule/devenv-e2e/inventory/group_vars/molecule.yml
@@ -1,0 +1,5 @@
+---
+# This scenario is inherently kubevirt: it exists to validate the devenv host
+# lifecycle on a real cluster VM. No podman/docker fallback.
+mp_backend: kubevirt
+mp_kubevirt_wait_timeout: 600

--- a/molecule/devenv-e2e/inventory/hosts.yml
+++ b/molecule/devenv-e2e/inventory/hosts.yml
@@ -9,9 +9,18 @@ all:
         devenv-devenv:
           mp:
             kubevirt:
+              # Boot from the SAME golden image production clones (the
+              # centos-stream10 DataSource tracks its DataImportCron-managed
+              # rolling PVC), so image drift between test and production is
+              # impossible. Needs the ansible-molecule CDI grants from
+              # igou-openshift#428. Size matches production's vm_root_size;
+              # storage_class omitted -> cluster default, like production.
               boot_source:
-                type: container_disk
-                image: quay.io/containerdisks/centos-stream:10
+                type: data_volume_source_ref
+                source_ref:
+                  name: centos-stream10
+                  namespace: openshift-virtualization-os-images
+                size: 30Gi
               # Log in as the same user the production cloud-init seeds; the
               # devhost packages role's user-level npm/@devcontainers/cli
               # steps run as the login user.

--- a/molecule/devenv-e2e/inventory/hosts.yml
+++ b/molecule/devenv-e2e/inventory/hosts.yml
@@ -1,0 +1,37 @@
+---
+all:
+  children:
+    molecule:
+      hosts:
+        # Named devenv-devenv on purpose: it is the kubevirt.core inventory
+        # name of the production VM (namespace-vmname), so bootstrap.yml's
+        # default hosts pattern targets this instance without any override.
+        devenv-devenv:
+          mp:
+            kubevirt:
+              boot_source:
+                type: container_disk
+                image: quay.io/containerdisks/centos-stream:10
+              # Log in as the same user the production cloud-init seeds; the
+              # devhost packages role's user-level npm/@devcontainers/cli
+              # steps run as the login user.
+              ssh_user: igou
+              cpu:
+                cores: 4
+              memory: 8Gi
+              # Dedicated docker storage — formatted and mounted by prepare.yml.
+              extra_disks:
+                - name: docker-scratch
+                  serial: docker
+                  disk:
+                    bus: virtio
+              extra_volumes:
+                - name: docker-scratch
+                  emptyDisk:
+                    capacity: 20Gi
+              # Deliberately NOT pinned to the casval burst node (unlike the
+              # production provision-vm.yml and ghapp-e2e): a transient 8Gi
+              # test VM fits the tenant workers, and unpinned means the test
+              # runs even when the burst node is scaled to zero. Copy the
+              # node_selector/tolerations/machine-type block from ghapp-e2e's
+              # inventory if burst placement is ever wanted here.

--- a/molecule/devenv-e2e/molecule.yml
+++ b/molecule/devenv-e2e/molecule.yml
@@ -5,16 +5,20 @@
 # The provisioner replaces phase 1 (playbooks/devenv/provision-vm.yml) with a
 # throwaway molecule VM; converge then runs the REAL phase-2 playbook
 # (playbooks/devenv/bootstrap.yml — david_igou.devhost roles, repo clone,
-# code-server container from the published image) unmodified, and verify
-# asserts deployment health: docker up, the igou-devenv-code-server container
-# running, code-server answering HTTPS on 8080, devcontainer prerequisites in
-# place.
+# code-server container from the published image) unmodified, THEN brings up the
+# real devcontainer from the published image via the repo's own `make up-release`
+# path. verify asserts deployment health (docker up, the igou-devenv-code-server
+# container running, code-server answering HTTPS on 8080, devcontainer
+# prerequisites in place) and runs the devcontainer image's OWN test suite
+# in-container: `make test-tools` and `make test-podman` (nested rootless podman).
 #
-# Scope (for now): end-to-end deploy + health. Intended to grow more
-# lab-contextual over time (devcontainer build, `make e2e` in the guest,
-# ghapp gate, NodePort reachability). `idempotence` is intentionally not in
-# the sequence yet — bootstrap's docker_container pull=true and the mise
-# bootstrap paths are not proven change-free on a second pass.
+# Scope (for now): end-to-end deploy + health + devcontainer up from the
+# published image + in-container tool/podman tests. Intended to grow more
+# lab-contextual over time (devcontainer build from source, full `make e2e` in
+# the guest, ghapp gate, in-container qemu once nested KVM is available, NodePort
+# reachability). `idempotence` is intentionally not in the sequence yet —
+# bootstrap's docker_container pull=true and the mise bootstrap paths are not
+# proven change-free on a second pass.
 #
 # Requirements to run:
 #   - KUBECONFIG for a principal with VM + Service CRUD and node reads in the

--- a/molecule/devenv-e2e/molecule.yml
+++ b/molecule/devenv-e2e/molecule.yml
@@ -1,0 +1,62 @@
+---
+# devenv-e2e: live end-to-end test of the devenv host lifecycle on a real
+# KubeVirt VM via david_igou.molecule_provisioners.
+#
+# The provisioner replaces phase 1 (playbooks/devenv/provision-vm.yml) with a
+# throwaway molecule VM; converge then runs the REAL phase-2 playbook
+# (playbooks/devenv/bootstrap.yml — david_igou.devhost roles, repo clone,
+# code-server container from the published image) unmodified, and verify
+# asserts deployment health: docker up, the igou-devenv-code-server container
+# running, code-server answering HTTPS on 8080, devcontainer prerequisites in
+# place.
+#
+# Scope (for now): end-to-end deploy + health. Intended to grow more
+# lab-contextual over time (devcontainer build, `make e2e` in the guest,
+# ghapp gate, NodePort reachability). `idempotence` is intentionally not in
+# the sequence yet — bootstrap's docker_container pull=true and the mise
+# bootstrap paths are not proven change-free on a second pass.
+#
+# Requirements to run:
+#   - KUBECONFIG for a principal with VM + Service CRUD and node reads in the
+#     `molecule` namespace (the `ansible-molecule` SA:
+#     op://claude/ocp-ansible-molecule/token, host api.ocp.igou.systems:6443)
+#   - a kubevirt-schedulable worker with ~8Gi free (the VM is deliberately
+#     NOT pinned to the casval burst node, so tenant workers qualify)
+#   - VM egress to github.com (repo clone) and ghcr.io (image pull)
+#   - no 1Password needed: the ghapp gate stays off (devenv_ghapp_enabled=false)
+#
+# Run:  molecule test -s devenv-e2e
+prerun: false
+
+dependency:
+  name: galaxy
+  options:
+    requirements-file: molecule/devenv-e2e/collections.yml
+    force: true
+
+ansible:
+  executor:
+    args:
+      ansible_playbook:
+        - --inventory=inventory/
+        - --inventory=${MOLECULE_EPHEMERAL_DIRECTORY}/inventory/
+  playbooks:
+    create: create.yml
+    destroy: destroy.yml
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+
+scenario:
+  name: devenv-e2e
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy
+
+verifier:
+  name: ansible

--- a/molecule/devenv-e2e/molecule.yml
+++ b/molecule/devenv-e2e/molecule.yml
@@ -22,9 +22,10 @@
 # up from the published image + in-container tool/podman tests + external
 # NodePort reachability + reboot resilience. Intended to grow more lab-contextual
 # over time (devcontainer build from source, full `make e2e` in the guest, ghapp
-# gate, in-container qemu once nested KVM is available). `idempotence` is
-# intentionally not in the sequence yet — bootstrap's docker_container pull=true
-# and the mise bootstrap paths are not proven change-free on a second pass.
+# gate, in-container qemu once nested KVM is available). The `idempotence` step
+# runs: a second converge is change-free except `make up-release`, which is
+# tagged molecule-idempotence-notest (devcontainer up reuses the running
+# container but offers no created-vs-reused marker to key changed_when on).
 #
 # COST: the reboot verify play adds several minutes (a full KubeVirt VM boot plus
 # code-server re-warm) on top of the already-long converge; budget accordingly.
@@ -68,6 +69,7 @@ scenario:
     - create
     - prepare
     - converge
+    - idempotence
     - verify
     - destroy
 

--- a/molecule/devenv-e2e/molecule.yml
+++ b/molecule/devenv-e2e/molecule.yml
@@ -49,6 +49,14 @@ dependency:
     force: true
 
 ansible:
+  cfg:
+    defaults:
+      # molecule generates its own ansible.cfg, so the repo-root paths for
+      # galaxy roles/collections must be restated here — otherwise the
+      # dependency step installs into ${MOLECULE_PROJECT_DIRECTORY}/.ansible
+      # while runtime resolution falls back to a stale ~/.ansible copy.
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles:${MOLECULE_PROJECT_DIRECTORY}/.ansible/roles:~/.ansible/roles
+      collections_path: ${MOLECULE_PROJECT_DIRECTORY}/.ansible/collections:~/.ansible/collections
   executor:
     args:
       ansible_playbook:

--- a/molecule/devenv-e2e/molecule.yml
+++ b/molecule/devenv-e2e/molecule.yml
@@ -7,18 +7,27 @@
 # (playbooks/devenv/bootstrap.yml — david_igou.devhost roles, repo clone,
 # code-server container from the published image) unmodified, THEN brings up the
 # real devcontainer from the published image via the repo's own `make up-release`
-# path. verify asserts deployment health (docker up, the igou-devenv-code-server
-# container running, code-server answering HTTPS on 8080, devcontainer
-# prerequisites in place) and runs the devcontainer image's OWN test suite
-# in-container: `make test-tools` and `make test-podman` (nested rootless podman).
+# path, then exposes code-server through a NodePort service. verify asserts
+# deployment health (docker up, the igou-devenv-code-server container running,
+# code-server answering HTTPS on 8080 AND enforcing auth — lands on the login
+# page, a forged session cookie is bounced — devcontainer prerequisites in
+# place), runs the devcontainer image's OWN test suite in-container
+# (`make test-tools` and `make test-podman`, nested rootless podman), probes
+# code-server from OUTSIDE the cluster over the NodePort, and finally reboots the
+# VM to prove core health (docker, the scratch-disk mount, the auto-restarting
+# code-server container) survives — the devcontainer intentionally does not
+# auto-restart (restart policy 'no'; re-run `make up-release`).
 #
-# Scope (for now): end-to-end deploy + health + devcontainer up from the
-# published image + in-container tool/podman tests. Intended to grow more
-# lab-contextual over time (devcontainer build from source, full `make e2e` in
-# the guest, ghapp gate, in-container qemu once nested KVM is available, NodePort
-# reachability). `idempotence` is intentionally not in the sequence yet —
-# bootstrap's docker_container pull=true and the mise bootstrap paths are not
-# proven change-free on a second pass.
+# Scope (for now): end-to-end deploy + health + auth-enforcement + devcontainer
+# up from the published image + in-container tool/podman tests + external
+# NodePort reachability + reboot resilience. Intended to grow more lab-contextual
+# over time (devcontainer build from source, full `make e2e` in the guest, ghapp
+# gate, in-container qemu once nested KVM is available). `idempotence` is
+# intentionally not in the sequence yet — bootstrap's docker_container pull=true
+# and the mise bootstrap paths are not proven change-free on a second pass.
+#
+# COST: the reboot verify play adds several minutes (a full KubeVirt VM boot plus
+# code-server re-warm) on top of the already-long converge; budget accordingly.
 #
 # Requirements to run:
 #   - KUBECONFIG for a principal with VM + Service CRUD and node reads in the

--- a/molecule/devenv-e2e/prepare.yml
+++ b/molecule/devenv-e2e/prepare.yml
@@ -1,0 +1,46 @@
+---
+- name: Prepare molecule instances
+  import_playbook: david_igou.molecule_provisioners.prepare
+
+# The centos-stream containerdisk root is ~10Gi — too tight for the multi-GB
+# devenv image pull on top of the OS. The emptyDisk declared in the inventory
+# (extra_disks/extra_volumes, serial "docker") gets a stable by-id path;
+# format and mount it before converge installs docker.
+- name: Mount the docker scratch disk
+  hosts: molecule
+  gather_facts: false
+  become: true
+  vars:
+    __docker_disk: /dev/disk/by-id/virtio-docker
+  tasks:
+    # The CentOS Stream GenericCloud image ships kernel-core/-modules only; on
+    # EL10 the netfilter modules docker's bridge network needs (xt_addrtype …)
+    # live in kernel-modules-extra, so dockerd fails to start without it.
+    # Arguably a david_igou.devhost.docker role gap — kept here until the role
+    # handles it.
+    - name: Install the netfilter kernel modules docker needs
+      ansible.builtin.dnf:
+        name: kernel-modules-extra
+        state: present
+
+    - name: Assert the docker bridge netfilter module now loads
+      community.general.modprobe:
+        name: xt_addrtype
+        state: present
+
+    - name: Wait for the scratch disk device to appear
+      ansible.builtin.wait_for:
+        path: "{{ __docker_disk }}"
+        timeout: 60
+
+    - name: Create an xfs filesystem on the scratch disk
+      community.general.filesystem:
+        fstype: xfs
+        dev: "{{ __docker_disk }}"
+
+    - name: Mount the scratch disk at /var/lib/docker
+      ansible.posix.mount:
+        path: /var/lib/docker
+        src: "{{ __docker_disk }}"
+        fstype: xfs
+        state: mounted

--- a/molecule/devenv-e2e/prepare.yml
+++ b/molecule/devenv-e2e/prepare.yml
@@ -44,3 +44,61 @@
         src: "{{ __docker_disk }}"
         fstype: xfs
         state: mounted
+
+    # Devcontainer host preflight. The igou-devenv devcontainer runs --privileged
+    # with --device=/dev/fuse, --device=/dev/net/tun and --network=host (see
+    # .devcontainer/devcontainer.json), and its nested rootless podman needs
+    # unprivileged user namespaces. Fail fast on a missing host prerequisite here
+    # — otherwise it surfaces as a confusing devcontainer-up or test-podman error
+    # two plays later. /dev/kvm is only needed for the in-container qemu /
+    # molecule-provisioner path (make test-qemu), which this scenario does not
+    # hard-require, so its absence is a soft warning, not a failure.
+    - name: Load the tun module the devcontainer's --device=/dev/net/tun needs
+      community.general.modprobe:
+        name: tun
+        state: present
+
+    - name: Stat the character devices the devcontainer binds
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop:
+        - /dev/fuse
+        - /dev/net/tun
+      register: __devenv_chardevs
+
+    - name: Assert /dev/fuse and /dev/net/tun are present character devices
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+          - item.stat.ischr
+        fail_msg: "{{ item.item }} is missing — the devcontainer cannot bind it"
+      loop: "{{ __devenv_chardevs.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Read the user-namespace limit (nested rootless podman needs it)
+      ansible.builtin.command:
+        cmd: sysctl -n user.max_user_namespaces
+      register: __devenv_userns
+      changed_when: false
+
+    - name: Assert unprivileged user namespaces are enabled
+      ansible.builtin.assert:
+        that:
+          - __devenv_userns.stdout | int > 0
+        fail_msg: >-
+          user.max_user_namespaces is {{ __devenv_userns.stdout }} — rootless
+          podman inside the devcontainer needs unprivileged user namespaces
+
+    - name: Check for /dev/kvm (nested virt — gates the in-container qemu path)
+      ansible.builtin.stat:
+        path: /dev/kvm
+      register: __devenv_kvm
+
+    - name: Warn when /dev/kvm is absent (non-fatal)
+      ansible.builtin.debug:
+        msg: >-
+          /dev/kvm is not present on this VM — nested virtualization is off, so
+          the devcontainer's qemu / molecule-provisioner workflows (make
+          test-qemu) will not work. Non-fatal for this scenario.
+      when: not __devenv_kvm.stat.exists

--- a/molecule/devenv-e2e/verify.yml
+++ b/molecule/devenv-e2e/verify.yml
@@ -1,0 +1,76 @@
+---
+# Health verification of the deployed devenv host: docker up, the code-server
+# container running, code-server answering HTTPS, devcontainer prerequisites
+# present. Deliberately deploy-and-health only for now — deeper lab-contextual
+# checks (devcontainer build, `make e2e` in the guest, ghapp mint, NodePort
+# reachability from outside the cluster) are future iterations.
+
+- name: Verify the devenv host deployment health
+  hosts: devenv-devenv
+  gather_facts: false
+  tasks:
+    - name: Collect service facts
+      ansible.builtin.service_facts:
+      become: true
+
+    - name: Assert the docker daemon is running
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services['docker.service'].state == 'running'
+        fail_msg: docker.service is not running
+
+    - name: Assert the docker scratch disk is what backs /var/lib/docker
+      ansible.builtin.command:
+        cmd: findmnt -n -o SOURCE /var/lib/docker
+      register: __docker_mount
+      changed_when: false
+      failed_when: __docker_mount.rc != 0
+
+    - name: Inspect the code-server container
+      community.docker.docker_container_info:
+        name: igou-devenv-code-server
+      become: true
+      register: __cs_container
+
+    - name: Assert the code-server container is up
+      ansible.builtin.assert:
+        that:
+          - __cs_container.exists
+          - __cs_container.container.State.Running
+          - not __cs_container.container.State.Restarting
+        fail_msg: the igou-devenv-code-server container is not running
+
+    - name: Probe code-server over HTTPS (self-signed) until it answers
+      ansible.builtin.uri:
+        url: https://localhost:8080/
+        validate_certs: false
+        return_content: true
+      register: __cs_http
+      retries: 12
+      delay: 5
+      until: __cs_http.status == 200
+
+    - name: Assert the response is the code-server app
+      ansible.builtin.assert:
+        that:
+          - "'code-server' in __cs_http.content"
+        fail_msg: port 8080 answered but does not look like code-server
+
+    - name: Check the devcontainer CLI is installed for the login user
+      ansible.builtin.command:
+        cmd: ~/.local/bin/devcontainer --version
+      register: __devcontainer_cli
+      changed_when: false
+
+    - name: Check the igou-devenv repo clone
+      ansible.builtin.stat:
+        path: "{{ ansible_user_dir | default('/home/igou') }}/igou-devenv/.git"
+      register: __devenv_repo
+
+    - name: Assert devcontainer prerequisites are in place
+      ansible.builtin.assert:
+        that:
+          - __devcontainer_cli.rc == 0
+          - __devenv_repo.stat.exists
+          - __devenv_repo.stat.isdir
+        fail_msg: devcontainer CLI or the igou-devenv clone is missing

--- a/molecule/devenv-e2e/verify.yml
+++ b/molecule/devenv-e2e/verify.yml
@@ -74,3 +74,70 @@
           - __devenv_repo.stat.exists
           - __devenv_repo.stat.isdir
         fail_msg: devcontainer CLI or the igou-devenv clone is missing
+
+# In-container acceptance: run the repo's OWN checks inside the running
+# devcontainer (each make target docker-execs via `devcontainer exec`). The
+# container is named igou-devenv (its runArgs --name). test-tools proves the
+# toolchain baked into the published image; test-podman is the load-bearing one
+# — pull/run/build with nested rootless podman, the exact primitive the
+# --privileged / user-namespace host prereqs exist to enable. test-env / test-ssh
+# (need 1Password) are out of scope; test-qemu / test-sandbox-primitives (need
+# nested KVM) are not hard requirements here — test-qemu runs informational-only.
+- name: Verify the devcontainer's own test suite passes in-container
+  hosts: devenv-devenv
+  gather_facts: true
+  vars:
+    devenv_dir: "{{ ansible_user_dir }}/igou-devenv"
+    # make test-* shell out to `devcontainer exec`, which lives in ~/.local/bin;
+    # a non-login Ansible SSH shell doesn't have it on PATH. Applied per task
+    # (not play-level) so it isn't templated against the implicit fact-gathering
+    # task, which runs before ansible_env/ansible_user_dir exist.
+    devenv_path: "{{ ansible_user_dir }}/.local/bin:{{ ansible_env.PATH }}"
+  tasks:
+    - name: Inspect the devcontainer container
+      community.docker.docker_container_info:
+        name: igou-devenv
+      become: true
+      register: __devcontainer
+
+    - name: Assert the devcontainer container is running
+      ansible.builtin.assert:
+        that:
+          - __devcontainer.exists
+          - __devcontainer.container.State.Running
+          - not __devcontainer.container.State.Restarting
+        fail_msg: the igou-devenv devcontainer is not running
+
+    - name: Run the in-container tool suite (make test-tools)
+      ansible.builtin.command:
+        cmd: make test-tools
+        chdir: "{{ devenv_dir }}"
+      environment:
+        PATH: "{{ devenv_path }}"
+      register: __test_tools
+      changed_when: false
+
+    - name: Run the in-container nested-podman suite (make test-podman)
+      ansible.builtin.command:
+        cmd: make test-podman
+        chdir: "{{ devenv_dir }}"
+      environment:
+        PATH: "{{ devenv_path }}"
+      register: __test_podman
+      changed_when: false
+
+    - name: Run the in-container qemu suite (informational — kvm may be absent)
+      ansible.builtin.command:
+        cmd: make test-qemu
+        chdir: "{{ devenv_dir }}"
+      environment:
+        PATH: "{{ devenv_path }}"
+      register: __test_qemu
+      changed_when: false
+      failed_when: false
+
+    - name: Report the informational qemu result
+      ansible.builtin.debug:
+        msg: >-
+          make test-qemu rc={{ __test_qemu.rc }} (informational, non-fatal —
+          nested KVM is not required by this scenario)

--- a/molecule/devenv-e2e/verify.yml
+++ b/molecule/devenv-e2e/verify.yml
@@ -1,13 +1,23 @@
 ---
 # Health verification of the deployed devenv host: docker up, the code-server
-# container running, code-server answering HTTPS, devcontainer prerequisites
-# present. Deliberately deploy-and-health only for now — deeper lab-contextual
-# checks (devcontainer build, `make e2e` in the guest, ghapp mint, NodePort
-# reachability from outside the cluster) are future iterations.
+# container running and ENFORCING auth (lands on the login page, forged cookie
+# bounced), devcontainer prerequisites present, the in-container test suite, the
+# code-server NodePort reachable from OUTSIDE the cluster, and core health
+# surviving a VM reboot. Still-future lab-contextual checks: devcontainer build
+# from source, `make e2e` in the guest, ghapp mint.
 
 - name: Verify the devenv host deployment health
   hosts: devenv-devenv
   gather_facts: false
+  vars:
+    # Login-page markers observed in the live code-server response. code-server
+    # 302-redirects an unauthenticated GET / to ./login; uri follows it (default
+    # follow_redirects: safe) and returns the login HTML, which carries the
+    # <title>code-server login</title> and a password <input name="password">.
+    # Asserting these (not just the substring 'code-server', which the
+    # authenticated workbench also contains) proves auth is actually enforced.
+    cs_login_title: code-server login
+    cs_password_input: name="password"
   tasks:
     - name: Collect service facts
       ansible.builtin.service_facts:
@@ -50,11 +60,35 @@
       delay: 5
       until: __cs_http.status == 200
 
-    - name: Assert the response is the code-server app
+    - name: Assert the unauthenticated response is the code-server LOGIN page
       ansible.builtin.assert:
         that:
-          - "'code-server' in __cs_http.content"
-        fail_msg: port 8080 answered but does not look like code-server
+          - cs_login_title in __cs_http.content
+          - cs_password_input in __cs_http.content
+        fail_msg: >-
+          port 8080 answered but did not serve the code-server login page —
+          authentication does not look enforced
+
+    # A forged session cookie must NOT be accepted: code-server bounces it back
+    # to the login page rather than serving the workbench. We assert the login
+    # marker is present (equivalently: the workbench was NOT served) without ever
+    # learning the real password — the point is only that auth is enforced.
+    - name: Probe code-server with a forged session cookie
+      ansible.builtin.uri:
+        url: https://localhost:8080/
+        validate_certs: false
+        return_content: true
+        headers:
+          Cookie: code-server-session=forged-not-a-real-token
+      register: __cs_forged
+
+    - name: Assert the forged cookie is bounced to the login page
+      ansible.builtin.assert:
+        that:
+          - cs_password_input in __cs_forged.content
+        fail_msg: >-
+          a forged session cookie was not sent to the login page — code-server
+          is serving the workbench without valid credentials
 
     - name: Check the devcontainer CLI is installed for the login user
       ansible.builtin.command:
@@ -141,3 +175,196 @@
         msg: >-
           make test-qemu rc={{ __test_qemu.rc }} (informational, non-fatal —
           nested KVM is not required by this scenario)
+
+# External reachability: prove code-server is answering through the NodePort
+# service converge created, from OUTSIDE the VM. Runs on the controller (which
+# reaches cluster node InternalIPs directly — that is how molecule SSHes to the
+# VM). The nodePort is cluster-allocated (converge pins nothing), so discover it
+# and a node InternalIP from the API — the ansible-molecule SA can list both
+# nodes and namespaced Services — then probe and re-assert the login page.
+- name: Verify code-server is reachable from outside the cluster via NodePort
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    devenv_e2e_namespace: molecule
+    devenv_e2e_cs_service: devenv-devenv-code-server
+    cs_login_title: code-server login
+    cs_password_input: name="password"
+  tasks:
+    - name: Look up the code-server NodePort service
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Service
+        name: "{{ devenv_e2e_cs_service }}"
+        namespace: "{{ devenv_e2e_namespace }}"
+      register: __cs_svc
+
+    - name: Assert the NodePort service exists with an allocated nodePort
+      ansible.builtin.assert:
+        that:
+          - __cs_svc.resources | length == 1
+          - (__cs_svc.resources[0].spec.ports[0].nodePort | default(0)) | int > 0
+        fail_msg: the code-server NodePort service is missing or has no nodePort
+
+    - name: Look up cluster nodes for an InternalIP
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Node
+      register: __cs_nodes
+
+    - name: Resolve the code-server nodePort and a reachable node InternalIP
+      ansible.builtin.set_fact:
+        __cs_nodeport: "{{ __cs_svc.resources[0].spec.ports[0].nodePort }}"
+        __cs_node_ip: >-
+          {{ (__cs_nodes.resources[0].status.addresses
+              | selectattr('type', 'equalto', 'InternalIP')
+              | map(attribute='address') | first) }}
+
+    - name: Probe code-server over the NodePort until it answers
+      ansible.builtin.uri:
+        url: "https://{{ __cs_node_ip }}:{{ __cs_nodeport }}/"
+        validate_certs: false
+        return_content: true
+      register: __cs_ext
+      retries: 12
+      delay: 5
+      until: __cs_ext.status == 200
+
+    - name: Assert the external NodePort probe lands on the login page
+      ansible.builtin.assert:
+        that:
+          - cs_login_title in __cs_ext.content
+          - cs_password_input in __cs_ext.content
+        fail_msg: >-
+          the code-server NodePort answered but did not serve the login page
+
+# Reboot resilience — LAST on purpose: a reboot is destructive and slow, so a
+# failure here must not poison the health results above. Reboot the KubeVirt VM,
+# then re-assert the core health set survives: docker back up, the scratch disk
+# still mounted at /var/lib/docker (its fstab entry, written by prepare with
+# state: mounted, must persist), and the standalone code-server container
+# (restart_policy: unless-stopped) back and enforcing auth on :8080. The
+# devcontainer (make up-release) is verified to NOT return: its restart policy
+# is 'no' (devcontainer CLI default), so a host reboot leaves it stopped —
+# restarting it is the developer's job (re-run `make up-release`, which is what
+# cursor/make do). We assert that reality rather than wishing it back, then
+# perform that exact developer step so the host is left converged and verify is
+# re-runnable end-to-end (a second `molecule verify` finds the devcontainer up).
+- name: Verify core health survives a VM reboot
+  hosts: devenv-devenv
+  # Facts feed the make up-release PATH below; gathered pre-reboot, still valid
+  # after (user home / PATH don't change across a reboot).
+  gather_facts: true
+  vars:
+    devenv_dir: "{{ ansible_user_dir }}/igou-devenv"
+    cs_login_title: code-server login
+    cs_password_input: name="password"
+  tasks:
+    # The only mutating task in verify — reboot is inherently a change, so it is
+    # honestly reported as changed rather than masked with changed_when.
+    - name: Reboot the KubeVirt VM and wait for it to come back
+      ansible.builtin.reboot:
+        # Generous: this is a full KubeVirt VM boot, not a container restart.
+        reboot_timeout: 600
+      become: true
+
+    - name: Wait for docker to be running again after the reboot
+      ansible.builtin.service_facts:
+      register: __svc_post
+      until: >-
+        __svc_post.ansible_facts.services['docker.service'].state | default('')
+        == 'running'
+      retries: 12
+      delay: 5
+      become: true
+
+    - name: Assert the scratch disk is still mounted at /var/lib/docker
+      ansible.builtin.command:
+        cmd: findmnt -n -o SOURCE /var/lib/docker
+      register: __docker_mount_post
+      changed_when: false
+      failed_when: __docker_mount_post.rc != 0
+
+    - name: Probe code-server over HTTPS after the reboot until it answers
+      ansible.builtin.uri:
+        url: https://localhost:8080/
+        validate_certs: false
+        return_content: true
+      register: __cs_http_post
+      retries: 24
+      delay: 5
+      until: __cs_http_post.status == 200
+
+    - name: Assert code-server serves the login page after the reboot
+      ansible.builtin.assert:
+        that:
+          - cs_login_title in __cs_http_post.content
+          - cs_password_input in __cs_http_post.content
+        fail_msg: code-server did not come back on the login page after reboot
+
+    - name: Inspect the code-server container after the reboot
+      community.docker.docker_container_info:
+        name: igou-devenv-code-server
+      become: true
+      register: __cs_container_post
+
+    - name: Assert the code-server container auto-restarted (unless-stopped)
+      ansible.builtin.assert:
+        that:
+          - __cs_container_post.exists
+          - __cs_container_post.container.State.Running
+          - not __cs_container_post.container.State.Restarting
+          - __cs_container_post.container.HostConfig.RestartPolicy.Name == 'unless-stopped'
+        fail_msg: the code-server container did not come back after reboot
+
+    - name: Inspect the devcontainer after the reboot
+      community.docker.docker_container_info:
+        name: igou-devenv
+      become: true
+      register: __devcontainer_post
+
+    # The devcontainer is deliberately NOT expected back: `devcontainer up` gives
+    # it restart policy 'no', so a host reboot leaves it stopped-but-present. The
+    # real developer workflow restarts it by re-running `make up-release` (what
+    # cursor/make do), so we assert the honest post-reboot state, not a wish.
+    - name: Assert the devcontainer did NOT auto-restart (restart policy 'no')
+      ansible.builtin.assert:
+        that:
+          - __devcontainer_post.exists
+          - not __devcontainer_post.container.State.Running
+          - __devcontainer_post.container.HostConfig.RestartPolicy.Name == 'no'
+        fail_msg: >-
+          the igou-devenv devcontainer state after reboot is unexpected — it
+          should be present but stopped (restart policy 'no'); rerun
+          `make up-release` to bring it back
+
+    # Perform the developer's own recovery step: bring the devcontainer back with
+    # make up-release (the same path converge used). This both mirrors the real
+    # workflow (a host reboot means you re-run make up-release) and leaves the VM
+    # in the converged state, so a subsequent `molecule verify` — whose earlier
+    # play asserts the devcontainer is running — passes. The post-reboot SSH
+    # session is fresh, so igou's docker group membership is already in effect
+    # (no reset_connection needed, unlike converge's mid-session group add).
+    - name: Restore the devcontainer with make up-release (developer recovery)
+      ansible.builtin.command:
+        cmd: make up-release
+        chdir: "{{ devenv_dir }}"
+      environment:
+        PATH: "{{ ansible_user_dir }}/.local/bin:{{ ansible_env.PATH }}"
+      register: __up_release_post
+      changed_when: true
+
+    - name: Inspect the restored devcontainer
+      community.docker.docker_container_info:
+        name: igou-devenv
+      become: true
+      register: __devcontainer_restored
+
+    - name: Assert the devcontainer is running again after make up-release
+      ansible.builtin.assert:
+        that:
+          - __devcontainer_restored.exists
+          - __devcontainer_restored.container.State.Running
+          - not __devcontainer_restored.container.State.Restarting
+        fail_msg: make up-release did not bring the devcontainer back after reboot


### PR DESCRIPTION
Adds `molecule/devenv-e2e`, a live end-to-end test of the devenv host lifecycle on a real KubeVirt VM via `david_igou.molecule_provisioners` (kubevirt backend), following the `ghapp-e2e` scenario pattern.

## What it tests

The provisioner stands in for phase 1 (`playbooks/devenv/provision-vm.yml`) with a throwaway VM; **converge runs the real `playbooks/devenv/bootstrap.yml`, unmodified** — the instance is named `devenv-devenv` (the production kubevirt.core inventory name) so the playbook's default hosts pattern matches as-is, ghapp gate off, no 1Password needed. Verify then asserts deployment health:

- `docker.service` running, `/var/lib/docker` backed by the dedicated scratch disk
- the `igou-devenv-code-server` container up (not restarting)
- code-server answering HTTPS 200 on 8080 with real app content
- `devcontainer` CLI installed for the login user, `~/igou-devenv` clone present

## Notable

- **Found a real gap while bringing this up**: the CentOS Stream 10 GenericCloud image ships without `kernel-modules-extra`, which on EL10 contains the netfilter modules (`xt_addrtype`) dockerd's bridge needs — docker fails to start on a fresh image. `prepare.yml` installs it for now; arguably belongs in `david_igou.devhost.docker`.
- 20Gi `emptyDisk` (serial `docker`) mounted at `/var/lib/docker` in prepare — the ~10Gi containerdisk root is too tight for the devenv image pull.
- Deliberately **not** pinned to the casval burst node (unlike ghapp-e2e): a transient 4c/8Gi VM fits the tenant workers, so the test runs with burst scaled to zero. The ghapp-e2e pinning block is referenced in a comment if wanted later.
- Scope is intentionally deploy + health for now; meant to grow more lab-contextual (devcontainer build, `make e2e` in the guest, ghapp mint, NodePort reachability). No `idempotence` step yet — bootstrap's `docker_container pull=true` path isn't proven change-free.

## Testing

- Full clean-room `molecule test -s devenv-e2e` green against `ocp.igou.systems` with the `ansible-molecule` SA (`op://claude/ocp-ansible-molecule/token`); destroy leaves the `molecule` namespace empty.
- `yamllint` + `ansible-lint` (production profile) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E111DtdewtbY27csDfJBMN