### PR TITLE
chore(devenv): bump pin to igou-devenv v2026.07.12-1

### DIFF
--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -49,8 +49,8 @@
     # Pinned to the igou-devenv release cut for this rebuild (git tag +
     # container image promoted by digest from the tested :latest). Bump both
     # together when adopting a newer release.
-    devenv_repo_version: v2026.07.12
-    devenv_image: ghcr.io/igou-io/igou-devenv:2026.07.12
+    devenv_repo_version: v2026.07.12-1
+    devenv_image: ghcr.io/igou-io/igou-devenv:2026.07.12-1
     devenv_launch_devcontainer: true
 
     # GitHub App runtime tokens (ghapp, local-mint mode). ON by default so the


### PR DESCRIPTION
## What

Bump the devenv phase-2 pin to the freshly cut `igou-devenv` release **v2026.07.12-1**:

- `devenv_repo_version: v2026.07.12-1`
- `devenv_image: ghcr.io/igou-io/igou-devenv:2026.07.12-1`

## Why

This release re-cut bakes the in-container ghapp into the image (PR igou-devenv#127): plugin pinned to v0.2.0, dotfiles config sourcing the private key from `op://lab_external_api_keys/igou-dev-github-app/private_key`, credential helper, and the `ght` shell function. Bumping both together (git tag the VM clones + container image phase 2 launches) adopts it.

The `2026.07.12-1` image was promoted by digest from the tested `:latest` (`sha256:798cd03a0b23bc5d0de44af9a3ebfd3bd039fa71bdccb74e32bf13653cb8380a`). The `-1` suffix follows repo release history (v2026.06.29-1, etc.); a plain `v2026.07.12` tag already existed and released tags are immutable.

## Test

- `yamllint` clean
- `ansible-lint --profile=production` passed (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)