### PR TITLE
feat(devenv): VLAN9 KubeVirt VM variant + pin devenv release v2026.07.12

### DIFF
--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -33,8 +33,11 @@
 
     # devenv extras
     devenv_repo: https://github.com/igou-io/igou-devenv.git
-    devenv_repo_version: main
-    devenv_image: ghcr.io/igou-io/igou-devenv:latest
+    # Pinned to the igou-devenv release cut for this rebuild (git tag +
+    # container image promoted by digest from the tested :latest). Bump both
+    # together when adopting a newer release.
+    devenv_repo_version: v2026.07.12
+    devenv_image: ghcr.io/igou-io/igou-devenv:2026.07.12
     devenv_launch_devcontainer: true
 
     # GitHub App runtime tokens (ghapp, local-mint mode). Gated OFF so this is

--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -69,6 +69,45 @@
     - name: Gather facts (after the connection is proven)
       ansible.builtin.setup:
 
+    # The CentOS Stream 10 golden cloud image ships kernel-modules /
+    # kernel-modules-core but NOT the legacy netfilter compat modules
+    # (xt_addrtype, iptable_nat, br_netfilter) that live in
+    # kernel-modules-extra. docker-ce 29's daemon startup programs iptables NAT
+    # rules (`-m addrtype --dst-type LOCAL`) and fails to start without them
+    # ("Extension addrtype revision 0 not supported, missing kernel module?").
+    # Install the extra modules pinned to the running kernel and load them
+    # (persisted via modules-load.d) BEFORE the docker role starts the daemon.
+    - name: Ensure Docker's netfilter kernel modules are available
+      become: true
+      block:
+        - name: Install kernel-modules-extra matching the running kernel
+          ansible.builtin.dnf:
+            name: "kernel-modules-extra-{{ ansible_kernel }}"
+            state: present
+
+        - name: Persist the netfilter modules for load at boot
+          ansible.builtin.copy:
+            dest: /etc/modules-load.d/docker-netfilter.conf
+            owner: root
+            group: root
+            mode: "0644"
+            content: |
+              # Loaded for docker-ce's iptables/NAT bridge networking (see
+              # playbooks/devenv/bootstrap.yml). These live in
+              # kernel-modules-extra, absent from the CentOS Stream 10 golden image.
+              xt_addrtype
+              iptable_nat
+              br_netfilter
+
+        - name: Load the netfilter modules now
+          community.general.modprobe:
+            name: "{{ item }}"
+            state: present
+          loop:
+            - xt_addrtype
+            - iptable_nat
+            - br_netfilter
+
   roles:
     - role: david_igou.devhost.docker
     - role: david_igou.devhost.packages

