### PR TITLE
feat(devenv-e2e): optional 1Password use()/unuse() verification

### DIFF
--- a/molecule/devenv-e2e/converge.yml
+++ b/molecule/devenv-e2e/converge.yml
@@ -7,6 +7,149 @@
 - name: Converge via the production devenv bootstrap playbook
   ansible.builtin.import_playbook: ../../playbooks/devenv/bootstrap.yml
 
+# 1Password integration (OPTIONAL, gated) — seed the credentials and the
+# scenario-owned test env files that the verify play's use()/unuse() checks
+# consume. Runs BEFORE `make up-release` so everything is in place before the
+# container starts. With no MOLECULE_OP_* token this whole play is a single
+# skip debug and the run is byte-for-byte the baseline. See molecule.yml header.
+#
+# Why these exact paths:
+#   - Tokens go to the VM host's ~/.config/op, which the devcontainer bind-mounts
+#     read-only at /home/igou/.config/op; the container .bashrc's op-auth block
+#     reads connect-host/connect-token (Connect) or service-account-token (SA)
+#     from there. Written before `make up-release`, so they are present when the
+#     container starts — never passed via cloud-init, the VM spec, the k8s API,
+#     or the ephemeral inventory.
+#   - Env files go to ~/igou-devenv/envs, NOT ~/workspace/igou-devenv/envs. The
+#     container's use() hard-codes envdir=/workspace/igou-devenv/envs, and
+#     `make up-release` runs with --workspace-folder ~/igou-devenv, so the
+#     workspaceMount binds ~/igou-devenv -> /workspace/igou-devenv, shadowing the
+#     ~/workspace -> /workspace mount for that subtree. (Proof: the already-green
+#     `make test-tools` execs /workspace/igou-devenv/tests/... which only exists
+#     in the ~/igou-devenv bootstrap clone.) So ~/igou-devenv/envs is where use()
+#     actually looks — no second clone is needed. host_prep clones with
+#     update:false, so a second converge (idempotence) leaves these files intact.
+- name: Seed 1Password credentials and scenario test env files
+  hosts: devenv-devenv
+  gather_facts: true
+  vars:
+    devenv_e2e_op_dir: "{{ ansible_user_dir }}/.config/op"
+    devenv_e2e_envs_dir: "{{ ansible_user_dir }}/igou-devenv/envs"
+    devenv_e2e_op_env_files:
+      - molecule-simple.env
+      - molecule-kubeconfig.env
+      - molecule-k8s-token.env
+      - molecule-registry.env
+      - molecule-bad.env
+  tasks:
+    - name: Report that 1Password integration setup is skipped
+      ansible.builtin.debug:
+        msg: >-
+          1Password integration checks skipped (no token provided) — set
+          MOLECULE_OP_SERVICE_ACCOUNT_TOKEN, or MOLECULE_OP_CONNECT_HOST plus
+          MOLECULE_OP_CONNECT_TOKEN, to enable them.
+      when: not (devenv_e2e_op_enabled | bool)
+
+    # Guard the env configuration for everyone (even the disabled path catches a
+    # half-set Connect pair, which would otherwise silently disable the checks).
+    - name: Assert the MOLECULE_OP_* configuration is valid
+      ansible.builtin.assert:
+        that:
+          - not ((devenv_e2e_op_connect_enabled | bool) and (devenv_e2e_op_sa_enabled | bool))
+          - (devenv_e2e_op_connect_host | length > 0) == (devenv_e2e_op_connect_token | length > 0)
+        fail_msg: >-
+          invalid MOLECULE_OP_* configuration: set EITHER both
+          MOLECULE_OP_CONNECT_HOST and MOLECULE_OP_CONNECT_TOKEN, OR
+          MOLECULE_OP_SERVICE_ACCOUNT_TOKEN — never a half-set Connect pair, and
+          never both modes at once.
+        success_msg: >-
+          1Password auth mode:
+          {{ 'Connect' if (devenv_e2e_op_connect_enabled | bool)
+             else ('service account' if (devenv_e2e_op_sa_enabled | bool)
+             else 'none (checks disabled)') }}
+
+    - name: Seed 1Password credentials and test env files
+      when: devenv_e2e_op_enabled | bool
+      block:
+        - name: Ensure ~/.config/op exists with private permissions
+          ansible.builtin.file:
+            path: "{{ devenv_e2e_op_dir }}"
+            state: directory
+            mode: "0700"
+
+        # The op CLI must find an existing device config: ~/.config/op is
+        # bind-mounted READ-ONLY into the container, so op cannot create
+        # ~/.config/op/config itself ("open .../config: read-only file
+        # system"). On a real dev host the file already exists from first
+        # host-side op use; seed the same shape here. The device id is a
+        # client identifier (not a secret) — a fixed base32 value keeps
+        # re-runs change-free, and force:false leaves any pre-existing
+        # device identity alone.
+        - name: Seed the op device config the read-only bind keeps op from creating
+          ansible.builtin.copy:
+            content: '{"latest_signin":"","device":"moleculedevenve2edeviceidx"}'
+            dest: "{{ devenv_e2e_op_dir }}/config"
+            mode: "0600"
+            force: false
+
+        - name: Seed the 1Password Connect host
+          ansible.builtin.copy:
+            content: "{{ devenv_e2e_op_connect_host }}"
+            dest: "{{ devenv_e2e_op_dir }}/connect-host"
+            mode: "0600"
+          no_log: true
+          when: devenv_e2e_op_connect_enabled | bool
+
+        - name: Seed the 1Password Connect token
+          ansible.builtin.copy:
+            content: "{{ devenv_e2e_op_connect_token }}"
+            dest: "{{ devenv_e2e_op_dir }}/connect-token"
+            mode: "0600"
+          no_log: true
+          when: devenv_e2e_op_connect_enabled | bool
+
+        - name: Seed the 1Password service-account token
+          ansible.builtin.copy:
+            content: "{{ devenv_e2e_op_sa_token }}"
+            dest: "{{ devenv_e2e_op_dir }}/service-account-token"
+            mode: "0600"
+          no_log: true
+          when: devenv_e2e_op_sa_enabled | bool
+
+        # Keep the two modes from colliding across re-runs: the container .bashrc
+        # PREFERS Connect, so a stale Connect pair left over from a previous run
+        # would mask a fresh SA token (and vice versa). Remove whichever mode is
+        # not active. No token material here, so no no_log needed.
+        - name: Remove stale Connect credentials when using service-account mode
+          ansible.builtin.file:
+            path: "{{ devenv_e2e_op_dir }}/{{ item }}"
+            state: absent
+          loop:
+            - connect-host
+            - connect-token
+          when: devenv_e2e_op_sa_enabled | bool
+
+        - name: Remove a stale service-account token when using Connect mode
+          ansible.builtin.file:
+            path: "{{ devenv_e2e_op_dir }}/service-account-token"
+            state: absent
+          when: devenv_e2e_op_connect_enabled | bool
+
+        - name: Ensure the container's envs directory exists
+          ansible.builtin.file:
+            path: "{{ devenv_e2e_envs_dir }}"
+            state: directory
+            mode: "0755"
+
+        # Scenario-owned; deliberately NOT committed to igou-devenv. They carry
+        # only op:// references (and one literal plain value), no secrets.
+        - name: Install the scenario 1Password test env files
+          ansible.builtin.copy:
+            src: "envs/{{ item }}"
+            dest: "{{ devenv_e2e_envs_dir }}/{{ item }}"
+            mode: "0644"
+          loop: "{{ devenv_e2e_op_env_files }}"
+
 # With the host bootstrapped, bring up the REAL devcontainer from the published
 # image via the repo's own `make up-release` path (pull ghcr.io/igou-io/igou-devenv,
 # derive an image-based devcontainer.json on the fly with jq, `devcontainer up`).

