### PR TITLE
feat(devenv): ghapp by default + full devhost toolset + VLAN9 VM resize

### DIFF
--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -15,18 +15,27 @@
   hosts: "{{ ansible_limit | default('devenv-devenv') }}"
   gather_facts: false
   vars:
-    # Keep the host lean (devhost >= 27.0.0 mise interface). A devcontainer host only
-    # needs docker + a distro Node.js + @devcontainers/cli; the CLI toolset lives in
-    # the devcontainer, so mise (packages_install_cli_tools) stays OFF. cli_tools=false
-    # installs the distro Node.js fallback for @devcontainers/cli and skips the heavy
-    # CLI/pip/extra-OS-package work (incl. the dnf5-fragile CRB/EPEL step).
-    packages_install_cli_tools: false
-    packages_install_extra_packages: false
-    packages_install_pip_packages: false
-    packages_install_onepassword: false
-    packages_install_github_cli: false
-    packages_install_claude_code: false
-    packages_install_cursor_agent: false
+    # Toolset profile (devhost >= 27.0.0 mise interface). The operator wants the
+    # FULL devhost toolset on the box itself (not just inside the devcontainer):
+    # the mise-pinned CLI set (kubectl/helm/oc/... + Node.js), 1Password CLI,
+    # GitHub CLI, Claude Code, the Cursor agent, the extra OS packages, and the
+    # pip layer. `devenv_full_toolset` drives all of the packages role's feature
+    # toggles so the physical devhost rebuild gets the complete set by default;
+    # flip it off for a lean devcontainer-only host with `-e devenv_full_toolset=false`
+    # (that restores the old profile: docker + distro Node.js + @devcontainers/cli
+    # only, skipping mise and the extra-package work). On CentOS Stream 10 the
+    # extra-package step's `dnf config-manager --set-enabled crb` works with the
+    # stock dnf 4.20 — the earlier "dnf5-fragile" caveat does not manifest on this
+    # image. mise install needs a GITHUB_TOKEN in the environment (packages role
+    # default reads it from env) to avoid the 60/hr anonymous GitHub API limit.
+    devenv_full_toolset: true
+    packages_install_cli_tools: "{{ devenv_full_toolset }}"
+    packages_install_extra_packages: "{{ devenv_full_toolset }}"
+    packages_install_pip_packages: "{{ devenv_full_toolset }}"
+    packages_install_onepassword: "{{ devenv_full_toolset }}"
+    packages_install_github_cli: "{{ devenv_full_toolset }}"
+    packages_install_claude_code: "{{ devenv_full_toolset }}"
+    packages_install_cursor_agent: "{{ devenv_full_toolset }}"
 
     # docker role: install the full daemon (docker-ce + containerd.io).
     docker_install_daemon: true
@@ -40,16 +49,32 @@
     devenv_image: ghcr.io/igou-io/igou-devenv:2026.07.12
     devenv_launch_devcontainer: true
 
-    # GitHub App runtime tokens (ghapp, local-mint mode). Gated OFF so this is
-    # a no-op until launched with -e devenv_ghapp_enabled=true. When on, the
-    # igou-dev App identity/key default from 1Password (vault claude; override
+    # GitHub App runtime tokens (ghapp, local-mint mode). ON by default so the
+    # devhost mints repo-scoped ~1h GitHub tokens instead of carrying a static
+    # PAT; disable with -e devenv_ghapp_enabled=false. The igou-dev App
+    # identity/key default from 1Password (vault claude; override
     # devenv_ghapp_op_vault/_item or pass ghapp_client_* directly). The role
