### PR TITLE
fix(truenas): extract Windows ISO tree with 7zip (UDF), not xorriso osirrox

### DIFF
--- a/playbooks/truenas/publish_windows_isos.yml
+++ b/playbooks/truenas/publish_windows_isos.yml
@@ -196,16 +196,17 @@
     #      install.wim; do NOT add -udf)
     _remaster_script: |
       set -eu
-      apk add --no-cache xorriso >/dev/null
+      # 7zip reads the UDF tree (where Windows media stores everything but a
+      # stub README in ISO9660 — xorriso -osirrox extracts only that ISO9660
+      # view and misses efi/, sources/install.wim, boot/); xorriso does the
+      # bootable repack. Both are unprivileged, no loop mount, no KVM.
+      apk add --no-cache 7zip xorriso >/dev/null
       base="$1"
       src="/isos/${base}"
       tree="/work/${base%.iso}"
       rm -rf "$tree"
       mkdir -p "$tree"
-      # osirrox extracts the ISO filesystem to disk without a loop mount.
-      xorriso -osirrox on -indev "$src" -extract / "$tree"
-      # Extracted ISO dirs are read-only; make them writable so we can swap files.
-      chmod -R u+w "$tree"
+      7z x -bd -bso0 -bsp0 -o"$tree" "$src"
       bootdir="$tree/efi/microsoft/boot"
       # Per-ISO preflight: some media lack the shipped-but-undocumented noprompt
       # boot files. Refuse to produce a silently-still-prompting ISO.


### PR DESCRIPTION
Second live-run defect: the remaster produced an almost-empty tree because Windows install media stores only a stub `README.TXT` in ISO9660 and keeps everything real (`efi/`, `sources/install.wim`, `boot/`) in **UDF**, which `xorriso -osirrox` doesn't extract. Swap to `7z x` for extraction (reads UDF), keep xorriso for the bootable repack — both unprivileged, no loop mount, no KVM.

Validated end-to-end on Server 2025 before this PR: 8.15 GB `-noprompt.iso`, El Torito record = UEFI/bootable with boot image `efi/microsoft/boot/efisys.bin` now 1474560 B (the former `efisys_noprompt.bin`), 7.25 GB `install.wim` intact through `-iso-level 4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HvzcoALBzEpwoBvuqFegi