--- a/molecule/devenv-e2e/files/envs/molecule-bad.env
+++ b/molecule/devenv-e2e/files/envs/molecule-bad.env
@@ -1,0 +1,1 @@
+BAD_REF=op://molecule/does-not-exist/nope

--- a/molecule/devenv-e2e/files/envs/molecule-k8s-token.env
+++ b/molecule/devenv-e2e/files/envs/molecule-k8s-token.env
@@ -1,0 +1,2 @@
+KUBECONFIG_TOKEN=op://molecule/use-k8s-token/token
+KUBECONFIG_HOST=op://molecule/use-k8s-token/api-host

--- a/molecule/devenv-e2e/files/envs/molecule-kubeconfig.env
+++ b/molecule/devenv-e2e/files/envs/molecule-kubeconfig.env
@@ -1,0 +1,1 @@
+KUBECONFIG_DATA=op://molecule/use-kubeconfig/kubeconfig-b64

--- a/molecule/devenv-e2e/files/envs/molecule-registry.env
+++ b/molecule/devenv-e2e/files/envs/molecule-registry.env
@@ -1,0 +1,3 @@
+REGISTRY_HOST=op://molecule/use-registry/registry
+REGISTRY_USERNAME=op://molecule/use-registry/username
+REGISTRY_PASSWORD=op://molecule/use-registry/password