-    # params below are only templated when the gated role runs.
-    devenv_ghapp_enabled: false
+    # params below are only templated when the enabled role runs.
+    #
+    # Key source = private_key_content (the op lookups below resolve on the
+    # ANSIBLE CONTROLLER — the devcontainer or the AAP EE, both of which have op
+    # + 1P auth — and the PEM is written 0600 to ~/.config/ghapp/key.pem on the
+    # host). We deliberately do NOT use private_key_cmd (`op read`) on the host:
+    # even with the 1Password CLI now installed (full toolset), the host has no
+    # 1P credential of its own (no Connect token / service account), so an
+    # on-host `op read` would have nothing to authenticate with — and seeding one
+    # would just move a long-lived secret onto the box, which is what ghapp
+    # exists to avoid. In-container we DO use private_key_cmd, because the
+    # devcontainer already has op auth bind-mounted (see igou-devenv).
+    devenv_ghapp_enabled: true
     ghapp_client_enabled: true
     ghapp_client_user: igou
     devenv_ghapp_op_item: igou-dev-github-app
     devenv_ghapp_op_vault: claude
+    # Pin the plugin to a released tag so the host installs the same version as
+    # the devcontainer image (the role default is `main`). Renovate-bumpable on
+    # the igou-devenv side; bump here in lockstep.
+    devenv_ghapp_plugin_ref: v0.2.0
 
   pre_tasks:
     - name: Wait for the VM's SSH to come up
@@ -118,6 +143,8 @@
       # recurses at arg-spec validation). Pass devenv_ghapp_client_id/... at
       # launch to override the 1Password default.
       vars:
+        # Install the same pinned plugin tag the devcontainer image uses.
+        ghapp_package_git_ref: "{{ devenv_ghapp_plugin_ref }}"
         ghapp_client_id: >-
           {{ devenv_ghapp_client_id | default(lookup('community.general.onepassword',
              devenv_ghapp_op_item, field='client_id', vault=devenv_ghapp_op_vault), true) }}

--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -3,16 +3,20 @@
 # Docker host capable of running the igou-devenv devcontainer, using my
 # david_igou.devhost collection, then launch code-server from the published image.
 #
-# Reached over SSH by AAP: the kubevirt.core inventory (source igou_kubevirt_ocp)
-# resolves this host's virt-launcher pod IP; the play connects as remote_user igou
-# (ansible.cfg) with the `ansible_user_ed25519` machine credential. The workflow
-# node passes ansible_limit=devenv-devenv (hosts: reads it before group_vars apply).
+# Targets the `devenv` inventory group (github.com/igou-io/igou-inventory):
+# every devenv VM is added to that group and converged against the real
+# inventory, so its per-host connection details (ansible_host) and the ghapp
+# GitHub App wiring (group_vars/devenv/ghapp.yml — 1Password lookups) attach
+# automatically. `ansible_limit` still narrows the run to a single host when
+# passed (AAP limit field or `--limit`); it defaults to the whole `devenv`
+# group. The play connects as remote_user igou (ansible.cfg) with the
+# `ansible_user_ed25519` machine credential.
 #
 # NB: intentionally NO play-level become. The david_igou.devhost roles self-elevate
 # per task, and the packages role's user-level npm / @devcontainers/cli tasks must
 # run as the igou login user (not root).
 - name: Configure the devenv host via david_igou.devhost
-  hosts: "{{ ansible_limit | default('devenv-devenv') }}"
+  hosts: "{{ ansible_limit | default('devenv') }}"
   gather_facts: false
   vars:
     # Toolset profile (devhost >= 27.0.0 mise interface). The operator wants the
@@ -51,30 +55,29 @@
 
     # GitHub App runtime tokens (ghapp, local-mint mode). ON by default so the
     # devhost mints repo-scoped ~1h GitHub tokens instead of carrying a static
-    # PAT; disable with -e devenv_ghapp_enabled=false. The igou-dev App
-    # identity/key default from 1Password (vault claude; override
-    # devenv_ghapp_op_vault/_item or pass ghapp_client_* directly). The role
-    # params below are only templated when the enabled role runs.
+    # PAT; disable with -e devenv_ghapp_enabled=false.
     #
