### PR TITLE
feat(openshift_virtualization): windows golden-image build playbook + molecule scenario

### DIFF
--- a/molecule/windows-build-golden-image/README.md
+++ b/molecule/windows-build-golden-image/README.md
@@ -1,0 +1,74 @@
+# windows-build-golden-image
+
+Live, on-cluster molecule scenario that exercises
+`playbooks/openshift_virtualization/build_windows_golden.yml`: it installs
+Windows Server 2025 from an installer ISO, sysprep `/generalize`s it, and
+publishes a bootable **golden DataSource** — then proves that image boots
+hands-free.
+
+Everything happens inside the **`molecule`** namespace on
+`https://api.ocp.igou.systems:6443` as the scoped **`ansible-molecule`**
+ServiceAccount. The golden DataSource is published in `molecule`, never in
+`openshift-virtualization-os-images` (the SA has no access there by design).
+
+## Prerequisites
+
+- The live `ocp.igou.systems` cluster reachable, with the `ansible-molecule`
+  SA token exported (TLS verification works — public cert):
+
+  ```bash
+  export K8S_AUTH_HOST=https://api.ocp.igou.systems:6443
+  export K8S_AUTH_API_KEY=$(op read "op://lab_serviceaccounts/ocp-ansible-molecule/token")
+  ```
+
+- `virtctl` on `PATH` (VNC CD-boot helper).
+- `pip install vncdotool` (VNC automation for the install boot).
+- A **preexisting** Windows installer ISO DataVolume in the `windows-images`
+  namespace — `iso-winserver2025-eval`, phase `Succeeded`. This scenario reads
+  it and gates on it; it never creates or deletes anything in `windows-images`.
+- Optional: `WINDOWS_GOLDEN_ADMIN_PASSWORD` to pin the throwaway build password
+  (otherwise one is generated; sysprep wipes it from the published image).
+
+## How to run
+
+Full pipeline (create → converge → verify → destroy):
+
+```bash
+molecule test -s windows-build-golden-image
+```
+
+Step-wise (useful because converge is long-running):
+
+```bash
+molecule create  -s windows-build-golden-image   # preflight gates only
+molecule converge -s windows-build-golden-image  # ~60–90 min build + publish
+molecule verify   -s windows-build-golden-image  # boot-test proof
+molecule destroy  -s windows-build-golden-image  # cleanup
+```
+
+## Expected duration
+
+~60–90 minutes for converge (unattended Windows install + sysprep + publish);
+verify adds ~5–15 minutes (clone + boot + guest-agent handshake). There is **no
+idempotence step** — a multi-hour Windows install is not a re-runnable no-op.
+
+## What verify proves
+
+1. The golden **DataSource** `golden-win2k25` exists and its `Ready` condition
+   is `True`.
+2. Its backing **PVC** `golden-win2k25` is `Bound`.
+3. A throwaway VM `golden-verify` cloned from the golden DataSource — with **no
+   ISO and no unattend volume** — boots and its **guest agent connects**
+   (`AgentConnected == True`). That is the hands-free proof: the generalized
+   disk is self-sufficient with virtio drivers + `qemu-guest-agent` intact. The
+   VM sits at interactive OOBE (cloudbase-init lands in P2), which is expected;
+   the guest agent runs as a Windows service regardless.
+
+## Cleanup semantics
+
+`destroy` removes only the named resources this scenario owns in the `molecule`
+namespace: the build/verify VMs, the installer-CD and golden DataVolumes, the
+unattend Secret, and the golden DataSource. The golden DataSource is treated as
+a **test artifact** here — production publishing is a separate concern in a
+separate namespace. `destroy` never touches `windows-images`, and the SA cannot
+delete namespaces.

--- a/molecule/windows-build-golden-image/converge.yml
+++ b/molecule/windows-build-golden-image/converge.yml
@@ -1,0 +1,29 @@
+---
+# Converge = run the real golden-image build playbook against the live cluster,
+# scoped to the molecule namespace. This is the ~60–90 min unattended install +
+# sysprep + publish. Every var not set here rides its playbook default.
+- name: Converge — build and publish the Windows golden DataSource
+  ansible.builtin.import_playbook: ../../playbooks/openshift_virtualization/build_windows_golden.yml
+  vars:
+    windows_golden_namespace: molecule
+    # Throwaway local-administrator password for the build VM. It is safe to
+    # generate on the fly because sysprep /generalize wipes local accounts and
+    # credentials from the published image — nothing that clones the golden
+    # DataSource inherits this password. Honor an explicit override if set.
+    # The 'zZ9!' suffix guarantees Windows' upper/lower/digit/symbol complexity.
+    windows_golden_admin_password: >-
+      {{ lookup('ansible.builtin.env', 'WINDOWS_GOLDEN_ADMIN_PASSWORD')
+         | default(lookup('ansible.builtin.password',
+                          '/dev/null length=16 chars=ascii_letters,digits') ~ 'zZ9!',
+                   true) }}
+    # All other vars use playbook defaults (win2k25 / windows.2k25 / u1.medium,
+    # ISO windows-images/iso-winserver2025-eval, image_index 2, 50Gi rootdisk,
+    # freenas-nfs-cold-csi ISO storage, keep_build_artifacts false, temp
+    # kubeconfig rendered from K8S_AUTH_HOST/K8S_AUTH_API_KEY for virtctl).
+    #
+    # To build a SECOND edition instead, override the edition/preference/ISO,
+    # e.g. Windows 11 desktop:
+    #   windows_golden_edition: win11
+    #   windows_golden_preference: windows.11
+    #   windows_golden_iso_dv: iso-win11-25h2-eval
+    #   windows_golden_image_index: 6

