### PR TITLE
feat(molecule/grafana-kiosk): kubevirt backend + no-destroy render testing; cog fixes from the live bench

### DIFF
--- a/molecule/grafana-kiosk/inventory/group_vars/grafana_kiosk.yml
+++ b/molecule/grafana-kiosk/inventory/group_vars/grafana_kiosk.yml
@@ -5,6 +5,17 @@
 kiosk_grafana_url: http://127.0.0.1:3000
 kiosk_grafana_token: molecule-dummy-token
 kiosk_dashboard_path: /d/mock/dashboard?orgId=1
-# Molecule guests (containers AND headless qemu VMs) have no DRM/display -
-# leave the browser unit enabled-but-stopped; verify runs headless smokes.
+# Molecule guests default to headless - leave the browser unit
+# enabled-but-stopped; verify runs headless smokes. On the kubevirt backend
+# the VM does have a virtual display: override with
+# `-- -e kiosk_start_browser=true` and watch it over `virtctl vnc` (see
+# playbooks/grafana-kiosk/README.md "Render testing").
 kiosk_start_browser: false
+# The kubevirt backend's virtio-gpu has no working dmabuf path and WebKit's
+# accelerated compositing segfaults on real Grafana there - both renderers
+# must fall back to plain software. Harmless for the container backends
+# (browser never starts); DO NOT set these on real Pi hardware, vc4/v3d
+# wants both.
+kiosk_cog_env:
+  WEBKIT_DISABLE_DMABUF_RENDERER: "1"
+  WEBKIT_DISABLE_COMPOSITING_MODE: "1"

--- a/molecule/grafana-kiosk/inventory/group_vars/molecule.yml
+++ b/molecule/grafana-kiosk/inventory/group_vars/molecule.yml
@@ -12,6 +12,7 @@ mp_backend: "{{ lookup('env', 'PROVISIONER') | default('podman', true) }}"
 # podman there has no cgroup delegation, so it cannot boot systemd containers
 # and silently ignores --memory. Docker runs host-side and enforces both.
 # PROVISIONER=kubevirt works from anywhere with a KUBECONFIG (see below).
+# Containerdisk pull + first boot can exceed the collection's 120s default.
 mp_kubevirt_wait_timeout: 600
 mp_defaults:
   podman:
@@ -41,8 +42,9 @@ mp_defaults:
   # a containerdisk (no CDI/storage needed). Needs a KUBECONFIG with VM +
   # Service CRUD in the `molecule` namespace (the ansible-molecule SA:
   # op://claude/ocp-ansible-molecule/token, host api.ocp.igou.systems:6443).
-  # Unlike containers and headless qemu, the VM gets a virtual display -
-  # `virtctl vnc -n molecule <host>` shows what actually renders.
+  # Unlike containers (and the retired headless-qemu backend), the VM gets
+  # a virtual display - `virtctl vnc -n molecule <host>` shows what
+  # actually renders.
   kubevirt:
     boot_source:
       type: container_disk

--- a/molecule/grafana-kiosk/inventory/group_vars/molecule.yml
+++ b/molecule/grafana-kiosk/inventory/group_vars/molecule.yml
@@ -1,14 +1,18 @@
 ---
 mp_backend: "{{ lookup('env', 'PROVISIONER') | default('podman', true) }}"
 
-# Both backends pin the Pi Zero 2 W memory envelope: 512MB RAM plus a 512MB
-# swap allowance, mirroring the zram swap the play configures on the real
-# board (memory.max stays 512m; dpkg/browsers can spill to swap like they
-# would to zram). Converge and the browser smokes all run inside that cap.
+# Every backend pins the Pi Zero 2 W memory envelope. The container backends
+# cap the cgroup at 512MB RAM plus a 512MB swap allowance, mirroring the zram
+# swap the play configures on the real board (memory.max stays 512m;
+# dpkg/browsers can spill to swap like they would to zram). The kubevirt
+# backend gives the guest 512MiB of real RAM and the play's zram path
+# genuinely runs. Converge and the browser smokes all run inside that cap.
 #
 # NOTE: in the igou devcontainer use PROVISIONER=docker - nested rootless
 # podman there has no cgroup delegation, so it cannot boot systemd containers
 # and silently ignores --memory. Docker runs host-side and enforces both.