-    # Key source = private_key_content (the op lookups below resolve on the
-    # ANSIBLE CONTROLLER — the devcontainer or the AAP EE, both of which have op
-    # + 1P auth — and the PEM is written 0600 to ~/.config/ghapp/key.pem on the
-    # host). We deliberately do NOT use private_key_cmd (`op read`) on the host:
-    # even with the 1Password CLI now installed (full toolset), the host has no
-    # 1P credential of its own (no Connect token / service account), so an
-    # on-host `op read` would have nothing to authenticate with — and seeding one
-    # would just move a long-lived secret onto the box, which is what ghapp
-    # exists to avoid. In-container we DO use private_key_cmd, because the
-    # devcontainer already has op auth bind-mounted (see igou-devenv).
+    # This is the ONLY ghapp var set here on purpose: it is a non-secret
+    # behavior toggle. The App identity, installation map, private-key source
+    # (op:// lookup), enabled flag, config user, and pinned plugin ref all live
+    # in the inventory as group_vars/devenv/ghapp.yml — the authoritative source
+    # per the roles-as-functions directive (op:// references belong in inventory
+    # data, not play vars or role tasks). Do NOT reintroduce ghapp_client_*
+    # here: play vars OUTRANK group_vars, so any ghapp_* left in this vars: block
+    # would silently shadow the inventory values.
+    #
+    # Key source note (implemented in group_vars): the op lookups resolve on the
+    # ANSIBLE CONTROLLER (the devcontainer or the AAP EE, both of which have op
+    # + 1P auth) and the PEM is written 0600 to ~/.config/ghapp/key.pem on the
+    # host via ghapp_client_private_key_content. We deliberately do NOT use
+    # private_key_cmd (`op read`) on the host: even with the 1Password CLI now
+    # installed (full toolset), the host has no 1P credential of its own (no
+    # Connect token / service account), so an on-host `op read` would have
+    # nothing to authenticate with — and seeding one would just move a
+    # long-lived secret onto the box, which is what ghapp exists to avoid.
+    # In-container we DO use private_key_cmd, because the devcontainer already
+    # has op auth bind-mounted (see igou-devenv).
     devenv_ghapp_enabled: true
-    ghapp_client_enabled: true
-    ghapp_client_user: igou
-    devenv_ghapp_op_item: igou-dev-github-app
-    devenv_ghapp_op_vault: claude
-    # Pin the plugin to a released tag so the host installs the same version as
-    # the devcontainer image (the role default is `main`). Renovate-bumpable on
-    # the igou-devenv side; bump here in lockstep.
-    devenv_ghapp_plugin_ref: v0.2.0
 
   pre_tasks:
     - name: Wait for the VM's SSH to come up
@@ -138,21 +141,14 @@
     - role: david_igou.devhost.packages
     - role: david_igou.devhost.ghapp
       when: devenv_ghapp_enabled | bool
-      # Override vars use a devenv_-prefixed name so the role param can't
-      # reference itself (a self-referential {{ ghapp_client_id | default(...) }}
-      # recurses at arg-spec validation). Pass devenv_ghapp_client_id/... at
-      # launch to override the 1Password default.
-      vars:
-        # Install the same pinned plugin tag the devcontainer image uses.
-        ghapp_package_git_ref: "{{ devenv_ghapp_plugin_ref }}"
-        ghapp_client_id: >-
-          {{ devenv_ghapp_client_id | default(lookup('community.general.onepassword',
-             devenv_ghapp_op_item, field='client_id', vault=devenv_ghapp_op_vault), true) }}
-        ghapp_client_app_slug: "{{ devenv_ghapp_app_slug | default('igou-dev') }}"
-        ghapp_client_installations: "{{ devenv_ghapp_installations | default(dict([['david-igou', lookup('community.general.onepassword', devenv_ghapp_op_item, field='installation_id_david-igou', vault=devenv_ghapp_op_vault)], ['igou-io', lookup('community.general.onepassword', devenv_ghapp_op_item, field='installation_id_igou-io', vault=devenv_ghapp_op_vault)]]), true) }}"
-        ghapp_client_private_key_content: >-
-          {{ devenv_ghapp_private_key | default(lookup('community.general.onepassword',
-             devenv_ghapp_op_item, field='private_key', vault=devenv_ghapp_op_vault), true) }}
+      # No vars: block. The role reads its parameters (ghapp_client_id,
+      # ghapp_client_app_slug, ghapp_client_installations,
+      # ghapp_client_private_key_content, ghapp_client_enabled, ghapp_client_user,
+      # ghapp_package_git_ref) straight from the inventory group_vars/devenv/
+      # ghapp.yml — validated by the role's argument_specs. Keeping them out of
+      # the play is deliberate: play/role vars outrank group_vars, so setting
+      # them here would shadow the inventory. Override at launch with extra vars
+      # (-e ghapp_client_id=...), which win over both.
 
   post_tasks:
     - name: Clone the igou-devenv repo (public, HTTPS — no agent forwarding needed)
