### PR TITLE
fix(igou-awx-ee): vncdotool needs service-identity; preflight imports vncdotool.api

### DIFF
--- a/execution-environments/igou-awx-ee/requirements.txt
+++ b/execution-environments/igou-awx-ee/requirements.txt
@@ -15,5 +15,10 @@ six==1.17.0
 receptorctl==1.6.5
 boto3>=1.35.0,<2.0
 # VNC keypress helper for the Windows golden-image CD-boot atom
-# (playbooks/openshift_virtualization/files/autoboot.py)
+# (playbooks/openshift_virtualization/files/autoboot.py).
+# service-identity is twisted's TLS-verification dep — NOT a hard dependency
+# of vncdotool, but `from vncdotool import api` imports twisted.internet.ssl
+# which hard-fails without it (ModuleNotFoundError at runtime, hit live in
+# AAP job 278 while `import vncdotool` alone passed preflight).
 vncdotool==1.3.0
+service-identity==26.1.0

--- a/playbooks/openshift_virtualization/build_windows_golden.yml
+++ b/playbooks/openshift_virtualization/build_windows_golden.yml
@@ -137,7 +137,10 @@
           kubevirt release) and re-run.
 
     - name: Check python3 vncdotool module is importable
-      ansible.builtin.command: python3 -c "import vncdotool"
+      # vncdotool.api, not bare vncdotool: the api module pulls twisted's TLS
+      # stack (service_identity et al), which is exactly what autoboot.py needs
+      # and exactly what a bare `import vncdotool` fails to prove.
+      ansible.builtin.command: python3 -c "import vncdotool.api"
       changed_when: false
       failed_when: false
       register: golden_vncdotool_check


### PR DESCRIPTION
Production AAP run (job 278) failed every CD-boot attempt: `autoboot.py` does `from vncdotool import api`, which imports `twisted.internet.ssl` → `ModuleNotFoundError: service_identity`. `service-identity` is a soft dep vncdotool never declares (it was present in the devcontainer only incidentally, which is why the molecule e2e passed).

Two fixes:
- EE `requirements.txt`: pin `service-identity==26.1.0` next to `vncdotool` with a comment recording the trap
- playbook preflight now imports `vncdotool.api` (exercises the twisted TLS import chain) instead of bare `vncdotool`, so this class of gap fails in preflight, not 5 minutes into boot attempts

Cluster state from job 278 is reusable (root disk still blank, ISO clone Succeeded) — relaunching the JT after the EE rebuild resumes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HvzcoALBzEpwoBvuqFegi