### PR TITLE
fix(hermes): set VM evictionStrategy None (no live migration)

### DIFF
--- a/playbooks/hermes/provision-vm.yml
+++ b/playbooks/hermes/provision-vm.yml
@@ -8,6 +8,11 @@
     vm_name: hermes
     vm_namespace: hermes
     vm_run_strategy: Always
+    # This cluster has no live migration (RWO-only storage), and hermes-root is
+    # RWO, so the VM is not migratable. Without this, the VMI inherits the HCO
+    # default and a node drain blocks on it (raising VMCannotBeEvicted). None =>
+    # a drain shuts the VM down and vm_run_strategy: Always restarts it after.
+    vm_eviction_strategy: None
     # image clone (match golden size — NO resize)
     vm_os_datasource: centos-stream10
     vm_storage_class: freenas-nvmeof-ssd-csi

--- a/roles/kubevirt_vm_provision/README.md
+++ b/roles/kubevirt_vm_provision/README.md
@@ -46,6 +46,7 @@ module reads `K8S_AUTH_*` (AAP/EE) or your kubeconfig.
 | `vm_architecture` | `""` | `spec.template.spec.architecture` (e.g. `amd64`); omitted when empty |
 | `vm_node_selector` | `{}` | `spec.template.spec.nodeSelector`; omitted when empty. Caller supplies the labels (e.g. burst: `{node-role.kubernetes.io/burst: ""}`) |
 | `vm_tolerations` | `[]` | `spec.template.spec.tolerations`; omitted when empty (e.g. burst: `[{key: workload, operator: Equal, value: burst, effect: NoSchedule}]`) |
+| `vm_eviction_strategy` | `""` | `spec.template.spec.evictionStrategy`; omitted when empty (inherits the HyperConverged cluster default). `None` \| `LiveMigrate` \| `LiveMigrateIfPossible` \| `External`. Use `None` on RWO-only clusters so node drains shut the VM down instead of blocking |
 | `vm_log_serial_console` | `true` | Enable serial-console logging (a virtio-rng device is always attached) |
 | `vm_extra_pvcs` | `[]` | Existing PVCs to attach as data disks: `[{name, claim}]` |
 | `vm_cloud_init` | `""` | cloud-init NoCloud userData string (empty → no cloud-init disk) |

--- a/roles/kubevirt_vm_provision/defaults/main.yml
+++ b/roles/kubevirt_vm_provision/defaults/main.yml
@@ -38,6 +38,13 @@ vm_architecture: ""          # spec.template.spec.architecture (e.g. amd64); omi
 vm_node_selector: {}         # spec.template.spec.nodeSelector; omitted when empty
 vm_tolerations: []           # spec.template.spec.tolerations; omitted when empty
 
+# Node-drain eviction behaviour (spec.template.spec.evictionStrategy). Empty ->
+# omitted, so the VM inherits the HyperConverged cluster default. Set to None on
+# clusters with RWO-only storage (no live migration possible) so a node drain
+# cleanly shuts the VM down instead of blocking the drain and raising the
+# VMCannotBeEvicted alert. Values: None | LiveMigrate | LiveMigrateIfPossible | External.
+vm_eviction_strategy: ""     # spec.template.spec.evictionStrategy; omitted when empty
+
 # Devices (a virtio-rng device is always attached)
 vm_log_serial_console: true
 

--- a/roles/kubevirt_vm_provision/tasks/main.yml
+++ b/roles/kubevirt_vm_provision/tasks/main.yml
@@ -70,6 +70,7 @@
                     storage: "{{ vm_root_size }}"
         spec:
           architecture: "{{ vm_architecture if (vm_architecture | length > 0) else omit }}"
+          evictionStrategy: "{{ vm_eviction_strategy if (vm_eviction_strategy | length > 0) else omit }}"
           nodeSelector: "{{ vm_node_selector if (vm_node_selector | length > 0) else omit }}"
           tolerations: "{{ vm_tolerations if (vm_tolerations | length > 0) else omit }}"
           domain:


### PR DESCRIPTION
## What

- Add a `vm_eviction_strategy` passthrough to the `kubevirt_vm_provision` role (`spec.template.spec.evictionStrategy`), emitted only when set — same optional-field pattern as `vm_architecture` / `vm_node_selector` / `vm_tolerations`.
- Set `vm_eviction_strategy: None` on the hermes VM (`playbooks/hermes/provision-vm.yml`).
- Document the new var in the role README.

## Why

Alert `VMCannotBeEvicted` fires for VM `hermes` in namespace `hermes`. Its root PVC `hermes-root` is RWO and this cluster (ocp.igou.systems) runs RWO block storage only — no live migration is possible. The running VMI's effective `evictionStrategy` is `LiveMigrate` (verified live: `oc get vmi hermes -n hermes` shows `LiveMigrate`), so a node drain blocks indefinitely on a migration that can never succeed.

The hermes VM spec did not set `evictionStrategy` at all (verified live: `.spec.template.spec.evictionStrategy` empty), so the VMI inherited the value in effect at creation time. The HyperConverged cluster default was already flipped to `None` in igou-openshift#410 (live-verified `.spec.evictionStrategy: None`), but the long-running hermes VMI predates that change and still carries `LiveMigrate`. Setting it explicitly on the VM spec makes the desired state declarative and independent of the HCO default; the VMI picks it up on the next VM restart/reprovision.

The hermes VM is `app.kubernetes.io/managed-by: ansible` (not in the `hermes-agent` ArgoCD kustomization — that only owns the state DataVolume), so this is the repo/manifest that actually owns the VM spec.

## Operational tradeoff

With `evictionStrategy: None`, a node drain (e.g. node maintenance/upgrade) **shuts the VM down** rather than blocking the drain. The VM then restarts on a schedulable node per its `runStrategy: Always` — i.e. a brief outage instead of a stuck drain. This is the intended behaviour on this cluster, which has no RWX/live-migration path.

## Note

The cluster-wide default (`HyperConverged .spec.evictionStrategy: None`) requested alongside this is **already present and live** via igou-openshift#410 — no igou-openshift change is needed. This PR only covers the explicit hermes VM setting, which lives in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbJatM2nf9eZU7Zs54HkLV