--- a/molecule/devenv-e2e/files/envs/molecule-simple.env
+++ b/molecule/devenv-e2e/files/envs/molecule-simple.env
@@ -1,0 +1,4 @@
+TEST_USERNAME=op://molecule/use-simple/username
+TEST_PASSWORD=op://molecule/use-simple/password
+TEST_HOST=op://molecule/use-simple/host
+TEST_PLAIN=plain-value-unchanged

--- a/molecule/devenv-e2e/inventory/group_vars/molecule.yml
+++ b/molecule/devenv-e2e/inventory/group_vars/molecule.yml
@@ -3,3 +3,25 @@
 # lifecycle on a real cluster VM. No podman/docker fallback.
 mp_backend: kubevirt
 mp_kubevirt_wait_timeout: 600
+
+# ---------------------------------------------------------------------------
+# 1Password integration gate (optional — see molecule.yml header for the full
+# requirements). Everything to do with the container's use()/1Password flow is
+# opt-in via MOLECULE_OP_* env vars so the default no-token run stays byte-for-
+# byte identical. The env lookups are LAZY (evaluated only when a play references
+# them), which keeps the actual tokens out of any inventory dump — an
+# `ansible-inventory --list` renders these as the unresolved lookup expressions,
+# never the secret values.
+devenv_e2e_op_connect_host: "{{ lookup('ansible.builtin.env', 'MOLECULE_OP_CONNECT_HOST') }}"
+devenv_e2e_op_connect_token: "{{ lookup('ansible.builtin.env', 'MOLECULE_OP_CONNECT_TOKEN') }}"
+devenv_e2e_op_sa_token: "{{ lookup('ansible.builtin.env', 'MOLECULE_OP_SERVICE_ACCOUNT_TOKEN') }}"
+
+# Connect mode needs BOTH the host and the token; SA mode needs just the token.
+# devenv_e2e_op_enabled is the single master switch every 1P play/task gates on.
+devenv_e2e_op_connect_enabled: >-
+  {{ (devenv_e2e_op_connect_host | length > 0)
+     and (devenv_e2e_op_connect_token | length > 0) }}
+devenv_e2e_op_sa_enabled: "{{ devenv_e2e_op_sa_token | length > 0 }}"
+devenv_e2e_op_enabled: >-
+  {{ (devenv_e2e_op_connect_enabled | bool)
+     or (devenv_e2e_op_sa_enabled | bool) }}

--- a/molecule/devenv-e2e/molecule.yml
+++ b/molecule/devenv-e2e/molecule.yml
@@ -39,6 +39,29 @@
 #   - VM egress to github.com (repo clone) and ghcr.io (image pull)
 #   - no 1Password needed: the ghapp gate stays off (devenv_ghapp_enabled=false)
 #