@@ -189,6 +185,31 @@
           - "8080:8080"
         volumes:
           - "{{ ansible_user_dir }}/igou-devenv:/workspace:Z"
+        # Allow bubblewrap (bwrap) — and any codex/OpenAI-style agent sandbox
+        # built on it — to create UNPRIVILEGED user + mount + network
+        # namespaces from inside this container. Docker's default seccomp
+        # profile blocks the userns-creating syscalls (clone/unshare with
+        # CLONE_NEWUSER), so a plain `bwrap --ro-bind / / true` fails with
+        # "No permissions to creating new namespace". seccomp=unconfined lifts
+        # only the syscall filter; it does NOT add capabilities, grant device
+        # access, or use --privileged — the container still runs as the
+        # unprivileged igou uid with the default (dropped) cap set. bwrap then
+        # RE-confines each sandbox it launches, so the net posture for agent
+        # workloads is tighter, not looser. This is strictly more minimal than
+        # the physical devhost devcontainer (rootless podman --privileged).
+        #
+        # Covers: `bwrap --ro-bind / / true`, `--unshare-user`, `--unshare-net`,
+        # and loopback bring-up inside the netns (the last via bwrap's own
+        # `--cap-add CAP_NET_ADMIN`, which needs no extra container privilege).
+        # NOT covered: mounting a FRESH procfs (`bwrap --proc /proc`) — Docker's
+        # default /proc masks trip the kernel's mount_too_revealing check.
+        # Sandboxes should bind the existing /proc (`--dev-bind /proc /proc`)
+        # instead; a fresh proc mount would need Docker's /proc masks cleared
+        # (HostConfig.MaskedPaths=[]), which community.docker 5.2.1 cannot
+        # express (systempaths=unconfined is a docker-CLI-only convenience the
+        # daemon API rejects). See the PR body for that follow-up.
+        security_opts:
+          - seccomp=unconfined
         command: code-server --bind-addr 0.0.0.0:8080 /workspace --cert
       become: true
       when: devenv_launch_devcontainer | bool

--- a/playbooks/devenv/provision-vm-vlan9.yml
+++ b/playbooks/devenv/provision-vm-vlan9.yml
@@ -58,8 +58,12 @@
     vm_root_size: 30Gi
 
     # Compute (overridable at launch). No resources block -> Burstable QoS.
-    vm_cpu_cores: 8
-    vm_memory: 16Gi
+    # Sized for the full devhost toolset + real workloads. casval has ample
+    # headroom (192 cores / ~364Gi allocatable), so this fits comfortably with
+    # room for the burst autoscaler. A change here is a spec change: the VM must
+    # be RESTARTED to take effect (not hot-plugged).
+    vm_cpu_cores: 20
+    vm_memory: 64Gi
 
     # Pin the versioned machine type so the burst autoscaler's synthetic
     # template node (built from the casval MachineSet capacity-labels


### PR DESCRIPTION
## Summary

Makes the devenv host bring-up match the operator's real daily workflow so the
**physical devhost rebuild gets it automatically**, and applies the same changes
to the live VLAN9 interim VM:

1. **ghapp on by default** — the `david_igou.devhost.ghapp` role (runtime-minted,
   repo-scoped GitHub App tokens) was wired in but gated off; it is now enabled by
   default. The host gets the `ghapp` CLI + git credential helper so plain HTTPS
   `git push` mints a `contents:write`, single-repo, ~1h token instead of carrying
   a static PAT.
2. **Full devhost toolset** — flips the box from the lean devcontainer-host profile
   to the complete toolset (mise CLI set, 1Password CLI, GitHub CLI, Claude Code,
   Cursor agent, extra OS packages, pip) behind one documented profile var.
