### PR TITLE
chore(molecule): repoint ghapp-e2e at the lab_external_api_keys vault

### DIFF
--- a/molecule/ghapp-e2e/converge.yml
+++ b/molecule/ghapp-e2e/converge.yml
@@ -14,17 +14,17 @@
     ghapp_client_enabled: true
     ghapp_client_user: cloud-user
     ghapp_client_id: >-
-      {{ lookup('ansible.builtin.pipe', 'op read op://claude/igou-dev-github-app/client_id') }}
+      {{ lookup('ansible.builtin.pipe', 'op read op://lab_external_api_keys/igou-dev-github-app/client_id') }}
     ghapp_client_app_slug: igou-dev
     ghapp_client_installations:
       david-igou: >-
         {{ lookup('ansible.builtin.pipe',
-                  'op read "op://claude/igou-dev-github-app/installation_id_david-igou"') }}
+                  'op read "op://lab_external_api_keys/igou-dev-github-app/installation_id_david-igou"') }}
       igou-io: >-
         {{ lookup('ansible.builtin.pipe',
-                  'op read op://claude/igou-dev-github-app/installation_id_igou-io') }}
+                  'op read op://lab_external_api_keys/igou-dev-github-app/installation_id_igou-io') }}
     ghapp_client_private_key_content: >-
-      {{ lookup('ansible.builtin.pipe', 'op read op://claude/igou-dev-github-app/private_key') }}
+      {{ lookup('ansible.builtin.pipe', 'op read op://lab_external_api_keys/igou-dev-github-app/private_key') }}
   roles:
     - role: david_igou.devhost.ghapp
       when: devenv_ghapp_enabled | bool


### PR DESCRIPTION
## What

Repoint the four `op read` lookups in `molecule/ghapp-e2e/converge.yml` from `op://claude/igou-dev-github-app/...` to `op://lab_external_api_keys/igou-dev-github-app/...`.

## Why

The `igou-dev-github-app` item moved out of the `claude` vault to `lab_external_api_keys` on 2026-07-12 (igou-inventory#160 group_vars and the igou-devenv v2026.07.12-1 dotfiles config already read from there). This scenario was the last merged-main consumer of the old claude-vault copy; after this merges, that copy can be archived.

Both vault copies currently resolve with identical field layout, so this is a no-op for the scenario's behavior.

## Test

- `yamllint` clean, `ansible-lint --profile=production` passed
- `op read op://lab_external_api_keys/igou-dev-github-app/client_id` verified resolving

🤖 Generated with [Claude Code](https://claude.com/claude-code)