+# 1Password integration (optional):
+#   By default this scenario needs NO 1Password access and skips every use()/op
+#   check — the no-token run is byte-for-byte the baseline suite. To ALSO exercise
+#   the container's 1Password-backed environment switching (the .bashrc use() /
+#   unuse() functions), export ONE auth mode before running molecule:
+#     - service-account mode (recommended, scoped): set
+#       MOLECULE_OP_SERVICE_ACCOUNT_TOKEN to a service account scoped to just the
+#       `molecule` vault — read its credential from
+#       op://lab_serviceaccounts/op-molecule-sa/credential and export it.
+#     - Connect mode: set MOLECULE_OP_CONNECT_HOST (url) and
+#       MOLECULE_OP_CONNECT_TOKEN (token).
+#   (Env-var syntax is spelled out in words here on purpose: molecule interpolates
+#   dollar-brace placeholders in this file, so a literal shell example would break
+#   config parsing.)
+#   Set exactly one mode (both → converge fails an assert). Tokens are seeded onto
+#   the VM host's ~/.config/op (0600, no_log) and reach the container through the
+#   existing read-only bind mount — never via cloud-init, the VM spec, the k8s
+#   API, or the ephemeral inventory. The scenario-owned molecule-*.env files and
+#   their backing `molecule` vault items (use-simple / use-kubeconfig /
+#   use-k8s-token / use-registry, plus a deliberately-broken molecule-bad) drive
+#   the converge/verify 1Password plays; with no token those plays skip with an
+#   explicit "1Password integration checks skipped (no token provided)" debug.
+#
 # Run:  molecule test -s devenv-e2e
 prerun: false
 

--- a/molecule/devenv-e2e/verify.yml
+++ b/molecule/devenv-e2e/verify.yml
@@ -239,6 +239,223 @@
         fail_msg: >-
           the code-server NodePort answered but did not serve the login page
 