--- a/playbooks/devenv/provision-vm-vlan9.yml
+++ b/playbooks/devenv/provision-vm-vlan9.yml
@@ -1,0 +1,232 @@
+---
+# Provision / reprovision the CentOS "devenv" VM tagged directly onto VLAN 9.
+#
+# VLAN 9 variant of playbooks/devenv/provision-vm.yml. Same lifecycle and
+# cloud-init, but the VM sits on the lab LAN (VLAN 9, 10.10.9.0/24) via the
+# vlan9-no-ipam ClusterUserDefinedNetwork instead of the pod network — so it
+# gets a real DHCP address reachable from the lab, and there are NO NodePort
+# services (SSH and code-server are reached directly on the VM's VLAN 9 IP).
+#
+# Why this drives kubevirt.core.kubevirt_vm directly instead of the generic
+# roles/kubevirt_vm_provision role: that role is deliberately masquerade /
+# pod-network-only (its README says to drive the module directly for
+# secondary/Multus networks). This VM has a single bridged Multus interface and
+# autoattachPodInterface:false, so it needs the direct path.
+#
+# The VLAN 9 attachment only materializes in a namespace labelled
+# network.igou.systems/vlan9="true" (the CUDN's namespaceSelector) — this play
+# creates/labels the namespace when create_namespace is true. IPAM is Disabled
+# on the CUDN, so the guest DHCPs on VLAN 9 (CentOS Stream 10 cloud-init DHCPs
+# the single NIC by default); the qemu-guest-agent reports the lease back so the
+# address is visible via `oc get vmi -o yaml`.
+#
+# Cluster API auth is ambient (kubevirt.core / kubernetes.core read K8S_AUTH_*
+# from the credential, or your kubeconfig for local runs).
+#
+# The host is configured afterwards over SSH by playbooks/devenv/bootstrap.yml,
+# but reached by its VLAN 9 IP (there is no virt-launcher pod IP to resolve, so
+# target it with a static inventory, e.g. `-i '<vlan9-ip>,'`), NOT via the AAP
+# kubevirt inventory.
+#
+# Lifecycle knobs (pass as extra_vars at launch):
+#   rebuild=true       -> destructive reprovision (fresh VM, namespace kept)
+#   vm_state=absent    -> tear down the VM (lets the autoscaler scale casval to 0)
+- name: Provision the devenv KubeVirt VM on VLAN 9
+  hosts: "{{ host | default('localhost') }}"
+  # Talks to the cluster API via env-injected K8S_AUTH_* vars; no SSH. Force
+  # local so the inventory's localhost entry doesn't default to ssh.
+  connection: local
+  gather_facts: false
+  vars:
+    vm_name: devenv-vlan9
+    vm_namespace: devenv-vlan9
+    vm_state: present
+    vm_rebuild: "{{ rebuild | default(false) | bool }}"
+    vm_run_strategy: Always
+    # Locally you have cluster-admin, so create the namespace here (with the
+    # CUDN selector label). Under a scoped ServiceAccount that can only
+    # get/list/watch namespaces, pre-create it out of band and pass
+    # create_namespace=false.
+    create_namespace: true
+
+    # Root disk: clone the centos-stream10 golden image on the DEFAULT
+    # StorageClass. Keep the size at the golden 30Gi — the default
+    # democratic-csi class deadlocks on resize-during-clone.
+    vm_os_datasource: centos-stream10
+    vm_os_datasource_namespace: openshift-virtualization-os-images
+    vm_storage_class: ""              # empty -> cluster default StorageClass
+    vm_root_size: 30Gi
+
+    # Compute (overridable at launch). No resources block -> Burstable QoS.
+    vm_cpu_cores: 8
+    vm_memory: 16Gi
+
+    # Pin the versioned machine type so the burst autoscaler's synthetic
+    # template node (built from the casval MachineSet capacity-labels
+    # annotation) matches; otherwise the VM stays Pending and never triggers
+    # scale-from-zero. Never use a kubernetes.io/hostname selector for casval.
+    vm_machine_type: pc-q35-rhel9.6.0
+    vm_architecture: amd64
+
+    # Burst placement (casval).
+    vm_node_selector:
+      node-role.kubernetes.io/burst: ""
+    vm_tolerations:
+      - key: workload
+        operator: Equal
+        value: burst
+        effect: NoSchedule
+
+    # VLAN 9 secondary network (localnet, IPAM disabled -> guest DHCP). The
+    # network name is the CUDN name, which is also the NAD name materialized
+    # into the labelled namespace.
+    vlan9_network_name: vlan9-no-ipam
+
+    # Labels on the VM metadata.
+    vm_labels:
+      app: devenv-vlan9
+      app.kubernetes.io/managed-by: ansible
+
+    # cloud-init login user + authorized keys. The igou public half of the AAP
+    # machine credential is baked in so Ansible can converge the guest
+    # unattended in Phase 2. Append a personal key for direct SSH via
+    # -e devenv_ssh_authorized_key='ssh-ed25519 ...'.
+    vm_admin_user: igou
+    devenv_ansible_pubkey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHO7UsiIgAepf5+s2z+1CbPQf2eqJo8aNK/vT9Oaf4B"
+    devenv_ssh_authorized_key: ""
+    devenv_authorized_keys: "{{ [devenv_ansible_pubkey, devenv_ssh_authorized_key] | reject('equalto', '') | list }}"
+
+    # Wait for the VM to be Ready on converge (casval scale-from-zero is slow —
+    # allow generous headroom).
+    vm_wait: true
+    vm_wait_timeout: 1200
+
+  pre_tasks:
+    - name: Render the devenv cloud-init
+      ansible.builtin.set_fact:
+        vm_cloud_init: "{{ lookup('template', 'templates/devenv-cloudinit.yaml.j2') }}"
+      when: vm_state == "present"
+
+  tasks:
+    - name: Ensure the devenv-vlan9 namespace exists with the CUDN selector label
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "{{ vm_namespace }}"
+            labels:
+              # Selected by the vlan9-no-ipam ClusterUserDefinedNetwork, which
+              # auto-materializes the NetworkAttachmentDefinition into this
+              # namespace. Without this label the VM's interface never attaches.
+              network.igou.systems/vlan9: "true"
+      when:
+        - vm_state == "present"
+        - create_namespace | bool
+
+    - name: Deprovision the devenv-vlan9 VM
+      kubevirt.core.kubevirt_vm:
+        state: absent
+        name: "{{ vm_name }}"
+        namespace: "{{ vm_namespace }}"
+        wait: true
+      when: vm_state == "absent"
+
+    - name: Provision / converge the devenv-vlan9 VM
+      when: vm_state == "present"
+      block:
+        - name: "Reprovision: delete the existing VM first"
+          kubevirt.core.kubevirt_vm:
+            state: absent
+            name: "{{ vm_name }}"
+            namespace: "{{ vm_namespace }}"
+            wait: true
+          when: vm_rebuild | bool
+
+        - name: Assemble the cloud-init volume (multi-line userData)
+          ansible.builtin.set_fact:
+            _devenv_volumes:
+              - name: rootdisk
+                dataVolume:
+                  name: "{{ vm_name }}-root"
+              - name: cloudinitdisk
+                cloudInitNoCloud:
+                  userData: "{{ vm_cloud_init }}"
+
+        - name: Converge the devenv-vlan9 VM (idempotent)
+          kubevirt.core.kubevirt_vm:
+            state: present
+            name: "{{ vm_name }}"
+            namespace: "{{ vm_namespace }}"
+            labels: "{{ vm_labels }}"
+            run_strategy: "{{ vm_run_strategy }}"
+            data_volume_templates:
+              - metadata:
+                  name: "{{ vm_name }}-root"
+                spec:
+                  sourceRef:
+                    kind: DataSource
+                    name: "{{ vm_os_datasource }}"
+                    namespace: "{{ vm_os_datasource_namespace }}"
+                  storage:
+                    storageClassName: "{{ vm_storage_class if (vm_storage_class | length > 0) else omit }}"
+                    resources:
+                      requests:
+                        storage: "{{ vm_root_size }}"
+            spec:
+              architecture: "{{ vm_architecture }}"
+              nodeSelector: "{{ vm_node_selector }}"
+              tolerations: "{{ vm_tolerations }}"
+              domain:
+                cpu:
+                  cores: "{{ vm_cpu_cores | int }}"
+                  sockets: 1
+                  threads: 1
+                memory:
+                  guest: "{{ vm_memory }}"
+                firmware:
+                  bootloader:
+                    bios: {}
+                machine:
+                  type: "{{ vm_machine_type }}"
+                devices:
+                  # No pod interface — the VM lives solely on VLAN 9.
+                  autoattachPodInterface: false
+                  disks:
+                    - name: rootdisk
+                      disk:
+                        bus: virtio
+                      bootOrder: 1
+                    - name: cloudinitdisk
+                      disk:
+                        bus: virtio
+                  interfaces:
+                    - name: vlan9
+                      bridge: {}
+                      model: virtio
+                      state: up
+                  rng: {}
+                  logSerialConsole: true
+              networks:
+                - name: vlan9
+                  multus:
+                    networkName: "{{ vlan9_network_name }}"
+              volumes: "{{ _devenv_volumes }}"
+            wait: "{{ vm_wait | bool }}"
+            wait_timeout: "{{ vm_wait_timeout | int }}"
+
+        - name: Register VM identity for downstream workflow nodes
+          ansible.builtin.set_stats:
+            data:
+              provisioned_vm: "{{ vm_namespace }}/{{ vm_name }}"
+
+    - name: Summarize next steps
+      ansible.builtin.debug:
+        msg:
+          - "devenv-vlan9 VM converged in namespace {{ vm_namespace }}."
+          - "Get its VLAN 9 DHCP address:"
+          - "  oc -n {{ vm_namespace }} get vmi {{ vm_name }} -o jsonpath='{.status.interfaces[0].ipAddress}'"
+          - "Then bootstrap over that IP:"
+          - "  ansible-playbook playbooks/devenv/bootstrap.yml -i '<vlan9-ip>,' -e ansible_limit=<vlan9-ip>"
+      when: vm_state == "present"