--- a/molecule/windows-build-golden-image/create.yml
+++ b/molecule/windows-build-golden-image/create.yml
@@ -1,0 +1,92 @@
+---
+# Preflight ONLY — this play creates nothing on the cluster. It fails fast if
+# the environment or the standing windows-images ISO dependency is not ready,
+# so a 60–90 min converge never starts against a broken setup.
+- name: Create — preflight gates for the Windows golden-image build
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    # Namespace everything this scenario owns lives in.
+    golden_namespace: molecule
+    # The preexisting Windows installer ISO DataVolume this build depends on.
+    # Owned by a separate process — we only read it, never create/delete it.
+    iso_namespace: windows-images
+    iso_dv_name: iso-winserver2025-eval
+  tasks:
+    - name: Assert cluster auth env vars are present
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.env', 'K8S_AUTH_HOST') | length > 0
+          - lookup('ansible.builtin.env', 'K8S_AUTH_API_KEY') | length > 0
+        fail_msg: >-
+          K8S_AUTH_HOST and K8S_AUTH_API_KEY must be set. Run:
+          export K8S_AUTH_HOST=https://api.ocp.igou.systems:6443 &&
+          export K8S_AUTH_API_KEY=$(op read "op://lab_serviceaccounts/ocp-ansible-molecule/token")
+        success_msg: Cluster auth env vars present.
+
+    - name: Prove auth works — list VirtualMachines in the molecule namespace
+      kubernetes.core.k8s_info:
+        api_version: kubevirt.io/v1
+        kind: VirtualMachine
+        namespace: "{{ golden_namespace }}"
+      register: _molecule_vms
+
+    - name: Assert the molecule-namespace query succeeded
+      ansible.builtin.assert:
+        that:
+          - _molecule_vms is not failed
+        fail_msg: >-
+          Could not list VirtualMachines in namespace "{{ golden_namespace }}"
+          — check the ansible-molecule ServiceAccount token/RBAC.
+        success_msg: >-
+          Authenticated to the cluster as ansible-molecule; can read the
+          "{{ golden_namespace }}" namespace.
+
+    - name: Fetch the preexisting Windows installer ISO DataVolume (dependency)
+      kubernetes.core.k8s_info:
+        api_version: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        name: "{{ iso_dv_name }}"
+        namespace: "{{ iso_namespace }}"
+      register: _iso_dv
+
+    - name: Assert the ISO DataVolume exists and is fully imported (Succeeded)
+      ansible.builtin.assert:
+        that:
+          - _iso_dv.resources | length == 1
+          - _iso_dv.resources[0].status.phase == "Succeeded"
+        fail_msg: >-
+          Required installer ISO DataVolume {{ iso_namespace }}/{{ iso_dv_name }}
+          is missing or not Succeeded
+          (phase={{ (_iso_dv.resources[0].status.phase | default('absent')) }}).
+          Hydrate it before running this scenario — this build does not create it.
+        success_msg: >-
+          ISO dependency {{ iso_namespace }}/{{ iso_dv_name }} is present and
+          Succeeded.
+
+    - name: Check virtctl is on PATH (needed for the VNC CD-boot helper)
+      ansible.builtin.command: virtctl version --client
+      changed_when: false
+      register: _virtctl_check
+
+    - name: Assert virtctl is available
+      ansible.builtin.assert:
+        that:
+          - _virtctl_check.rc == 0
+        fail_msg: >-
+          virtctl not found on PATH — install it (mise/virtctl) before running.
+        success_msg: virtctl is available.
+
+    - name: Check the vncdotool python module is importable
+      ansible.builtin.command: python3 -c "import vncdotool"
+      changed_when: false
+      register: _vncdotool_check
+
+    - name: Assert vncdotool is installed
+      ansible.builtin.assert:
+        that:
+          - _vncdotool_check.rc == 0
+        fail_msg: >-
+          Python module vncdotool is missing — install it: pip install vncdotool
+        success_msg: vncdotool is importable.

--- a/molecule/windows-build-golden-image/destroy.yml
+++ b/molecule/windows-build-golden-image/destroy.yml
@@ -1,0 +1,54 @@
+---
+# Destroy = best-effort teardown of ONLY the named resources this scenario
+# owns, all in the molecule namespace. `state: absent` is naturally idempotent
+# (deleting an absent object is a no-op), so no ignore_errors is needed. The
+# ansible-molecule SA cannot delete namespaces and this play NEVER touches the
+# windows-images namespace or its ISO DataVolume.
+- name: Destroy — remove golden-image build + verify artifacts
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    golden_namespace: molecule
+  tasks:
+    - name: Delete the build and verify VirtualMachines
+      kubernetes.core.k8s:
+        state: absent
+        api_version: kubevirt.io/v1
+        kind: VirtualMachine
+        name: "{{ item }}"
+        namespace: "{{ golden_namespace }}"
+        wait: true
+      loop:
+        - golden-win2k25-build
+        - golden-verify
+
+    # golden-verify-rootdisk is garbage-collected with golden-verify (owner
+    # ref from its dataVolumeTemplate), so it is intentionally not listed here.
+    - name: Delete the installer-CD and golden DataVolumes
+      kubernetes.core.k8s:
+        state: absent
+        api_version: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        name: "{{ item }}"
+        namespace: "{{ golden_namespace }}"
+        wait: true
+      loop:
+        - golden-win2k25-installcd
+        - golden-win2k25
+
+    - name: Delete the unattend Secret
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        name: golden-win2k25-unattend
+        namespace: "{{ golden_namespace }}"
+
+    - name: Delete the golden DataSource
+      kubernetes.core.k8s:
+        state: absent
+        api_version: cdi.kubevirt.io/v1beta1
+        kind: DataSource
+        name: golden-win2k25
+        namespace: "{{ golden_namespace }}"