+# 1Password environment switching (OPTIONAL, gated) — exercise the container's
+# use()/unuse() shell functions end-to-end against the `molecule` vault. Placed
+# BEFORE the reboot play so ordering stays sane (the reboot is destructive/slow
+# and stays last). With no MOLECULE_OP_* token this play is a single skip debug.
+#
+# Each check runs as ONE `bash -ic` script via `docker exec` (the same in-
+# container exec pattern the make test-* plays use). `-i` is required: use() is
+# an interactive-shell function defined by ~/.bashrc, which `docker exec` sources
+# because BASH_ENV/-i pull it in. Every invocation is a FRESH shell — no state
+# survives between tasks — so multi-step checks are each fully self-contained and
+# exit nonzero on the first failed assertion. Scripts assert by EXIT CODE and
+# file inspection and never echo a resolved secret (synthetic here, but the
+# discipline is the point). NO_AUTO_TMUX=1 belt-and-suspenders the tmux
+# auto-attach guard (already inert: it only fires when TERM_PROGRAM=vscode, which
+# a docker exec shell is not).
+#
+# The registry check covers use()'s containers-auth.json flow: REGISTRY_HOST/
+# _USERNAME/_PASSWORD are consumed (never exported as plain vars) into a temp
+# auth dir — REGISTRY_AUTH_FILE points at its config.json (0600, docker-style
+# "auths" schema shared by podman/buildah/skopeo) and DOCKER_CONFIG at the
+# directory; unuse removes the dir and unsets both. The password is only ever
+# prefix-checked through base64, never printed.
+- name: Verify the container's 1Password environment switching (use/unuse)
+  hosts: devenv-devenv
+  gather_facts: false
+  tasks:
+    - name: Report that 1Password verification is skipped
+      ansible.builtin.debug:
+        msg: 1Password integration checks skipped (no token provided)
+      when: not (devenv_e2e_op_enabled | bool)
+
+    - name: Run the in-container use()/unuse() checks
+      when: devenv_e2e_op_enabled | bool
+      become: true
+      block:
+        - name: Auth smoke — op resolves a molecule-vault reference
+          ansible.builtin.command:
+            argv:
+              - docker
+              - exec
+              - -e
+              - NO_AUTO_TMUX=1
+              - igou-devenv
+              - bash
+              - -ic
+              - |
+                op read op://molecule/use-simple/username >/dev/null \
+                  || { echo "auth smoke: op read failed" >&2; exit 1; }
+                echo "auth-smoke ok"
+          register: __op_smoke
+          changed_when: false
+
+        - name: Simple env — values export, '='-bearing host is exact, plain untouched
+          ansible.builtin.command:
+            argv:
+              - docker
+              - exec
+              - -e
+              - NO_AUTO_TMUX=1
+              - igou-devenv
+              - bash
+              - -ic
+              - |
+                fail() { echo "FAIL: $1" >&2; exit 1; }
+                use molecule-simple || fail "use molecule-simple returned nonzero"
+                [ -n "${TEST_USERNAME:-}" ] || fail "TEST_USERNAME empty"
+                [ -n "${TEST_PASSWORD:-}" ] || fail "TEST_PASSWORD empty"
+                [ "${TEST_HOST:-}" = 'https://use-simple.molecule.invalid:6443/?scope=admin&x=1' ] \
+                  || fail "TEST_HOST does not match the exact '='-bearing value"
+                [ "${TEST_PLAIN:-}" = 'plain-value-unchanged' ] || fail "TEST_PLAIN changed"
+                [ "${OP_ENV:-}" = 'molecule-simple' ] || fail "OP_ENV != molecule-simple"
+                echo "simple-env ok"
+          register: __op_simple
+          changed_when: false
+
+        - name: Stacking and selective unuse — survivors, fallback, full clear
+          ansible.builtin.command:
+            argv:
+              - docker
+              - exec
+              - -e
+              - NO_AUTO_TMUX=1
+              - igou-devenv
+              - bash
+              - -ic
+              - |
+                fail() { echo "FAIL: $1" >&2; exit 1; }
+                use molecule-simple || fail "use molecule-simple"
+                use molecule-registry || fail "use molecule-registry"
+                unuse molecule-registry || fail "unuse molecule-registry"
+                [ -n "${TEST_USERNAME:-}" ] || fail "simple vars did not survive selective unuse"
+                [ -z "${REGISTRY_AUTH_FILE:-}" ] || fail "REGISTRY_AUTH_FILE survived unuse molecule-registry"
+                [ -z "${DOCKER_CONFIG:-}" ] || fail "DOCKER_CONFIG survived unuse molecule-registry"
+                [ "${OP_ENV:-}" = 'molecule-simple' ] || fail "OP_ENV did not fall back to molecule-simple"
+                unuse || fail "unuse (all) returned nonzero"
+                [ -z "${OP_ENV:-}" ] || fail "OP_ENV set after unuse all"
+                [ -z "${OP_ENV_LIST:-}" ] || fail "OP_ENV_LIST set after unuse all"
+                [ -z "${TEST_USERNAME:-}" ] || fail "TEST_USERNAME set after unuse all"
+                echo "stack-unuse ok"
+          register: __op_stack
+          changed_when: false
+
+        - name: KUBECONFIG_DATA — file 0600 with the decoded server, cleaned on unuse
+          ansible.builtin.command:
+            argv:
+              - docker
+              - exec
+              - -e
+              - NO_AUTO_TMUX=1
+              - igou-devenv
+              - bash
+              - -ic
+              - |
+                fail() { echo "FAIL: $1" >&2; exit 1; }
+                use molecule-kubeconfig || fail "use molecule-kubeconfig"
+                [ -n "${KUBECONFIG:-}" ] || fail "KUBECONFIG not set"
+                [ -f "$KUBECONFIG" ] || fail "kubeconfig file missing"
+                m=$(stat -c %a "$KUBECONFIG"); [ "$m" = "600" ] || fail "kubeconfig mode $m != 600"
+                grep -q 'use-kubeconfig.molecule.invalid' "$KUBECONFIG" \
+                  || fail "decoded kubeconfig missing the expected server host"
+                saved="$KUBECONFIG"
+                unuse molecule-kubeconfig || fail "unuse molecule-kubeconfig"
+                [ ! -e "$saved" ] || fail "temp kubeconfig not deleted by unuse"
+                [ -z "${KUBECONFIG:-}" ] || fail "KUBECONFIG still set after unuse"
+                echo "kubeconfig-data ok"
+          register: __op_kubedata
+          changed_when: false
+
+        - name: TOKEN+HOST — rendered kubeconfig has host and insecure-skip-tls-verify
+          ansible.builtin.command:
+            argv:
+              - docker
+              - exec
+              - -e
+              - NO_AUTO_TMUX=1
+              - igou-devenv
+              - bash
+              - -ic
+              - |
+                fail() { echo "FAIL: $1" >&2; exit 1; }
+                use molecule-k8s-token || fail "use molecule-k8s-token"
+                [ -n "${KUBECONFIG:-}" ] || fail "KUBECONFIG not set"
+                [ -f "$KUBECONFIG" ] || fail "kubeconfig file missing"
+                grep -q 'use-k8s-token.molecule.invalid' "$KUBECONFIG" \
+                  || fail "rendered kubeconfig missing the token host"
+                grep -q 'insecure-skip-tls-verify: true' "$KUBECONFIG" \
+                  || fail "rendered kubeconfig missing insecure-skip-tls-verify: true"
+                saved="$KUBECONFIG"
+                unuse molecule-k8s-token || fail "unuse molecule-k8s-token"
+                [ ! -e "$saved" ] || fail "temp kubeconfig not cleaned up by unuse"
+                echo "k8s-token ok"
+          register: __op_k8stoken
+          changed_when: false
+
+        - name: Registry — containers-auth.json written 0600, cleaned up on unuse
+          ansible.builtin.command:
+            argv:
+              - docker
+              - exec
+              - -e
+              - NO_AUTO_TMUX=1
+              - igou-devenv
+              - bash
+              - -ic
+              - |
+                fail() { echo "FAIL: $1" >&2; exit 1; }
+                use molecule-registry || fail "use molecule-registry"
+                # REGISTRY_* inputs are consumed into the auth file, never
+                # exported as plain vars.
+                [ -z "${REGISTRY_HOST:-}" ] || fail "REGISTRY_HOST leaked as a plain export"
+                [ -z "${REGISTRY_PASSWORD:-}" ] || fail "REGISTRY_PASSWORD leaked as a plain export"
+                [ -n "${REGISTRY_AUTH_FILE:-}" ] || fail "REGISTRY_AUTH_FILE not set"
+                [ -f "$REGISTRY_AUTH_FILE" ] || fail "auth file missing"
+                m=$(stat -c %a "$REGISTRY_AUTH_FILE"); [ "$m" = "600" ] || fail "auth file mode $m != 600"
+                [ "${DOCKER_CONFIG:-}" = "$(dirname "$REGISTRY_AUTH_FILE")" ] \
+                  || fail "DOCKER_CONFIG is not the auth file's directory"
+                auth=$(jq -er '.auths["registry.molecule.invalid"].auth' "$REGISTRY_AUTH_FILE") \
+                  || fail "auths entry for registry.molecule.invalid missing"
+                # Prefix-check the decoded user:pass only — never print it.
+                case "$(printf '%s' "$auth" | base64 -d)" in
+                  'molecule+testrobot:'*) : ;;
+                  *) fail "decoded auth does not start with molecule+testrobot:" ;;
+                esac
+                saved_dir="$DOCKER_CONFIG"
+                unuse molecule-registry || fail "unuse molecule-registry"
+                [ ! -e "$saved_dir" ] || fail "auth dir not removed by unuse"
+                [ -z "${REGISTRY_AUTH_FILE:-}" ] || fail "REGISTRY_AUTH_FILE survived unuse"
+                [ -z "${DOCKER_CONFIG:-}" ] || fail "DOCKER_CONFIG survived unuse"
+                echo "registry ok"
+          register: __op_registry
+          changed_when: false
+
+        - name: Failure path — bad ref fails cleanly with no residue
+          ansible.builtin.command:
+            argv:
+              - docker
+              - exec
+              - -e
+              - NO_AUTO_TMUX=1
+              - igou-devenv
+              - bash
+              - -ic
+              - |
+                fail() { echo "FAIL: $1" >&2; exit 1; }
+                use molecule-bad && fail "use molecule-bad unexpectedly succeeded"
+                env | grep -q '^_USE_KEYS_molecule_bad=' && fail "_USE_KEYS residue after failed use"
+                [ "${OP_ENV:-}" != 'molecule-bad' ] || fail "OP_ENV wrongly set to molecule-bad"
+                echo "failure-path ok"
+          register: __op_badref
+          changed_when: false
+
+        - name: Summarize the 1Password checks
+          ansible.builtin.debug:
+            msg: >-
+              1Password use()/unuse() checks passed: auth-smoke, simple-env,
+              stack-unuse, kubeconfig-data, k8s-token, registry, failure-path.
+
 # Reboot resilience — LAST on purpose: a reboot is destructive and slow, so a
 # failure here must not poison the health results above. Reboot the KubeVirt VM,
 # then re-assert the core health set survives: docker back up, the scratch disk