3. **VLAN9 VM resize** — 8 cores / 16Gi → **20 cores / 64Gi**.

Pairs with igou-io/igou-devenv#127 (the devcontainer side) and the new
`v0.2.0` tag on david-igou/hermes_github_app_plugin.

## Design decisions & trade-offs

### Key source: `private_key_content` (not `private_key_cmd`)
The `ghapp` role accepts exactly one key source. On the **host** we keep
`private_key_content`:

- The `community.general.onepassword` lookups resolve on the **ansible controller**
  (the devcontainer for a local run, or the AAP EE for the automated path) — both
  already have `op` + 1Password auth. The resolved PEM travels over the SSH
  connection and the role writes it `0600` to `~/.config/ghapp/key.pem`.
- We deliberately do **not** use `private_key_cmd` (`op read`) on the host. Even
  now that the full toolset installs the 1Password CLI, the host has **no 1P
  credential of its own** (no Connect token / service account), so an on-host
  `op read` would have nothing to authenticate against — and seeding one would just
  move a long-lived secret onto the box, which is exactly what ghapp exists to
  avoid. The devcontainer *does* use `private_key_cmd`, because it already has op
  auth bind-mounted (see the devenv PR).

### Plugin pinned to a tag
The role default is `ghapp_package_git_ref: main`. We pin `v0.2.0` (new tag on the
plugin repo) so the **host installs the same version as the devcontainer image**.
Renovate-bumpable on the devenv side; bump both in lockstep.

### Full toolset behind a profile var
`devenv_full_toolset: true` drives every `packages_install_*` toggle, so the
physical rebuild gets the complete set by default and `-e devenv_full_toolset=false`
restores the lean profile. The packages role's CRB/EPEL step was flagged
"dnf5-fragile" — on this CentOS Stream 10 image `dnf` is 4.20 and
`dnf config-manager --set-enabled crb` returns rc=0, so **no workaround was
needed**; documented inline.

### Broker mode: out of scope
The role's broker mode (systemd + unix-socket + policy clamp + SELinux domain) is
for **containerized agents** that must not read key material. The devenv operator
works interactively as a login user, so local-mint (client) mode is the right fit.
Broker mode remains available for a future Hermes-agent host.

## Live verification (VM host, both orgs)

Re-ran `bootstrap.yml` against `10.10.9.187` with the new defaults:
`ok=62 changed=8 failed=0`.

```
ghapp 0.2.0 installed to /opt/ghapp; console scripts symlinked to /usr/local/bin
~/.config/ghapp/config.yaml → both installations (david-igou, igou-io), key.pem 0600
git credential.https://github.com.helper=ghapp, useHttpPath=true

ghapp doctor --repo igou-io/igou-ansible                 → Doctor passed (token minted, repo access verified)
ghapp doctor --repo david-igou/hermes_github_app_plugin  → Doctor passed
gh-app --repo igou-io/igou-ansible -- api repos/...       → igou-io/igou-ansible   (no GH_TOKEN in env)
git ls-remote https://github.com/igou-io/igou-ansible.git      → 0d2f0d1  (helper, no token)
git ls-remote https://github.com/david-igou/hermes_..._plugin  → 4fe6f08  (helper, no token)
git push --dry-run (igou-io/igou-devenv)                 → server accepted (contents:write mint)
git push --dry-run (david-igou/hermes_github_app_plugin) → server accepted
```

Full-toolset spot check (as `igou`): kubectl v1.34.1, oc 4.21.16, argocd v3.4.4,
virtctl v1.8.2, helm, kustomize, terraform, node (mise) + op 2.34.1, gh 2.95.0,
claude 2.1.207, cursor-agent, jq, direnv, shellcheck, yamllint.

## Not done (needs operator / outside auto mode)