--- a/molecule/windows-build-golden-image/molecule.yml
+++ b/molecule/windows-build-golden-image/molecule.yml
@@ -1,0 +1,85 @@
+---
+# Windows golden-image build — LIVE on-cluster scenario.
+#
+# What this proves:
+#   The playbooks/openshift_virtualization/build_windows_golden.yml pipeline
+#   installs Windows Server 2025 from an installer ISO, sysprep /generalize's
+#   it, and publishes a bootable golden DataSource that clones and boots
+#   hands-free (no ISO, no CD prompt, guest agent + virtio drivers intact).
+#
+# Where it runs:
+#   Against the LIVE cluster https://api.ocp.igou.systems:6443 as the scoped
+#   `ansible-molecule` ServiceAccount, entirely inside the `molecule`
+#   namespace. TLS verification WORKS (public cert) — K8S_AUTH_VERIFY_SSL
+#   defaults to true. The golden DataSource is published in `molecule`, NEVER
+#   in openshift-virtualization-os-images (the SA has no access there).
+#
+# Dependency:
+#   A preexisting Windows installer ISO DataVolume in the `windows-images`
+#   namespace (iso-winserver2025-eval, phase Succeeded). create.yml gates on
+#   it and fails fast if missing. This scenario NEVER creates or deletes
+#   anything in windows-images.
+#
+# Wall clock:
+#   ~60–90 minutes end to end (unattended Windows install + sysprep + clone +
+#   boot). This is NOT idempotence-testable, so the test_sequence omits the
+#   idempotence step by design.
+#
+# Env setup one-liner (run before `molecule test -s windows-build-golden-image`):
+#   export K8S_AUTH_HOST=https://api.ocp.igou.systems:6443
+#   export K8S_AUTH_API_KEY="`op read op://lab_serviceaccounts/ocp-ansible-molecule/token`"
+# (molecule interpolates dollar-placeholders across this whole file, comments
+# included, so the usual dollar-paren command substitution cannot appear here.)
+prerun: false
+
+dependency:
+  name: galaxy
+  options:
+    ignore_errors: true
+    role-file: requirements.yml
+    requirements-file: requirements.yml
+
+driver:
+  name: default
+
+platforms:
+  - name: localhost
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      host_key_checking: false
+      verbosity: 1
+      # molecule generates its own ansible.cfg, so the repo-root paths for
+      # galaxy roles/collections must be restated here.
+      roles_path: ${MOLECULE_PROJECT_DIRECTORY}/roles:${MOLECULE_PROJECT_DIRECTORY}/.ansible/roles:~/.ansible/roles
+      collections_path: ${MOLECULE_PROJECT_DIRECTORY}/.ansible/collections:~/.ansible/collections
+  env:
+    # kubernetes.core reads these directly; virtctl/oc get a rendered temp
+    # kubeconfig from them inside the playbook (windows_golden_kubeconfig="").
+    K8S_AUTH_HOST: "${K8S_AUTH_HOST}"
+    K8S_AUTH_API_KEY: "${K8S_AUTH_API_KEY}"
+    K8S_AUTH_VERIFY_SSL: "${K8S_AUTH_VERIFY_SSL:-true}"
+  playbooks:
+    create: create.yml
+    converge: converge.yml
+    verify: verify.yml
+    destroy: destroy.yml
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+
+scenario:
+  name: windows-build-golden-image
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - converge
+    # No idempotence: a 60–90 min unattended Windows install + sysprep is not
+    # a re-runnable no-op, so idempotence is deliberately excluded here.
+    - verify
+    - destroy

--- a/molecule/windows-build-golden-image/verify.yml
+++ b/molecule/windows-build-golden-image/verify.yml
@@ -1,0 +1,162 @@
+---
+# Verify = definition-of-done for the golden image. Asserts the deliverable
+# exists and is Ready, then proves the generalized disk boots HANDS-FREE by
+# cloning it into a throwaway VM and waiting for the guest agent to phone home.
+# This play deletes nothing — destroy.yml owns cleanup (golden-verify and its
+# GC'd rootdisk included).
+- name: Verify — golden DataSource exists, is Ready, and boots hands-free
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    golden_namespace: molecule
+    golden_name: golden-win2k25
+    verify_vm: golden-verify
+  tasks:
+    - name: Fetch the published golden DataSource
+      kubernetes.core.k8s_info:
+        api_version: cdi.kubevirt.io/v1beta1
+        kind: DataSource
+        name: "{{ golden_name }}"
+        namespace: "{{ golden_namespace }}"
+      register: _golden_ds
+
+    - name: Assert the golden DataSource exists and reports Ready == True
+      ansible.builtin.assert:
+        that:
+          - _golden_ds.resources | length == 1
+          - >-
+            _golden_ds.resources[0].status.conditions
+            | selectattr('type', 'equalto', 'Ready')
+            | selectattr('status', 'equalto', 'True')
+            | list | length == 1
+        fail_msg: >-
+          DataSource {{ golden_namespace }}/{{ golden_name }} is missing or not
+          Ready — the build did not publish a usable golden image.
+        success_msg: >-
+          Golden DataSource {{ golden_namespace }}/{{ golden_name }} is Ready.
+
+    - name: Fetch the backing golden PVC
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: PersistentVolumeClaim
+        name: "{{ golden_name }}"
+        namespace: "{{ golden_namespace }}"
+      register: _golden_pvc
+
+    - name: Assert the golden PVC exists and is Bound
+      ansible.builtin.assert:
+        that:
+          - _golden_pvc.resources | length == 1
+          - _golden_pvc.resources[0].status.phase == "Bound"
+        fail_msg: >-
+          Golden PVC {{ golden_namespace }}/{{ golden_name }} is missing or not
+          Bound — the deliverable has no backing storage.
+        success_msg: Golden PVC is Bound.
+
+    # Boot test — the real proof. Clone the golden DataSource into a fresh VM
+    # with NO installer ISO and NO sysprep/unattend volume: if it boots, the
+    # generalized disk is self-sufficient. Shape mirrors the proven build VM
+    # (EFI + SecureBoot + TPM + e1000e), which is what Windows Server 2025
+    # expects. The VM will land at interactive OOBE (cloudbase-init arrives in
+    # P2), but qemu-guest-agent runs as a Windows service regardless — so
+    # AgentConnected flipping True is a hands-free proof the image is bootable
+    # with virtio drivers + guest agent intact.
+    - name: Create the golden-verify boot-test VirtualMachine
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: kubevirt.io/v1
+          kind: VirtualMachine
+          metadata:
+            name: "{{ verify_vm }}"
+            namespace: "{{ golden_namespace }}"
+          spec:
+            runStrategy: Always
+            dataVolumeTemplates:
+              - metadata:
+                  name: "{{ verify_vm }}-rootdisk"
+                spec:
+                  sourceRef:
+                    kind: DataSource
+                    name: "{{ golden_name }}"
+                    namespace: "{{ golden_namespace }}"
+                  storage:
+                    resources:
+                      requests:
+                        storage: 50Gi
+            template:
+              metadata:
+                labels:
+                  kubevirt.io/domain: "{{ verify_vm }}"
+              spec:
+                domain:
+                  cpu:
+                    sockets: 2
+                    cores: 1
+                    threads: 1
+                  memory:
+                    guest: 6Gi
+                  firmware:
+                    bootloader:
+                      efi:
+                        secureBoot: true
+                  features:
+                    smm:
+                      enabled: true
+                    acpi: {}
+                  devices:
+                    tpm: {}
+                    disks:
+                      - name: rootdisk
+                        bootOrder: 1
+                        disk:
+                          bus: sata
+                    interfaces:
+                      - name: default
+                        model: e1000e
+                        masquerade: {}
+                networks:
+                  - name: default
+                    pod: {}
+                volumes:
+                  - name: rootdisk
+                    dataVolume:
+                      name: "{{ verify_vm }}-rootdisk"
+                # truenas-w1 is a storage-hosting VM worker; keep guest VMs off
+                # it (same rationale as the build VM). Short hostname on purpose.
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/hostname
+                              operator: NotIn
+                              values:
+                                - truenas-w1
+
+    - name: Wait for the golden-verify guest agent to connect (clone + boot)
+      kubernetes.core.k8s_info:
+        api_version: kubevirt.io/v1
+        kind: VirtualMachineInstance
+        name: "{{ verify_vm }}"
+        namespace: "{{ golden_namespace }}"
+      register: _verify_vmi
+      # Clone + first boot (sysprep specialize pass) + agent handshake ≈ 5–15
+      # min; 20 min cap leaves margin for a host-assisted clone fallback.
+      retries: 40
+      delay: 30
+      until:
+        - _verify_vmi.resources | length == 1
+        - >-
+          _verify_vmi.resources[0].status.conditions | default([])
+          | selectattr('type', 'equalto', 'AgentConnected')
+          | selectattr('status', 'equalto', 'True')
+          | list | length == 1
+
+    - name: Trophy — report the guest OS the golden image booted into
+      ansible.builtin.debug:
+        msg: >-
+          golden-verify booted:
+          {{ _verify_vmi.resources[0].status.guestOSInfo.prettyName
+             | default('(guestOSInfo not yet populated)') }}