### PR DESCRIPTION
Adds opt-in 1Password integration to the devenv-e2e scenario: securely seed an op token onto the test VM and validate the devcontainer's `use()`/`unuse()` environment switching end-to-end against real 1Password — every code path, driven by synthetic test items in the dedicated `molecule` vault.

## Design

- **Opt-in via env vars, off by default.** `MOLECULE_OP_SERVICE_ACCOUNT_TOKEN` (recommended: the `op-molecule-sa` service account, scoped to only the `molecule` vault — credential at `op://lab_serviceaccounts/op-molecule-sa/credential`) or `MOLECULE_OP_CONNECT_HOST`+`MOLECULE_OP_CONNECT_TOKEN`. Exactly one mode; both or a half-set pair fail an assert. With no token, every gated play/task skips with an explicit message and the run is byte-for-byte the baseline suite.
- **Secure seeding**: token written over SSH only (`copy content=`, `no_log` on every token-bearing task) to the VM host's `~/.config/op` (0700/0600), reaching the container through the existing read-only bind mount. Never via cloud-init, the VM spec, the k8s API, or the ephemeral inventory. Lazy env lookups keep tokens out of inventory dumps; mode switches clean up the other mode's stale files (the container `.bashrc` prefers Connect).
- **Test data**: scenario-owned `molecule-*.env` files (op:// references only) copied to the container's envdir, backed by synthetic items in the `molecule` vault (`use-simple` — including an `=`-bearing value, `use-kubeconfig`, `use-k8s-token`, `use-registry`, plus a deliberately broken ref).

## Verification (in-container, exit-code-only, no secrets echoed)

auth smoke · simple resolution + plain passthrough + `OP_ENV` tracking · stacking/selective-unuse/fallback/full-clear · `KUBECONFIG_DATA` temp file (0600, decode, cleanup) · `KUBECONFIG_TOKEN`+`HOST` render · registry containers-auth.json (0600, auths entry, base64 prefix check, `DOCKER_CONFIG`, unuse cleanup) · bad-ref failure with no residue.

## Live results

- SA-token mode: full `molecule verify` green (`ok=40 failed=0`) — all seven 1P checks plus the entire baseline (reboot resilience included); converge idempotent.
- No-token mode: green (`ok=33 skipped=8 failed=0`), gated tasks skip cleanly.
- Connect mode: seeding + in-container Connect reachability and an `op read` through Connect verified; full Connect verify needs a Connect token with `molecule`-vault access (ambient one is scoped elsewhere).

Notable find: `op` needs a writable `~/.config/op/config` device file on first use, which the read-only bind precludes — the seeding play pre-creates it (fixed device id, not a secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E111DtdewtbY27csDfJBMN