+# PROVISIONER=kubevirt works from anywhere with a KUBECONFIG (see below).
+mp_kubevirt_wait_timeout: 600
 mp_defaults:
   podman:
     image: "docker.io/geerlingguy/docker-{{ lookup('env', 'MOLECULE_DISTRO') | default('debian12', true) }}-ansible:latest"
@@ -30,11 +34,20 @@ mp_defaults:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     memory: 512m
     memory_swap: 1g
-  # Real VMs: the closest analog to the Pi - 512MiB of actual RAM, and the
-  # metal-only play paths (zram swap, sysctls) genuinely execute. Browser
-  # smokes then run against real memory pressure with zram active.
-  qemu:
-    image: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
+  # Real VMs on the cluster: the closest analog to the Pi - 512MiB of actual
+  # RAM, and the metal-only play paths (zram swap, sysctls) genuinely execute.
+  # Browser smokes then run against real memory pressure with zram active.
+  # Same Debian genericcloud lineage the old qemu backend booted, packaged as
+  # a containerdisk (no CDI/storage needed). Needs a KUBECONFIG with VM +
+  # Service CRUD in the `molecule` namespace (the ansible-molecule SA:
+  # op://claude/ocp-ansible-molecule/token, host api.ocp.igou.systems:6443).
+  # Unlike containers and headless qemu, the VM gets a virtual display -
+  # `virtctl vnc -n molecule <host>` shows what actually renders.
+  kubevirt:
+    boot_source:
+      type: container_disk
+      image: quay.io/containerdisks/debian:12
     ssh_user: debian
-    cpus: 2
-    memory: 512
+    cpu:
+      cores: 2
+    memory: 512Mi

--- a/molecule/grafana-kiosk/inventory/hosts.yml
+++ b/molecule/grafana-kiosk/inventory/hosts.yml
@@ -10,13 +10,28 @@ all:
           mp:
             podman: {}
             docker: {}
-            qemu: {}
+            # cog live-render testing needs Trixie (cog 0.18/WPE 2.48 - the
+            # 0.16 Bookworm ships segfaults on virtio-gpu) and a virtio
+            # display (Mesa has no driver for the default bochs VGA). Matches
+            # the Pi target too: RPi OS is Trixie-based now.
+            kubevirt:
+              boot_source:
+                type: container_disk
+                image: quay.io/containerdisks/debian:13
+              vm_overrides:
+                spec:
+                  template:
+                    spec:
+                      domain:
+                        devices:
+                          video:
+                            type: virtio
         kiosk-chromium:
           kiosk_stack: chromium
           mp:
             podman: {}
             docker: {}
-            qemu: {}
+            kubevirt: {}
     # The setup play's default hosts pattern; the real igou-inventory adds
     # the same group around kiosk.igou.systems.
     grafana_kiosk:

--- a/molecule/grafana-kiosk/molecule.yml
+++ b/molecule/grafana-kiosk/molecule.yml
@@ -1,11 +1,14 @@
 ---
 # Grafana kiosk scenario: converges BOTH browser stacks (cog + chromium)
-# inside podman containers hard-capped at the Pi Zero 2 W's 512MB, then
-# smoke-tests real browser rendering inside that memory envelope.
+# inside guests capped at the Pi Zero 2 W's 512MB, then smoke-tests real
+# browser rendering inside that memory envelope.
 #
 # Provisioning is delegated to david_igou.molecule_provisioners
 # (inventory-driven; see inventory/hosts.yml for the instances and
-# inventory/group_vars/ for the memory caps and kiosk vars).
+# inventory/group_vars/ for the memory caps and kiosk vars). Backends:
+# podman (default) / docker containers, or PROVISIONER=kubevirt for real
+# 512MiB VMs on the cluster - the kubevirt path also supports no-destroy
+# render inspection (see playbooks/grafana-kiosk/README.md "Render testing").
 prerun: false
 
 ansible:

--- a/molecule/grafana-kiosk/verify.yml
+++ b/molecule/grafana-kiosk/verify.yml
@@ -49,9 +49,13 @@
     # Headless because containers have no DRM/X; the memory ceiling is what
     # is under test (an OOM kill fails the task).
 
-    - name: Chromium render smoke (screenshot fetched to the controller)
+    - name: Chromium render smoke
       when: kiosk_stack == 'chromium'
       vars:
+        # Opt-in render inspection: KIOSK_FETCH_SCREENSHOT=1 pulls the
+        # render back to the controller (see README "Render testing").
+        # The smoke itself always runs - the fetch is human-eyeball only.
+        _verify_fetch_screenshot: "{{ lookup('env', 'KIOSK_FETCH_SCREENSHOT') | bool }}"
         # Falls back to the scenario dir if run outside molecule.
         _verify_shot_dest: >-
           {{ (lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY')
@@ -71,16 +75,17 @@
           register: verify_shot
           failed_when: not verify_shot.stat.exists or verify_shot.stat.size == 0
 
-        # Pull the render back to the controller so a human can eyeball it.
         - name: Fetch the Chromium screenshot to the controller
           ansible.builtin.fetch:
             src: /tmp/kiosk-smoke.png
             dest: "{{ _verify_shot_dest }}"
             flat: true
+          when: _verify_fetch_screenshot
 
         - name: Show where the screenshot landed
           ansible.builtin.debug:
             msg: "Screenshot fetched to {{ _verify_shot_dest }}"
+          when: _verify_fetch_screenshot
 
     - name: Run headless cog against the proxy for 20s
       ansible.builtin.command:

--- a/molecule/grafana-kiosk/verify.yml
+++ b/molecule/grafana-kiosk/verify.yml
@@ -49,36 +49,38 @@
     # Headless because containers have no DRM/X; the memory ceiling is what
     # is under test (an OOM kill fails the task).
 
-    - name: Render a screenshot with headless Chromium through the proxy
-      ansible.builtin.command:
-        cmd: >-
-          timeout 90 chromium --headless --no-sandbox --disable-gpu
-          --disable-dev-shm-usage --screenshot=/tmp/kiosk-smoke.png
-          --window-size=1280,720 {{ _verify_proxy }}/d/mock/dashboard
-      changed_when: false
+    - name: Chromium render smoke (screenshot fetched to the controller)
       when: kiosk_stack == 'chromium'
+      vars:
+        # Falls back to the scenario dir if run outside molecule.
+        _verify_shot_dest: >-
+          {{ (lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY')
+              or playbook_dir) ~ '/screenshots/' ~ inventory_hostname ~ '.png' }}
+      block:
+        - name: Render a screenshot with headless Chromium through the proxy
+          ansible.builtin.command:
+            cmd: >-
+              timeout 90 chromium --headless --no-sandbox --disable-gpu
+              --disable-dev-shm-usage --screenshot=/tmp/kiosk-smoke.png
+              --window-size=1280,720 {{ _verify_proxy }}/d/mock/dashboard
+          changed_when: false
 
-    - name: Assert the Chromium screenshot rendered
-      ansible.builtin.stat:
-        path: /tmp/kiosk-smoke.png
-      register: verify_shot
-      failed_when: not verify_shot.stat.exists or verify_shot.stat.size == 0
-      when: kiosk_stack == 'chromium'
+        - name: Assert the Chromium screenshot rendered
+          ansible.builtin.stat:
+            path: /tmp/kiosk-smoke.png
+          register: verify_shot
+          failed_when: not verify_shot.stat.exists or verify_shot.stat.size == 0
 
-    # Pull the render back to the controller so a human can eyeball it.
-    - name: Fetch the Chromium screenshot to the controller
-      ansible.builtin.fetch:
-        src: /tmp/kiosk-smoke.png
-        dest: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/screenshots/{{ inventory_hostname }}.png"
-        flat: true
-      when: kiosk_stack == 'chromium'
+        # Pull the render back to the controller so a human can eyeball it.
+        - name: Fetch the Chromium screenshot to the controller
+          ansible.builtin.fetch:
+            src: /tmp/kiosk-smoke.png
+            dest: "{{ _verify_shot_dest }}"
+            flat: true
 
-    - name: Show where the screenshot landed
-      ansible.builtin.debug:
-        msg: >-
-          Screenshot fetched to
-          {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/screenshots/{{ inventory_hostname }}.png
-      when: kiosk_stack == 'chromium'
+        - name: Show where the screenshot landed
+          ansible.builtin.debug:
+            msg: "Screenshot fetched to {{ _verify_shot_dest }}"
 
     - name: Run headless cog against the proxy for 20s
       ansible.builtin.command:

--- a/molecule/grafana-kiosk/verify.yml
+++ b/molecule/grafana-kiosk/verify.yml
@@ -65,6 +65,21 @@
       failed_when: not verify_shot.stat.exists or verify_shot.stat.size == 0
       when: kiosk_stack == 'chromium'
 
+    # Pull the render back to the controller so a human can eyeball it.
+    - name: Fetch the Chromium screenshot to the controller
+      ansible.builtin.fetch:
+        src: /tmp/kiosk-smoke.png
+        dest: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/screenshots/{{ inventory_hostname }}.png"
+        flat: true
+      when: kiosk_stack == 'chromium'
+
+    - name: Show where the screenshot landed
+      ansible.builtin.debug:
+        msg: >-
+          Screenshot fetched to
+          {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/screenshots/{{ inventory_hostname }}.png
+      when: kiosk_stack == 'chromium'
+
     - name: Run headless cog against the proxy for 20s
       ansible.builtin.command:
         cmd: timeout 20 cog --platform=headless {{ _verify_proxy }}/d/mock/dashboard

--- a/playbooks/grafana-kiosk/README.md
+++ b/playbooks/grafana-kiosk/README.md
@@ -59,6 +59,7 @@ ansible-playbook playbooks/grafana-kiosk/converge.yaml \
 | `kiosk_zram_size` | `ram / 2` | zram-generator expression |
 | `kiosk_gpu_mem` | `96` | Pi GPU memory split |
 | `kiosk_drm_video_mode` | unset | e.g. `1920x1080` (cog stack) |
+| `kiosk_cog_env` | `{}` | Extra `Environment=` lines for the cog unit (VM render testing; leave empty on real hardware) |
 | `kiosk_chromium_packages` / `kiosk_chromium_bin` | Debian `chromium` | Override if RPi OS ships `chromium-browser` |
 | `kiosk_verify_api` | `true` | End-of-play proxy/token verification |
 
@@ -73,10 +74,85 @@ ansible-playbook playbooks/grafana-kiosk/converge.yaml \
 
 ## Testing
 
-`molecule test -s grafana-kiosk` converges **both stacks** in podman
-containers hard-capped at 512MB (`--memory=512m --memory-swap=512m` — the Pi
-Zero 2 W envelope), against a mock Grafana that echoes the Authorization
-header. Verify proves end-to-end token injection, unit enablement, config
-permissions, and runs real headless browser renders (Chromium screenshot,
-cog 20s survival) inside the memory cap. Provisioning uses
-`david_igou.molecule_provisioners` (see `molecule/grafana-kiosk/inventory/`).
+`molecule test -s grafana-kiosk` converges **both stacks** in guests capped
+at the Pi Zero 2 W's 512MB envelope, against a mock Grafana that echoes the
+Authorization header. Verify proves end-to-end token injection, unit
+enablement, config permissions, and runs real headless browser renders
+(Chromium screenshot — fetched back to the controller — and cog 20s
+survival) inside the memory cap. Provisioning uses
+`david_igou.molecule_provisioners` (see `molecule/grafana-kiosk/inventory/`);
+pick a backend with `PROVISIONER`:
+
+| `PROVISIONER` | Guests | Notes |
+|---|---|---|
+| `podman` (default) | systemd containers, cgroup-capped at 512m | Broken in the igou devcontainer (nested rootless podman has no cgroup delegation) — use `docker` there |
+| `docker` | same containers via host-side docker | Enforces the memory cap everywhere |
+| `kubevirt` | real 512MiB VMs (`quay.io/containerdisks/debian:12`) on the cluster | Needs a `KUBECONFIG` with VM + Service CRUD in the `molecule` namespace (ansible-molecule SA: `op://claude/ocp-ansible-molecule/token`). The zram/sysctl metal paths genuinely run, and the VM has a virtual display |
+
+### Render testing (run without destroy)
+
+Only `molecule test` destroys instances; the step commands leave everything
+up so you can iterate on the play and eyeball what the kiosk actually
+renders:
+
+```bash
+export PROVISIONER=kubevirt   # and a KUBECONFIG for the ansible-molecule SA
+
+molecule converge -s grafana-kiosk   # create + prepare + converge; instances stay up
+molecule verify -s grafana-kiosk     # re-runnable; regenerates the screenshot
+```
+
+Each `verify` renders the dashboard with headless Chromium inside the guest
+and fetches it to
+`$MOLECULE_EPHEMERAL_DIRECTORY/screenshots/kiosk-chromium.png` — verify
+prints the exact path; it lives under
+`~/.ansible/tmp/molecule.*.grafana-kiosk/`. Open it locally, tweak the play
+or dashboard vars, re-run `converge`/`verify`, repeat.
+
+On the kubevirt backend you can also watch the **live** kiosk on the VM's
+virtual display. Molecule defaults to `kiosk_start_browser: false` (units
+enabled but stopped); override it and attach VNC:
+
+```bash
+molecule converge -s grafana-kiosk -- -e kiosk_start_browser=true
+virtctl vnc -n molecule kiosk-cog        # or kiosk-chromium
+```
+
+> **Cloud-kernel caveat:** the containerdisk ships Debian's `cloud` kernel,
+> which has no DRM drivers — `/dev/dri` is missing and the browser units
+> can't render to the display. `apt install linux-image-amd64 && apt purge
+> "linux-image-*cloud*"` + `sudo reboot` in the guest first, or stick to
+> the headless screenshot loop.
+>
+> **cog specifics:** `kiosk-cog` boots `debian:13` with a virtio display
+> (per-host override in `inventory/hosts.yml`): Bookworm's cog 0.16
+> segfaults on virtio-gpu, and Mesa can't drive the default bochs VGA at
+> all. The molecule inventory also presets `kiosk_cog_env` with
+> `WEBKIT_DISABLE_DMABUF_RENDERER=1` + `WEBKIT_DISABLE_COMPOSITING_MODE=1`
+> — WebKit's dmabuf renderer and accelerated compositing both crash on
+> virtual GPUs. Don't set either on real hardware.
+>
+> **cog + real Grafana verdict (2026-07-10 VM bench):** cog renders simple
+> pages (the mock) fine on the virtio display, but crash-loops 10–60s into
+> the real Grafana app in `libcogplatform-drm` buffer handling, under every
+> renderer combination (dmabuf off, compositing off, llvmpipe). Use the
+> **chromium** guest for live-Grafana render testing — playlist rotation
+> verified working there. The cog-on-real-hardware bench gate (Pi vc4)
+> remains open; this VM result raises its risk.
+>
+> **Ephemeral-disk caveat:** containerdisk roots survive a guest-initiated
+> `sudo reboot`, but anything that recreates the virt-launcher pod
+> (`virtctl restart`, node drain) resets the VM to a fresh image — re-run
+> `molecule prepare --force` and `molecule converge` afterwards.
+
+To get a shell, use `virtctl ssh debian@vmi/kiosk-cog -n molecule`, or plain
+`ssh` with the host/NodePort/key the provisioner wrote to
+`$MOLECULE_EPHEMERAL_DIRECTORY/inventory/` + `identity_file`. When you're
+done:
+
+```bash
+molecule destroy -s grafana-kiosk
+```
+
+(`molecule test -s grafana-kiosk --destroy=never` gives the same
+keep-alive behavior for a full one-shot run.)

--- a/playbooks/grafana-kiosk/README.md
+++ b/playbooks/grafana-kiosk/README.md
@@ -87,7 +87,7 @@ pick a backend with `PROVISIONER`:
 |---|---|---|
 | `podman` (default) | systemd containers, cgroup-capped at 512m | Broken in the igou devcontainer (nested rootless podman has no cgroup delegation) — use `docker` there |
 | `docker` | same containers via host-side docker | Enforces the memory cap everywhere |
-| `kubevirt` | real 512MiB VMs (`quay.io/containerdisks/debian:12`) on the cluster | Needs a `KUBECONFIG` with VM + Service CRUD in the `molecule` namespace (ansible-molecule SA: `op://claude/ocp-ansible-molecule/token`). The zram/sysctl metal paths genuinely run, and the VM has a virtual display |
+| `kubevirt` | real 512MiB VMs on the cluster (`containerdisks/debian:12` for chromium, `debian:13` + virtio display for cog) | Needs a `KUBECONFIG` with VM + Service CRUD in the `molecule` namespace (ansible-molecule SA: `op://claude/ocp-ansible-molecule/token`). The zram/sysctl metal paths genuinely run, and the VMs have virtual displays |
 
 ### Render testing (run without destroy)
 

--- a/playbooks/grafana-kiosk/README.md
+++ b/playbooks/grafana-kiosk/README.md
@@ -78,8 +78,7 @@ ansible-playbook playbooks/grafana-kiosk/converge.yaml \
 at the Pi Zero 2 W's 512MB envelope, against a mock Grafana that echoes the
 Authorization header. Verify proves end-to-end token injection, unit
 enablement, config permissions, and runs real headless browser renders
-(Chromium screenshot — fetched back to the controller — and cog 20s
-survival) inside the memory cap. Provisioning uses
+(Chromium screenshot and cog 20s survival) inside the memory cap. Provisioning uses
 `david_igou.molecule_provisioners` (see `molecule/grafana-kiosk/inventory/`);
 pick a backend with `PROVISIONER`:
 
@@ -99,11 +98,11 @@ renders:
 export PROVISIONER=kubevirt   # and a KUBECONFIG for the ansible-molecule SA
 
 molecule converge -s grafana-kiosk   # create + prepare + converge; instances stay up
-molecule verify -s grafana-kiosk     # re-runnable; regenerates the screenshot
+KIOSK_FETCH_SCREENSHOT=1 molecule verify -s grafana-kiosk   # re-runnable
 ```
 
-Each `verify` renders the dashboard with headless Chromium inside the guest
-and fetches it to
+With `KIOSK_FETCH_SCREENSHOT=1` (off by default — plain test runs leave the
+render in the guest), `verify` fetches the headless Chromium render to
 `$MOLECULE_EPHEMERAL_DIRECTORY/screenshots/kiosk-chromium.png` — verify
 prints the exact path; it lives under
 `~/.ansible/tmp/molecule.*.grafana-kiosk/`. Open it locally, tweak the play

--- a/playbooks/grafana-kiosk/setup-kiosk.yaml
+++ b/playbooks/grafana-kiosk/setup-kiosk.yaml
@@ -40,7 +40,8 @@
     _kiosk_dashboard_path: "{{ kiosk_dashboard_path | default('/') }}"
     _kiosk_cog_url: >-
       {{ _kiosk_proxy_base ~ _kiosk_dashboard_path
-         ~ ('&kiosk' if '?' in _kiosk_dashboard_path else '?kiosk') }}
+         ~ ('' if 'kiosk' in (_kiosk_dashboard_path | urlsplit('query'))
+            else ('&kiosk' if '?' in _kiosk_dashboard_path else '?kiosk')) }}
     # Explicit token wins (molecule/CI); otherwise resolve from 1Password on
     # the controller. The inline-if keeps the lookup lazy so container runs
     # never touch 1Password.

--- a/playbooks/grafana-kiosk/setup-kiosk.yaml
+++ b/playbooks/grafana-kiosk/setup-kiosk.yaml
@@ -38,10 +38,14 @@
     # '/d/<uid>/<slug>?orgId=1&refresh=30s'. The cog stack appends Grafana's
     # kiosk URL param itself; grafana-kiosk adds it via kiosk-mode.
     _kiosk_dashboard_path: "{{ kiosk_dashboard_path | default('/') }}"
+    # Append Grafana's kiosk param unless the query already carries a
+    # `kiosk` KEY (a value merely containing "kiosk", e.g. ?var-svc=kiosk,
+    # must not suppress it). Fragments in the path are unsupported.
+    _kiosk_dashboard_query: "{{ _kiosk_dashboard_path | urlsplit('query') }}"
     _kiosk_cog_url: >-
       {{ _kiosk_proxy_base ~ _kiosk_dashboard_path
-         ~ ('' if 'kiosk' in (_kiosk_dashboard_path | urlsplit('query'))
-            else ('&kiosk' if '?' in _kiosk_dashboard_path else '?kiosk')) }}
+         ~ ('' if _kiosk_dashboard_query is search('(^|&)kiosk(=|&|$)')
+            else ('&kiosk' if _kiosk_dashboard_query else '?kiosk')) }}
     # Explicit token wins (molecule/CI); otherwise resolve from 1Password on
     # the controller. The inline-if keeps the lookup lazy so container runs
     # never touch 1Password.
@@ -66,10 +70,13 @@
       {{ ansible_virtualization_type | default('')
          in ['container', 'podman', 'docker', 'lxc', 'containerd'] }}
     # Whether to start (and verify) the browser service. Defaults to "not a
-    # container", but headless guests without DRM/display (molecule qemu VMs,
-    # a Pi staged without a monitor) set kiosk_start_browser: false - the
-    # unit stays enabled and starts on next boot with a display attached.
+    # container", but headless guests without DRM/display (cloud-kernel
+    # molecule VMs, a Pi staged without a monitor) set kiosk_start_browser:
+    # false - the unit stays enabled and starts on next boot with a display.
     _kiosk_start_browser: "{{ kiosk_start_browser | default(not _kiosk_is_container) }}"
+    # Extra Environment= lines for the cog unit (VM render testing; empty on
+    # real hardware - see README).
+    _kiosk_cog_env: "{{ kiosk_cog_env | default({}) }}"
     # grafana-kiosk release pinning (chromium stack). Upstream publishes no
     # checksums file, so sha256s are computed from the release assets and
     # pinned here per version/arch. Extend the map when bumping the version.
@@ -90,9 +97,11 @@
         that:
           - kiosk_grafana_url is defined
           - _kiosk_stack in ['cog', 'chromium']
+          - _kiosk_cog_env is mapping
         fail_msg: >-
           Set kiosk_grafana_url (e.g. https://grafana.example.com) in
-          host_vars, and kiosk_stack to 'cog' or 'chromium'.
+          host_vars, kiosk_stack to 'cog' or 'chromium', and kiosk_cog_env
+          (if set) to a dict of VAR: value pairs.
 
     # video/input are static base groups and render normally comes from
     # udev, but molecule's slim containers lack it - ensure all three.

--- a/playbooks/grafana-kiosk/stack_tasks/_stack_cog.yml
+++ b/playbooks/grafana-kiosk/stack_tasks/_stack_cog.yml
@@ -10,6 +10,9 @@
     name:
       - cog
       - seatd
+      # WPE's WebProcess dlopens libGLESv2 at runtime (no hard package
+      # dependency) - without it every page render crashes the renderer.
+      - libgles2
     state: present
     install_recommends: false
 

--- a/playbooks/grafana-kiosk/templates/cog-kiosk.service.j2
+++ b/playbooks/grafana-kiosk/templates/cog-kiosk.service.j2
@@ -19,10 +19,22 @@ StandardOutput=journal
 StandardError=journal
 Environment=XDG_SEAT=seat0
 Environment=LIBSEAT_BACKEND=seatd
+# The PAM login session hands the unit capabilities; WPE's bwrap sandbox
+# refuses to start a capable-but-not-setuid process ("Unexpected
+# capabilities but not setuid"). The browser needs no caps - drop them all.
+CapabilityBoundingSet=
+{% for k, v in (kiosk_cog_env | default({})) | dictsort %}
+# Extra env from kiosk_cog_env (e.g. WEBKIT_DISABLE_* on virtual GPUs).
+Environment={{ k }}={{ v }}
+{% endfor %}
 {% if kiosk_drm_video_mode | default('') %}
 Environment=COG_PLATFORM_DRM_VIDEO_MODE={{ kiosk_drm_video_mode }}
 {% endif %}
-ExecStart=/usr/bin/cog --platform=drm --webprocess-failure=restart-exit "{{ _kiosk_cog_url }}"
+# --webprocess-failure=restart: 'restart-exit' is not a valid action on the
+# cog 0.16 that Bookworm/RPi OS ship (valid: error-page, exit, exit-ok,
+# restart) - the unit crash-loops with "Invalid action name". WebProcess
+# crashes restart in-place; full cog exits come back via Restart=always.
+ExecStart=/usr/bin/cog --platform=drm --webprocess-failure=restart "{{ _kiosk_cog_url }}"
 Restart=always
 RestartSec=5
 # Daily recycle: browsers leak on live dashboards; Restart=always brings the

--- a/playbooks/grafana-kiosk/templates/cog-kiosk.service.j2
+++ b/playbooks/grafana-kiosk/templates/cog-kiosk.service.j2
@@ -23,9 +23,9 @@ Environment=LIBSEAT_BACKEND=seatd
 # refuses to start a capable-but-not-setuid process ("Unexpected
 # capabilities but not setuid"). The browser needs no caps - drop them all.
 CapabilityBoundingSet=
-{% for k, v in (kiosk_cog_env | default({})) | dictsort %}
-# Extra env from kiosk_cog_env (e.g. WEBKIT_DISABLE_* on virtual GPUs).
-Environment={{ k }}={{ v }}
+{# Extra env from kiosk_cog_env (e.g. WEBKIT_DISABLE_* on virtual GPUs). #}
+{% for k, v in _kiosk_cog_env | dictsort %}
+Environment="{{ k }}={{ v }}"
 {% endfor %}
 {% if kiosk_drm_video_mode | default('') %}
 Environment=COG_PLATFORM_DRM_VIDEO_MODE={{ kiosk_drm_video_mode }}


### PR DESCRIPTION
## What

Swaps the grafana-kiosk molecule scenario's **qemu backend for the kubevirt backend** (`david_igou.molecule_provisioners`), documents a **no-destroy render-testing loop**, and fixes **three real cog-stack bugs** the live bench surfaced.

### Molecule backend (commit 1)
- Backends are now podman (default) / docker / **kubevirt**: real 512MiB VMs on the cluster, so the zram/sysctl metal-only paths genuinely execute.
- `kiosk-chromium` boots `containerdisks/debian:12`; `kiosk-cog` boots `debian:13` with a **virtio display** via per-host overrides (Bookworm's cog 0.16 segfaults in the virtio Mesa driver; Mesa can't drive the default bochs VGA at all; Trixie also matches current RPi OS).
- `verify` now **fetches the headless Chromium render back to the controller** (`$MOLECULE_EPHEMERAL_DIRECTORY/screenshots/`) and prints the path.
- README: new backend table + **"Render testing (run without destroy)"** — `converge`/`verify` iteration, `virtctl vnc` live display with `-e kiosk_start_browser=true`, cloud-kernel `/dev/dri` caveat, ephemeral-containerdisk caveat (`sudo reboot` keeps state; `virtctl restart` wipes it), and the live-Grafana verdict below.

### cog fixes from the live bench (commit 2) — all unreachable in container CI (browsers never start there)
- `--webprocess-failure=restart-exit` is **not a valid cog action** (0.16 or 0.18) → instant crash-loop on any real host. Now `restart`.
- **`libgles2` missing** from the cog package set — WPE dlopens `libGLESv2.so.2` with no hard dep; every render crashed the WebProcess.
- The PAM login session hands the unit capabilities → WPE's bwrap sandbox aborts ("Unexpected capabilities but not setuid"). **`CapabilityBoundingSet=`** drops them.
- New **`kiosk_cog_env`** dict (molecule presets `WEBKIT_DISABLE_{DMABUF_RENDERER,COMPOSITING_MODE}` — required on virtual GPUs, must stay unset on Pi vc4) and a `?kiosk&kiosk` URL-dedup fix.

### Review feedback (commit 3)
Three Opus subagent reviewers (Zen of Ansible / CoP practices / PR checklist) ran over the diff; applied everything: kiosk-param dedup now matches the query **key** (not substring — `?var-svc=kiosk` no longer suppresses kiosk mode; verified against 6 edge cases), `kiosk_cog_env` funneled through `_kiosk_cog_env` + mapping validation + quoted `Environment=` lines, verify chromium smoke collapsed into one `block`, doc/comment polish.

## Testing

- `molecule test` sequence run live on ocp (`PROVISIONER=kubevirt`): create → prepare → converge → **idempotent re-converge (changed=0)** → verify → destroy, all green; both browser smokes pass inside the 512MiB cap and the zram handler fired (metal path real).
- Live bench beyond CI: both VMs pointed at the **real lab Grafana** via a playlist — **chromium auto-flips real dashboards flawlessly** (VNC-verified); **cog crash-loops in `libcogplatform-drm`** on the real Grafana app under every renderer fallback → README records the verdict: chromium is the live-render stack, and the cog-on-Pi bench gate's risk is raised.
- `yamllint`, `ansible-lint --profile=production`, `molecule syntax` all green.

Related: grafana runtime-state persistence bug found during the live bench → igou-io/igou-openshift#431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFcBx1EitVQkRAewjSgi8H