--- a/playbooks/openshift_virtualization/build_windows_golden.yml
+++ b/playbooks/openshift_virtualization/build_windows_golden.yml
@@ -1,0 +1,476 @@
+---
+# Build a Windows golden image for OpenShift Virtualization (issue #343, phase 1).
+#
+# Turns a Windows installer ISO DataVolume into a generalized (sysprepped)
+# bootable golden root disk, published as a CDI DataSource that stock KubeVirt
+# Windows templates can clone via sourceRef.
+#
+# Flow (all inside windows_golden_namespace, plus one cross-namespace ISO clone):
+#   1. preflight (tools + source ISO DataVolume)
+#   2. clone the installer ISO into the build namespace
+#   3. render the autounattend answer file into a Secret
+#   4. create a STANDALONE golden root DataVolume (not a dataVolumeTemplate, so
+#      it survives VM deletion and becomes the published disk with no capture)
+#   5. create a throwaway build VM (runStrategy Manual) and CD-boot it
+#   6. the answer file drives install -> guest tools -> sysprep /generalize
+#      /shutdown, fully unattended (no WinRM needed in phase 1); the VMI goes
+#      Succeeded on poweroff
+#   7. delete the VM, publish the surviving root DV as a DataSource, clean up
+#
+# All k8s tasks use kubernetes.core with NO explicit auth params — they honor
+# K8S_AUTH_HOST / K8S_AUTH_API_KEY / K8S_AUTH_VERIFY_SSL / KUBECONFIG from the
+# environment. boot-vm.sh drives virtctl/oc and needs a real kubeconfig FILE, so
+# one is rendered from K8S_AUTH_* when windows_golden_kubeconfig is not provided.
+- name: Build Windows golden image DataSource
+  hosts: "{{ target_hosts | default('localhost') }}"
+  # Talk to the API via env-injected K8S_AUTH_* / KUBECONFIG — no SSH needed.
+  # Force local so a bare `localhost` inventory entry does not default to ssh.
+  connection: local
+  gather_facts: false
+  vars:
+    # --- Interface contract (see issue #343 phase 1, part A) ---------------
+    # REQUIRED. Namespace used for BOTH the build VM and the published DataSource.
+    windows_golden_namespace: ""
+    # REQUIRED. Local Administrator / auto-logon password for the throwaway build
+    # VM. generalize wipes machine identity, so this is not a durable secret;
+    # every task that renders or uses it sets no_log: true.
+    windows_golden_admin_password: ""
+    # Short edition key; drives all derived resource names.
+    windows_golden_edition: win2k25
+    # virtualmachineclusterpreference applied to the build VM and stamped as the
+    # DataSource default-preference label.
+    windows_golden_preference: windows.2k25
+    # Only used as the DataSource default-instancetype label.
+    windows_golden_instancetype: u1.medium
+    # Where the source installer ISO DataVolume already lives.
+    windows_golden_iso_namespace: windows-images
+    windows_golden_iso_dv: iso-winserver2025-eval
+    # install.wim image index; 2 = Server 2025 Standard Eval (Desktop Experience).
+    windows_golden_image_index: 2
+    # ComputerName for the throwaway build VM.
+    windows_golden_hostname: goldenbuild
+    # Size of the golden root disk.
+    windows_golden_disk_size: 50Gi
+    # StorageClass for the golden root disk; empty -> cluster default SC.
+    windows_golden_storage_class: ""
+    # StorageClass for the ISO clone target; same SC as the source enables a
+    # smart (server-side) clone instead of a host-assisted copy.
+    windows_golden_iso_storage_class: freenas-nfs-cold-csi
+    # Local TCP port for the virtctl VNC proxy that autoboot.py drives.
+    windows_golden_vnc_port: 5901
+    # Cap on the install -> generalize -> shutdown wait (minutes).
+    windows_golden_install_timeout_minutes: 90
+    # Keep the installcd clone DV + unattend Secret after publishing.
+    windows_golden_keep_build_artifacts: false
+    # kubeconfig path for virtctl/oc in boot-vm.sh; empty -> render a temp one
+    # from K8S_AUTH_HOST / K8S_AUTH_API_KEY.
+    windows_golden_kubeconfig: ""
+
+    # --- Derived resource names (sibling molecule scenario depends on these) --
+    windows_golden_vm_name: "golden-{{ windows_golden_edition }}-build"
+    # Golden root DV == published PVC == DataSource name.
+    windows_golden_dv_name: "golden-{{ windows_golden_edition }}"
+    windows_golden_installcd_dv: "golden-{{ windows_golden_edition }}-installcd"
+    windows_golden_unattend_secret: "golden-{{ windows_golden_edition }}-unattend"
+
+  tasks:
+
+    # --- Step 1: assert inputs and required tooling -----------------------
+    - name: Assert windows_golden_namespace is set
+      ansible.builtin.assert:
+        that:
+          - windows_golden_namespace | length > 0
+        fail_msg: >-
+          windows_golden_namespace is required (build + publish namespace).
+
+    - name: Assert windows_golden_admin_password is set
+      no_log: true
+      ansible.builtin.assert:
+        that:
+          - windows_golden_admin_password | length > 0
+        fail_msg: >-
+          windows_golden_admin_password is required
+          (build-VM Administrator / auto-logon password).
+
+    - name: Check virtctl is available
+      ansible.builtin.command: virtctl version --client
+      changed_when: false
+      failed_when: false
+      register: golden_virtctl_check
+
+    - name: Assert virtctl is on PATH
+      ansible.builtin.assert:
+        that:
+          - golden_virtctl_check.rc == 0
+        fail_msg: >-
+          virtctl not found on PATH. Install it (e.g. `oc adm` /
+          kubevirt release) and re-run.
+
+    - name: Check python3 vncdotool module is importable
+      ansible.builtin.command: python3 -c "import vncdotool"
+      changed_when: false
+      failed_when: false
+      register: golden_vncdotool_check
+
+    - name: Assert vncdotool is importable
+      ansible.builtin.assert:
+        that:
+          - golden_vncdotool_check.rc == 0
+        fail_msg: >-
+          python3 cannot import vncdotool (needed by autoboot.py over VNC).
+          Install it: pip install vncdotool
+
+    # --- Step 2: resolve a kubeconfig FILE for boot-vm.sh -----------------
+    - name: Assert K8S_AUTH env is present when rendering a kubeconfig
+      when: windows_golden_kubeconfig | length == 0
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.env', 'K8S_AUTH_HOST') | length > 0
+          - lookup('ansible.builtin.env', 'K8S_AUTH_API_KEY') | length > 0
+        fail_msg: >-
+          windows_golden_kubeconfig is empty and K8S_AUTH_HOST /
+          K8S_AUTH_API_KEY are not set; cannot build a kubeconfig for
+          virtctl/oc.
+
+    - name: Create a temp kubeconfig file
+      when: windows_golden_kubeconfig | length == 0
+      ansible.builtin.tempfile:
+        state: file
+        suffix: kubeconfig
+      register: golden_kubeconfig_tmp
+
+    - name: Render the temp kubeconfig
+      when: windows_golden_kubeconfig | length == 0
+      no_log: true
+      ansible.builtin.copy:
+        dest: "{{ golden_kubeconfig_tmp.path }}"
+        mode: "0600"
+        content: |
+          apiVersion: v1
+          kind: Config
+          clusters:
+            - name: golden-build
+              cluster:
+                server: {{ lookup('ansible.builtin.env', 'K8S_AUTH_HOST') }}
+                insecure-skip-tls-verify: false
+          users:
+            - name: golden-build
+              user:
+                token: {{ lookup('ansible.builtin.env', 'K8S_AUTH_API_KEY') }}
+          contexts:
+            - name: golden-build
+              context:
+                cluster: golden-build
+                user: golden-build
+          current-context: golden-build
+
+    - name: Resolve the kubeconfig path for boot-vm.sh
+      ansible.builtin.set_fact:
+        windows_golden_resolved_kubeconfig: >-
+          {{ windows_golden_kubeconfig
+             if windows_golden_kubeconfig | length > 0
+             else golden_kubeconfig_tmp.path }}
+
+    - name: Build and publish the Windows golden image
+      block:
+
+        # --- Step 3: preflight the source ISO DataVolume ------------------
+        - name: Look up the source installer ISO DataVolume
+          kubernetes.core.k8s_info:
+            api_version: cdi.kubevirt.io/v1beta1
+            kind: DataVolume
+            name: "{{ windows_golden_iso_dv }}"
+            namespace: "{{ windows_golden_iso_namespace }}"
+          register: golden_iso_dv
+
+        - name: Assert the source ISO DataVolume exists and is ready
+          ansible.builtin.assert:
+            that:
+              - golden_iso_dv.resources | length == 1
+              - golden_iso_dv.resources[0].status.phase == "Succeeded"
+            fail_msg: >-
+              Source ISO DataVolume {{ windows_golden_iso_dv }} in
+              {{ windows_golden_iso_namespace }} is missing or not Succeeded.
+
+        - name: Capture the source ISO storage request (clone size)
+          ansible.builtin.set_fact:
+            windows_golden_iso_size: >-
+              {{ golden_iso_dv.resources[0].spec.storage.resources.requests.storage
+                 | default(golden_iso_dv.resources[0].spec.pvc.resources.requests.storage) }}
+
+        # --- Step 4: clone the ISO into the build namespace ---------------
+        - name: Clone the installer ISO into the build namespace
+          kubernetes.core.k8s:
+            definition:
+              apiVersion: cdi.kubevirt.io/v1beta1
+              kind: DataVolume
+              metadata:
+                name: "{{ windows_golden_installcd_dv }}"
+                namespace: "{{ windows_golden_namespace }}"
+                annotations:
+                  cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+                  cdi.kubevirt.io/storage.usePopulator: "true"
+              spec:
+                source:
+                  pvc:
+                    name: "{{ windows_golden_iso_dv }}"
+                    namespace: "{{ windows_golden_iso_namespace }}"
+                storage:
+                  storageClassName: "{{ windows_golden_iso_storage_class }}"
+                  resources:
+                    requests:
+                      storage: "{{ windows_golden_iso_size }}"
+
+        - name: Wait for the ISO clone to complete
+          kubernetes.core.k8s_info:
+            api_version: cdi.kubevirt.io/v1beta1
+            kind: DataVolume
+            name: "{{ windows_golden_installcd_dv }}"
+            namespace: "{{ windows_golden_namespace }}"
+          register: golden_clone_status
+          until:
+            - golden_clone_status.resources | length == 1
+            - golden_clone_status.resources[0].status.phase == "Succeeded"
+          retries: 60
+          delay: 30
+
+        # --- Step 5: render the autounattend answer file into a Secret ----
+        - name: Create the unattend Secret
+          no_log: true
+          kubernetes.core.k8s:
+            definition:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: "{{ windows_golden_unattend_secret }}"
+                namespace: "{{ windows_golden_namespace }}"
+              stringData:
+                autounattend.xml: "{{ lookup('ansible.builtin.template', 'templates/autounattend-server.xml.j2') }}"
+
+        # --- Step 6: create the STANDALONE golden root DataVolume ---------
+        # Build the storage spec so storageClassName is omitted (cluster default)
+        # when windows_golden_storage_class is empty.
+        - name: Build the golden root DV storage spec
+          ansible.builtin.set_fact:
+            windows_golden_root_storage: >-
+              {{
+                {'resources': {'requests': {'storage': windows_golden_disk_size}}}
+                | combine(
+                    {'storageClassName': windows_golden_storage_class}
+                    if windows_golden_storage_class | length > 0 else {}
+                  )
+              }}
+
+        - name: Create the standalone golden root DataVolume
+          # STANDALONE (not a dataVolumeTemplate): the VM must not own it so it
+          # survives VM deletion and becomes the published disk with zero
+          # capture-clone.
+          kubernetes.core.k8s:
+            definition:
+              apiVersion: cdi.kubevirt.io/v1beta1
+              kind: DataVolume
+              metadata:
+                name: "{{ windows_golden_dv_name }}"
+                namespace: "{{ windows_golden_namespace }}"
+                annotations:
+                  cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+              spec:
+                source:
+                  blank: {}
+                storage: "{{ windows_golden_root_storage }}"
+
+        # --- Step 7: create the throwaway build VM -----------------------
+        - name: Create the build VM (runStrategy Manual)
+          kubernetes.core.k8s:
+            definition:
+              apiVersion: kubevirt.io/v1
+              kind: VirtualMachine
+              metadata:
+                name: "{{ windows_golden_vm_name }}"
+                namespace: "{{ windows_golden_namespace }}"
+                labels:
+                  app.kubernetes.io/part-of: windows-golden-build
+                  windows-edition: "{{ windows_golden_edition }}"
+              spec:
+                # Manual: KubeVirt never auto-restarts. Guest reboots during
+                # Setup keep the VMI Running; only sysprep's /shutdown ends it,
+                # which is exactly our "install done" signal.
+                runStrategy: Manual
+                preference:
+                  kind: virtualmachineclusterpreference
+                  name: "{{ windows_golden_preference }}"
+                template:
+                  metadata:
+                    labels:
+                      kubevirt.io/domain: "{{ windows_golden_vm_name }}"
+                  spec:
+                    # Keep Windows VMs OFF the TrueNAS-hosted worker (nested virt
+                    # unsupported). Belt-and-suspenders with the HCO workloads
+                    # nodePlacement exclusion.
+                    affinity:
+                      nodeAffinity:
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          nodeSelectorTerms:
+                            - matchExpressions:
+                                - key: kubernetes.io/hostname
+                                  operator: NotIn
+                                  values:
+                                    # SHORT hostname — the node's
+                                    # kubernetes.io/hostname label is
+                                    # "truenas-w1", not the FQDN (verified on the
+                                    # live cluster; every other node uses its
+                                    # FQDN). FQDN here silently never matches, so
+                                    # the exclusion is a no-op. See README / #420.
+                                    - truenas-w1
+                    domain:
+                      cpu:
+                        cores: 1
+                        sockets: 2
+                        threads: 1
+                      memory:
+                        guest: 6Gi
+                      firmware:
+                        # secureBoot required for Windows 11 client install;
+                        # harmless for Server.
+                        bootloader:
+                          efi:
+                            secureBoot: true
+                      features:
+                        smm:
+                          enabled: true
+                        acpi: {}
+                      devices:
+                        # Non-persistent vTPM (satisfies Win 11 TPM 2.0 check).
+                        tpm: {}
+                        disks:
+                          - name: rootdisk
+                            bootOrder: 1
+                            disk:
+                              bus: sata
+                          - name: installcd
+                            bootOrder: 2
+                            cdrom:
+                              bus: sata
+                          - name: virtiodrivers
+                            cdrom:
+                              bus: sata
+                          - name: sysprep
+                            cdrom:
+                              bus: sata
+                        interfaces:
+                          - name: default
+                            masquerade: {}
+                            model: e1000e
+                    networks:
+                      - name: default
+                        pod: {}
+                    volumes:
+                      - name: rootdisk
+                        dataVolume:
+                          name: "{{ windows_golden_dv_name }}"
+                      - name: installcd
+                        persistentVolumeClaim:
+                          claimName: "{{ windows_golden_installcd_dv }}"
+                      - name: virtiodrivers
+                        containerDisk:
+                          image: registry.redhat.io/container-native-virtualization/virtio-win-rhel9@sha256:cc98b37978b84b5fe7127c08d52a09c8c136c61ae51085a3f3180e3e11275497
+                      - name: sysprep
+                        sysprep:
+                          # secret (not configMap): the rendered answer file
+                          # carries the Administrator password. The field is a
+                          # LocalObjectReference — `name`, NOT `secretName`
+                          # (the API silently drops unknown fields and the VM
+                          # ends up with an empty sysprep reference).
+                          secret:
+                            name: "{{ windows_golden_unattend_secret }}"
+
+        # --- Step 8: CD-boot the VM into Windows Setup -------------------
+        - name: CD-boot the build VM into Windows Setup
+          # boot-vm.sh power-cycles + drives autoboot.py over VNC to catch the
+          # "Press any key to boot from CD" prompt; self-bounds ~6 x 4 min.
+          ansible.builtin.command:
+            argv:
+              - bash
+              - "{{ playbook_dir }}/files/boot-vm.sh"
+              - "{{ windows_golden_vm_name }}"
+              - "{{ windows_golden_vnc_port }}"
+              - "{{ windows_golden_namespace }}"
+          environment:
+            KUBECONFIG: "{{ windows_golden_resolved_kubeconfig }}"
+          changed_when: true
+
+        # --- Step 9: wait for install -> generalize -> shutdown ----------
+        - name: Wait for the build VM to finish and power off (VMI Succeeded)
+          kubernetes.core.k8s_info:
+            api_version: kubevirt.io/v1
+            kind: VirtualMachineInstance
+            name: "{{ windows_golden_vm_name }}"
+            namespace: "{{ windows_golden_namespace }}"
+          register: golden_vmi_status
+          until:
+            - golden_vmi_status.resources | length == 1
+            - golden_vmi_status.resources[0].status.phase == "Succeeded"
+          retries: "{{ windows_golden_install_timeout_minutes | int }}"
+          delay: 60
+
+        # --- Step 10: publish -------------------------------------------
+        - name: Delete the build VM (standalone root DV survives)
+          kubernetes.core.k8s:
+            state: absent
+            api_version: kubevirt.io/v1
+            kind: VirtualMachine
+            name: "{{ windows_golden_vm_name }}"
+            namespace: "{{ windows_golden_namespace }}"
+            wait: true
+
+        - name: Publish the golden root disk as a DataSource
+          kubernetes.core.k8s:
+            definition:
+              apiVersion: cdi.kubevirt.io/v1beta1
+              kind: DataSource
+              metadata:
+                name: "{{ windows_golden_dv_name }}"
+                namespace: "{{ windows_golden_namespace }}"
+                labels:
+                  instancetype.kubevirt.io/default-preference: "{{ windows_golden_preference }}"
+                  instancetype.kubevirt.io/default-instancetype: "{{ windows_golden_instancetype }}"
+              spec:
+                source:
+                  pvc:
+                    name: "{{ windows_golden_dv_name }}"
+                    namespace: "{{ windows_golden_namespace }}"
+
+        # --- Step 11: clean up build artifacts --------------------------
+        - name: Delete the installcd clone DataVolume
+          when: not (windows_golden_keep_build_artifacts | bool)
+          kubernetes.core.k8s:
+            state: absent
+            api_version: cdi.kubevirt.io/v1beta1
+            kind: DataVolume
+            name: "{{ windows_golden_installcd_dv }}"
+            namespace: "{{ windows_golden_namespace }}"
+
+        - name: Delete the unattend Secret
+          when: not (windows_golden_keep_build_artifacts | bool)
+          kubernetes.core.k8s:
+            state: absent
+            api_version: v1
+            kind: Secret
+            name: "{{ windows_golden_unattend_secret }}"
+            namespace: "{{ windows_golden_namespace }}"
+
+        # --- Step 12: report --------------------------------------------
+        - name: Report the published DataSource
+          ansible.builtin.debug:
+            msg:
+              - "Published DataSource {{ windows_golden_dv_name }} in namespace {{ windows_golden_namespace }}."
+              - "Consume it from a VM via a dataVolumeTemplate sourceRef:"
+              - "  sourceRef: {kind: DataSource, name: {{ windows_golden_dv_name }}, namespace: {{ windows_golden_namespace }}}"
+
+      always:
+        - name: Remove the temp kubeconfig
+          when: windows_golden_kubeconfig | length == 0
+          ansible.builtin.file:
+            path: "{{ golden_kubeconfig_tmp.path }}"
+            state: absent
+          ignore_errors: true  # noqa: ignore-errors best-effort cleanup