--- a/playbooks/devenv/provision-vm-vlan9.yml
+++ b/playbooks/devenv/provision-vm-vlan9.yml
@@ -96,10 +96,12 @@
     devenv_ssh_authorized_key: ""
     devenv_authorized_keys: "{{ [devenv_ansible_pubkey, devenv_ssh_authorized_key] | reject('equalto', '') | list }}"
 
-    # Wait for the VM to be Ready on converge (casval scale-from-zero is slow —
-    # allow generous headroom).
+    # Wait for the VM to be Ready on converge. casval scale-from-zero (BMC
+    # power-on -> RHCOS deploy -> node join) can take ~20-25 min from cold, so
+    # allow generous headroom to avoid a false-negative wait timeout while the
+    # VM is still legitimately converging.
     vm_wait: true
-    vm_wait_timeout: 1200
+    vm_wait_timeout: 1800
 
   pre_tasks:
     - name: Render the devenv cloud-init


### PR DESCRIPTION
## What

Interim working environment for the operator while the physical devenv host is rebuilt: a VLAN9-tagged copy of the devenv KubeVirt VM on ocp.igou.systems.

### New: `playbooks/devenv/provision-vm-vlan9.yml`
VLAN9 variant of `provision-vm.yml`. Key differences from the pod-network variant:
- **Drives `kubevirt.core.kubevirt_vm` directly** rather than the generic `roles/kubevirt_vm_provision` role. That role is deliberately masquerade/pod-network-only — its README says to drive the module directly for secondary/Multus networks. This is the cleaner path (no alternate-network branch bolted onto the generic role, which also backs the Hermes VM).
- Single **bridged Multus interface** on the `vlan9-no-ipam` ClusterUserDefinedNetwork, `autoattachPodInterface: false`, guest DHCPs on VLAN9 (10.10.9.0/24). **No NodePort services** — SSH and code-server are reached directly on the VM's VLAN9 IP.
- The play **creates + labels** the `devenv-vlan9` namespace with `network.igou.systems/vlan9: "true"` so the CUDN materializes the NAD (verified: NAD appears within seconds of the labelled namespace).
- Same casval burst placement (`node-role.kubernetes.io/burst`, workload=burst toleration), pinned `pc-q35-rhel9.6.0` machine type, amd64, BIOS 30Gi `centos-stream10` clone, and `rebuild` / `vm_state=absent` lifecycle knobs. Reuses the existing `devenv-cloudinit.yaml.j2` (igou user, authorized keys, qemu-guest-agent; CentOS Stream 10 cloud-init DHCPs the single NIC).

