### PR TITLE
feat(devenv): mount the host ghapp config into the code-server container

### DIFF
--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -181,10 +181,31 @@
         user: igou
         env:
           HOME: /home/igou
+          # The baked ghapp CLI + git credential helper resolve their config
+          # via GHAPP_CONFIG. On the laptop-devcontainer path this export
+          # comes from dotfiles/.bashrc (seeded by post-create.sh), but this
+          # bare code-server launch never runs devcontainer lifecycle hooks,
+          # so set it at the container level — that also covers non-login
+          # contexts (the credential helper invoked by plain `git`).
+          GHAPP_CONFIG: /home/igou/.config/ghapp/config.yaml
         ports:
           - "8080:8080"
         volumes:
           - "{{ ansible_user_dir }}/igou-devenv:/workspace:Z"
+          # In-container GitHub App minting WITHOUT any 1P credential on this
+          # VM: reuse the host's file-based ghapp config (config.yaml with
+          # private_key_path + key.pem, both rendered 0600 by the devhost
+          # ghapp role — NOT the dotfiles' private_key_cmd/op variant, which
+          # would need op auth the host deliberately does not have). The same
+          # path inside and out keeps private_key_path valid verbatim, and
+          # the key is already on host disk 0600, so a read-only bind adds no
+          # new secret exposure (host + container igou are both uid 1000).
+          # SELinux is Enforcing and ~/.config/ghapp is config_home_t, which
+          # container_t cannot read — `z` (SHARED relabel, unlike the
+          # workspace's private `Z`) keeps the dir usable by the host user
+          # while letting the container read it; `ro` keeps the container
+          # from ever writing the key.
+          - "{{ ansible_user_dir }}/.config/ghapp:/home/igou/.config/ghapp:ro,z"
         # Allow bubblewrap (bwrap) — and any codex/OpenAI-style agent sandbox
         # built on it — to create UNPRIVILEGED user + mount + network
         # namespaces from inside this container. Docker's default seccomp


### PR DESCRIPTION
## What

Make in-container GitHub App minting work on the headless VLAN9 devenv VM, via the host's file-based ghapp config — no 1P credential on the VM:

- Bind-mount the host igou user's `~/.config/ghapp` (config.yaml using `private_key_path` + `key.pem`, both rendered 0600 by the devhost ghapp role) read-only into `igou-devenv-code-server` at the same path (`/home/igou/.config/ghapp`), so `private_key_path` stays valid verbatim.
- Set `GHAPP_CONFIG=/home/igou/.config/ghapp/config.yaml` as container env. The plugin only resolves its config via `GHAPP_CONFIG` (else `HERMES_HOME`); on the laptop-devcontainer path that export comes from `dotfiles/.bashrc` (seeded by `post-create.sh`), which this bare code-server launch never runs. Container-level env also covers the credential helper when `git` runs outside a login shell.

## Why

The v2026.07.12-1 image bakes the `ghapp` CLI and the system-scope git credential helper, but the container previously had no config and no op auth, so it could not mint at all. The dotfiles config variant (`private_key_cmd: op read ...`) is for the devcontainers path where `~/.config/op` is bind-mounted; this VM's model is host-file-based ghapp with no standalone 1P credential.

Security: the key is already on host disk 0600; a read-only bind into a container running as the same uid (1000) adds no new secret exposure. `ro` prevents container writes; `z` (shared relabel, unlike the workspace's private `Z`) covers the SELinux-enforcing host (Docker CE's SELinux enforcement is currently daemon-disabled, so `z` is defensive).

## Test

Live-verified on devenv-vlan9 (10.10.9.187) with a throwaway container using exactly this mount + env:

- `ghapp token --repo igou-io/igou-inventory` — minted
- `ghapp token --repo david-igou/hermes_github_app_plugin` — minted
- Host labels untouched, host ghapp still mints afterward
- `yamllint` / `ansible-lint --profile=production` / `--syntax-check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)