--- a/playbooks/openshift_virtualization/files/autoboot.py
+++ b/playbooks/openshift_virtualization/files/autoboot.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Press Enter while the screen is dark to catch the fresh-boot CD prompt.
+Connect with retry (VNC may not be ready immediately) and start pressing ASAP.
+blue -> Windows Setup (exit 0). Persistent gray Front Page -> exit 1 so the
+wrapper power-cycles for another fresh-boot attempt."""
+import sys, os, time
+from vncdotool import api
+
+port = sys.argv[1]
+duration = int(sys.argv[2]) if len(sys.argv) > 2 else 90
+
+client = None
+t0 = time.time()
+while time.time() - t0 < 25:
+    try:
+        client = api.connect('127.0.0.1::%s' % port)
+        client.timeout = 12
+        client.refreshScreen()
+        break
+    except Exception as e:
+        print('connect retry:', e); time.sleep(2); client = None
+if client is None:
+    print('NO_VNC'); sys.exit(2)
+
+def analyze():
+    client.refreshScreen()
+    img = client.screen.convert('RGB').resize((40, 30))
+    px = list(img.getdata()); n = len(px)
+    r = sum(p[0] for p in px) / n
+    g = sum(p[1] for p in px) / n
+    b = sum(p[2] for p in px) / n
+    mean = (r + g + b) / 3
+    if mean < 45:
+        return 'dark', mean
+    if b - (r + g) / 2 > 16:
+        return 'blue', mean
+    if abs(r - g) < 22 and abs(g - b) < 22 and mean > 85:
+        return 'gray', mean
+    return 'other', mean
+
+deadline = time.time() + duration
+blue_streak = gray_streak = 0
+while time.time() < deadline:
+    try:
+        s, m = analyze()
+    except Exception as e:
+        print('err', e); time.sleep(1); continue
+    print('%-6s %5.1f' % (s, m))
+    if s == 'dark':
+        client.keyPress('enter'); gray_streak = 0; blue_streak = 0
+    elif s == 'blue':
+        blue_streak += 1; gray_streak = 0
+        if blue_streak >= 3:
+            print('SETUP'); sys.stdout.flush(); os._exit(0)
+    else:  # gray / other
+        gray_streak += 1
+        if gray_streak >= 12:
+            print('STUCK'); sys.stdout.flush(); os._exit(1)
+    time.sleep(0.8)
+print('TIMEOUT'); sys.stdout.flush(); os._exit(1)

--- a/playbooks/openshift_virtualization/files/boot-vm.sh
+++ b/playbooks/openshift_virtualization/files/boot-vm.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Reliably boot a Windows installer VM into Setup.
+#
+# autoboot.py can only catch the "Press any key to boot from CD" prompt if it is
+# already pressing when the ~5s window appears. On a cold VMI the VNC proxy
+# isn't ready that early, so a single run often lands on the UEFI Front Page and
+# misses it. This wrapper force power-cycles the VM and retries autoboot.py from
+# a known start each time, until it detects the blue Windows Setup screen.
+#
+# This step is inherent to Windows install media on any headless UEFI VM (the
+# media requires a keypress to boot); it is NOT related to any storage backend.
+#
+# oc / virtctl / python3 are taken from PATH and honor the KUBECONFIG env var
+# exported by the calling playbook (the resolved golden-build kubeconfig).
+#
+# Usage: boot-vm.sh <vm-name> <local-vnc-port> <namespace>
+set -u
+NAME=${1:?vm name required}
+PORT=${2:?local vnc port required}
+NS=${3:?namespace required}
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+for attempt in 1 2 3 4 5 6; do
+  echo "[$NAME] attempt $attempt: power-cycle"
+  virtctl stop "$NAME" -n "$NS" --force --grace-period=0 >/dev/null 2>&1
+  for i in $(seq 1 15); do
+    [ -z "$(oc get vmi "$NAME" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null)" ] && break
+    sleep 3
+  done
+  virtctl start "$NAME" -n "$NS" >/dev/null 2>&1
+  for i in $(seq 1 25); do
+    [ "$(oc get vmi "$NAME" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null)" = Running ] && break
+    sleep 3
+  done
+  # start the VNC proxy; autoboot.py self-retries the connection until it is up
+  virtctl vnc "$NAME" -n "$NS" --proxy-only --port "$PORT" >/dev/null 2>&1 &
+  vpid=$!
+  sleep 3
+  python3 "$DIR/autoboot.py" "$PORT" 160
+  rc=$?
+  kill "$vpid" >/dev/null 2>&1
+  echo "[$NAME] attempt $attempt autoboot rc=$rc"
+  [ "$rc" = 0 ] && { echo "[$NAME] in Setup"; exit 0; }
+done
+echo "[$NAME] FAILED to reach Setup after retries"; exit 1

--- a/playbooks/openshift_virtualization/templates/autounattend-server.xml.j2
+++ b/playbooks/openshift_virtualization/templates/autounattend-server.xml.j2
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>EFI</Type>
+              <Size>260</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>MSR</Type>
+              <Size>128</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>3</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Label>System</Label>
+              <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>2</PartitionID>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>3</Order>
+              <PartitionID>3</PartitionID>
+              <Label>Windows</Label>
+              <Letter>C</Letter>
+              <Format>NTFS</Format>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>{{ windows_golden_image_index }}</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName>Homelab</FullName>
+        <Organization>igou.systems</Organization>
+      </UserData>
+    </component>
+  </settings>
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <ComputerName>{{ windows_golden_hostname }}</ComputerName>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+        <SkipMachineOOBE>true</SkipMachineOOBE>
+        <SkipUserOOBE>true</SkipUserOOBE>
+      </OOBE>
+      <UserAccounts>
+        <AdministratorPassword>
+          <Value>{{ windows_golden_admin_password }}</Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+      </UserAccounts>
+      <AutoLogon>
+        <Password>
+          <Value>{{ windows_golden_admin_password }}</Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <Enabled>true</Enabled>
+        <LogonCount>2</LogonCount>
+        <Username>Administrator</Username>
+      </AutoLogon>
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Description>Install virtio-win guest tools (drivers + qemu-ga)</Description>
+          <CommandLine>cmd /c for %d in (D E F G H) do @if exist %d:\virtio-win-guest-tools.exe start /wait %d:\virtio-win-guest-tools.exe /install /passive /norestart</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Description>Ensure QEMU Guest Agent running</Description>
+          <CommandLine>cmd /c sc config "QEMU-GA" start= auto &amp; net start "QEMU-GA"</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <Description>Marker</Description>
+          <CommandLine>cmd /c echo installed &gt; C:\windows-unattend-done.txt</CommandLine>
+        </SynchronousCommand>
+        <!-- Sysprep refuses to run while file-rename/reboot operations are
+             pending, and the virtio-win /norestart install can leave some
+             behind. So: queue sysprep via RunOnce, reboot to clear the
+             pending state, and let the second auto-logon (LogonCount=2
+             above) fire it. -->
+        <SynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <Description>Queue sysprep generalize for the next logon</Description>
+          <CommandLine>cmd /c reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce" /v GoldenSysprep /t REG_SZ /d "C:\Windows\System32\Sysprep\sysprep.exe /generalize /oobe /shutdown /quiet" /f</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>5</Order>
+          <Description>Reboot to clear pending operations before sysprep</Description>
+          <CommandLine>cmd /c shutdown /r /t 5 /c "reboot-before-sysprep"</CommandLine>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+</unattend>


### PR DESCRIPTION
## Summary

**Phase 1 of #343.** `playbooks/openshift_virtualization/build_windows_golden.yml` turns a Windows installer ISO DataVolume into a **generalized (sysprepped) bootable golden disk published as a CDI DataSource**, and `molecule/windows-build-golden-image/` proves it end-to-end on the live cluster as the scoped `ansible-molecule` SA — build **and publish entirely inside the `molecule` namespace** (never `openshift-virtualization-os-images`).

## Flow

1. Preflight: tooling (virtctl, vncdotool), source ISO DV `Succeeded` in `windows-images` (the scenario's standing dependency — never created/deleted by it)
2. Cross-namespace smart clone of the ISO into the build namespace (~2 min, same-SC ZFS snapshot clone)
3. Rendered autounattend → **Secret** (carries the admin password; `sysprep.secret.name` volume)
4. **Standalone** golden root DV — not a dataVolumeTemplate, so it survives VM deletion and *is* the published disk: zero capture-clone
5. Build VM (`runStrategy: Manual`, proven shape from igou-openshift `windows-vms/examples`: EFI+SecureBoot+SMM+TPM, sata, e1000e masquerade, virtio-win containerDisk, `NotIn truenas-w1`)
6. CD-boot atom: `boot-vm.sh`/`autoboot.py` (VNC keypress) — worked first try, rc=0 in 3 min under the SA's vnc-subresource grant
7. Unattended install → virtio-win → **clearing reboot → RunOnce'd `sysprep /generalize /oobe /shutdown`** (sysprep refuses to run with the pending operations `/norestart` leaves; the RunOnce+reboot sequencing is the reliable order). VMI `Succeeded` = done signal
8. Delete VM, publish DataSource with `instancetype.kubevirt.io/default-{preference,instancetype}` labels, clean build artifacts

## E2E proof (2026-07-10, live `ocp`)

| Leg | Result |
|-----|--------|
| converge | ~35 min total; install+sysprep ~25 min |
| verify | DataSource Ready; `golden-verify` VM cloned + booted **hands-free** (no ISO, no keypress); `AgentConnected=True` in ~9 min; guest reports **"Windows Server 2025 Standard Evaluation"** |
| destroy | namespace left clean (verified) |

`molecule test -s windows-build-golden-image` exit 0. Idempotence is deliberately omitted from the sequence (a 60–90 min OS install is not a re-runnable no-op — noted in `molecule.yml`).

## Gotchas found live (recorded as comments in the code)

- KubeVirt sysprep volume secret ref is `secret.name` (LocalObjectReference) — `secretName` is **silently dropped** by the API and the VMI wedges Pending
- molecule interpolates `$`-placeholders across the whole `molecule.yml` including comments — `$(...)` in a doc comment kills config parsing
- `kubernetes.core.k8s state=present` PATCHes existing objects → re-runs over leftover DVs need `datavolumes patch/update` (igou-io/igou-openshift#430)

## RBAC

- igou-io/igou-openshift#429 (merged): build/publish grants, molecule-namespace-scoped + `windows-images` source-clone authorization
- igou-io/igou-openshift#430 (open): `datavolumes patch/update` for re-runnability

## Env to run

```sh
export K8S_AUTH_HOST=https://api.ocp.igou.systems:6443
export K8S_AUTH_API_KEY="`op read op://lab_serviceaccounts/ocp-ansible-molecule/token`"
molecule test -s windows-build-golden-image
```

Relates #343 · RBAC igou-io/igou-openshift#429 #430 · examples source igou-io/igou-openshift#418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HvzcoALBzEpwoBvuqFegi