### PR TITLE
fix(openshift_virtualization): detect golden build completion via VM Stopped

### DIFF
--- a/playbooks/openshift_virtualization/build_windows_golden.yml
+++ b/playbooks/openshift_virtualization/build_windows_golden.yml
@@ -549,16 +549,24 @@
         # loop tolerates that because `resources | length == 1` simply stays
         # false for those polls and it keeps retrying until Succeeded (or the
         # timeout), never erroring on the empty window.
-        - name: Wait for the build VM to finish and power off (VMI Succeeded)
+        # Completion signal under runStrategy RerunOnFailure: the answer file
+        # ends with sysprep /generalize /shutdown, a CLEAN guest poweroff.
+        # RerunOnFailure treats a clean exit as success and STOPS the VM,
+        # DELETING the VMI (unlike Manual, which parked it in phase Succeeded).
+        # So we watch the VirtualMachine's printableStatus reach "Stopped",
+        # not the VMI phase. A genuine install failure keeps RerunOnFailure
+        # restarting the VMI (Starting/Running/CrashLoopBackOff), so it never
+        # reaches Stopped and this times out — which is the behavior we want.
+        - name: Wait for the build VM to finish and power off (VM Stopped)
           kubernetes.core.k8s_info:
             api_version: kubevirt.io/v1
-            kind: VirtualMachineInstance
+            kind: VirtualMachine
             name: "{{ windows_golden_vm_name }}"
             namespace: "{{ windows_golden_namespace }}"
-          register: golden_vmi_status
+          register: golden_vm_status
           until:
-            - golden_vmi_status.resources | length == 1
-            - golden_vmi_status.resources[0].status.phase == "Succeeded"
+            - golden_vm_status.resources | length == 1
+            - golden_vm_status.resources[0].status.printableStatus == "Stopped"
           retries: "{{ windows_golden_install_timeout_minutes | int }}"
           delay: 60
 


### PR DESCRIPTION
Live-run defect from the no-prompt cutover (#353): `runStrategy: RerunOnFailure` deletes the VMI on clean guest poweroff (sysprep `/shutdown`) and parks the VM in `printableStatus: Stopped`, whereas the old `Manual` left the VMI in phase `Succeeded`. The wait loop polled VMI phase → spun to timeout despite a successful install+capture. Now watches the VM reach `Stopped`; a genuine failure keeps RerunOnFailure restarting the VMI, so it never reaches Stopped and correctly times out.

**Live-verified end to end on the declarative no-prompt path**: build VM auto-booted the remastered ISO headless → unattended install + sysprep → published a `Ready` DataSource → `golden-verify` cloned it and reached `AgentConnected=True` ("Windows Server 2025 Standard Evaluation"). No VNC, no keypress, no wrapper scripts. Lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HvzcoALBzEpwoBvuqFegi
EOF
)