### `playbooks/devenv/bootstrap.yml`
- Pinned to the igou-devenv **v2026.07.12** release: `devenv_repo_version: main → v2026.07.12`, `devenv_image: …:latest → …:2026.07.12`.
- **Fix: install `kernel-modules-extra` before starting docker.** The CentOS Stream 10 golden image ships `kernel-modules`/`kernel-modules-core` but not the legacy netfilter compat modules (`xt_addrtype`, `iptable_nat`, `br_netfilter`), which live in `kernel-modules-extra`. docker-ce 29's daemon programs iptables NAT rules on startup (`-m addrtype --dst-type LOCAL`) and **fails to start** without them (`Extension addrtype revision 0 not supported, missing kernel module?`). New pre_task installs the extra modules pinned to the running kernel, persists them via `modules-load.d`, and loads them before the docker role runs. Applies to **both** devenv variants (both use this bootstrap). Found + fixed live during this provisioning.

## Namespace ownership decision
The namespace is **ansible-owned** (created + labelled by the playbook), not added to igou-openshift GitOps. Rationale: the VM and its namespace are a single ansible-managed lifecycle unit, and the `test-workloads/` VLAN9 namespaces are manual `oc apply -k`, not ArgoCD-synced — so a GitOps namespace would introduce dual ownership without an Argo app to own it. No igou-openshift PR was opened. Under a scoped ServiceAccount that can't create namespaces, pre-create it and pass `create_namespace=false`.

## Live verification (ocp.igou.systems)
- VM `devenv-vlan9` in namespace `devenv-vlan9`, Running on burst node `casval.igou.systems` (scale-from-zero, ~21 min cold).
- VLAN9 DHCP address **10.10.9.187** (enp1s0), reported by qemu-guest-agent.
- `ssh igou@10.10.9.187` works (hostname `devenv-vlan9`, cloud-init done).
- docker-ce 29.6.1 daemon active (after kernel-modules-extra fix); code-server container running from `ghcr.io/igou-io/igou-devenv:2026.07.12`, answering on `https://10.10.9.187:8080`.
- `~/igou-devenv` cloned at tag `v2026.07.12`.

## Out of scope / follow-ups
- AAP `controller_templates` wiring in igou-inventory for this new playbook (job template + static/VLAN9-IP inventory for phase 2) is intentionally not included here.
- Consider folding the kernel-modules-extra step into the `david_igou.devhost` docker role so any consumer of that role on the Stream 10 image benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Lq5KqQ3Wj6C3M7B92NVih