- **VLAN9 VM resize was NOT applied live.** The spec change (and required restart)
  to the shared cluster VM was blocked by the auto-mode permission classifier
  because it was only named in a coordinator-relayed message. The code default is
  updated here; apply with `oc patch` (cores→20, memory.guest→64Gi) **or** re-run
  `provision-vm-vlan9.yml`, then restart the VMI. **The VLAN9 DHCP IP may change on
  restart — re-read it** with `oc -n devenv-vlan9 get vmi devenv-vlan9 -o jsonpath='{.status.interfaces[0].ipAddress}'`.
  casval has ample headroom (192c / ~364Gi allocatable), so 20c/64Gi fits.
- The AAP path passes `packages_github_token` from the environment for the mise
  rate-limit; ensure the workflow provides `GITHUB_TOKEN` when running the full
  toolset.

## Lint

`ansible-lint --profile=production` and `yamllint` both pass on the two changed
playbooks.

---

## Update — inventory-sourced ghapp vars + bwrap support (stacked commit)

**ghapp vars moved to inventory (roles-as-functions).** The ghapp App identity/key defaults are removed from this play's `vars:` and the ghapp role's `vars:` block. They now live in the companion **igou-inventory#160** as `group_vars/devenv/ghapp.yml` (1Password lookups → `lab_external_api_keys`). The role reads `ghapp_client_*` + `ghapp_package_git_ref` straight from the inventory group, validated by its argument_specs. The play keeps only the non-secret `devenv_ghapp_enabled` toggle. This closes the "play vars outrank group_vars → silent shadow" gotcha: nothing ghapp-identity remains in-play.

`hosts:` now targets the **`devenv` inventory group** (`{{ ansible_limit | default('devenv') }}`) — every devenv VM is added to that group and converged against the real inventory; `ansible_limit` still narrows a single-host run.

**1Password item moved** `claude` → `lab_external_api_keys` (byte-identical copy verified; source retained pending the image rebuild — see below).

**bwrap / codex-style agent sandboxes.** The code-server container launch gains `security_opts: [seccomp=unconfined]` so bubblewrap can create unprivileged user/mount/network namespaces inside the container. Docker's default seccomp profile blocks the userns-creating syscalls (a plain `bwrap --ro-bind / / true` fails). This adds **no capabilities, no --privileged, no device access** — the container still runs as the unprivileged igou uid; bwrap then re-confines each sandbox. Strictly more minimal than the physical devhost (rootless podman `--privileged`).

### Live redeploy evidence (real inventory, `-i igou-inventory --limit devenv`)
```
PLAY RECAP: devenv-vlan9 : ok=62 changed=2 failed=0
```
- Host ghapp regenerated from the new vault: `~/.config/ghapp/key.pem` = **1678 bytes** (the lab_external_api_keys PEM), 0600 igou.
- `git ls-remote` succeeds for **both** orgs (igou-io + david-igou) via the ghapp credential helper → minting works end-to-end from the new-vault key.
- Live container `SecurityOpt=[seccomp=unconfined] Privileged=false CapAdd=[]`.

### bwrap matrix (inside the live recreated container)
| Test | Result |
|---|---|
| `bwrap --ro-bind / / true` | ✅ rc=0 |
| `bwrap --unshare-user --ro-bind / / id` | ✅ rc=0 |
| `bwrap --unshare-net --ro-bind / / true` | ✅ rc=0 |
| loopback bring-up (`bwrap --cap-add CAP_NET_ADMIN --unshare-user --unshare-net`) | ✅ lo UP |
| codex-style sandbox (userns+netns+ipc+uts, ro-bind /, `--dev-bind /proc /proc`) | ✅ rc=0 |

**Security trade-off / follow-up:** seccomp=unconfined removes syscall filtering for the code-server container. Acceptable here (agent host; bwrap tightens the actual sandboxes). **Not covered:** mounting a *fresh* procfs (`bwrap --proc /proc`) — Docker's default `/proc` masks trip the kernel's `mount_too_revealing` check. Sandboxes should bind the existing `/proc` instead. Enabling a fresh mount would need `HostConfig.MaskedPaths=[]`, which community.docker 5.2.1 can't express (`systempaths=unconfined` is a docker-CLI convenience the daemon API rejects) — deferred until community.docker exposes `masked_paths`, or accept `--privileged` parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Lq5KqQ3Wj6C3M7B92NVih

