### PR TITLE
fix(truenas): drop async from remaster task — it swallowed output, rc=38

### DIFF
--- a/playbooks/truenas/publish_windows_isos.yml
+++ b/playbooks/truenas/publish_windows_isos.yml
@@ -314,8 +314,9 @@
           - "{{ item }}"
       register: _remaster_run
       changed_when: "'REMASTERED' in _remaster_run.stdout"
-      async: 3600
-      poll: 20
+      # No async: `command` has no default timeout, so it waits out the
+      # multi-minute IO on its own. The async wrapper was swallowing the
+      # container's stdout/stderr and failing the task with an opaque rc=38.
       loop: "{{ _to_remaster | default([]) }}"
       loop_control:
         label: "{{ item }}"


### PR DESCRIPTION
Third live-run defect. The remaster `docker run` command runs clean as root, but ansible's `async` wrapper failed it with an opaque `rc=38` and empty stdout/stderr. `command` tasks have no default timeout, so async was unnecessary; synchronous execution also restores real error visibility. **Validated live before this PR**: `PLAY RECAP failed=0`, both `-noprompt.iso` files + `.src.sha256` markers + SHA256SUMS lines produced (Server 2025 8.15 GB, Win11 25H2 7.09 GB). Lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HvzcoALBzEpwoBvuqFegi