### PR TITLE
fix(igou-awx-ee): bump centos stream10-minimal digest — old manifest GC'd from quay

### DIFF
--- a/execution-environments/igou-awx-ee/execution-environment.yml
+++ b/execution-environments/igou-awx-ee/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 images:
   base_image:
     # renovate: datasource=docker depName=quay.io/centos/centos
-    name: quay.io/centos/centos:stream10-minimal@sha256:8553fc71b29dfcbba3e82349dfdbff2f57f45c6dbf0cbcb631f662c81e0124d6
+    name: quay.io/centos/centos:stream10-minimal@sha256:975d9a916423ed5c65991c8d248cb63a769d6b0a77f2e95db4c5a3e8f3dcfc64
 options:
   package_manager_path: /usr/bin/microdnf
 dependencies:


### PR DESCRIPTION
The igou-awx-ee build has been failing on main (pre-existing, since at least 03:15 today) with `manifest unknown` on the pinned `quay.io/centos/centos@sha256:8553fc71...` base — upstream rebuilt `stream10-minimal` and the old manifest was GC'd. This also blocked the EE rebuild that ships virtctl/vncdotool from #348.

Repins to the current digest `975d9a91...` (verified via skopeo). Renovate will keep tracking it from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HvzcoALBzEpwoBvuqFegi