### PR TITLE
fix(devenv): wrap the unit ExecStart in bash for SELinux exec transition

### DIFF
--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -308,7 +308,15 @@
           WorkingDirectory={{ ansible_user_dir }}/igou-devenv
           Environment=HOME={{ ansible_user_dir }}
           Environment=PATH={{ ansible_user_dir }}/.local/bin:/usr/local/bin:/usr/bin:/bin
-          ExecStart={{ ansible_user_dir }}/.local/bin/devcontainer up --workspace-folder {{ ansible_user_dir }}/igou-devenv --override-config {{ ansible_user_dir }}/.local/share/igou-devenv/devcontainer-release.json --update-remote-user-uid-default off
+          # ExecStart must go through a system interpreter: SELinux denies
+          # systemd (init_t) execve of a script under /home (the npm
+          # user-install lands devcontainer as gconf_home_t), failing with
+          # 203/EXEC "Permission denied". Exec'ing /usr/bin/bash
+          # (shell_exec_t) first transitions the service into an unconfined
+          # service domain, which may then exec the user-home script.
+          # Live-verified on devenv-vlan9: the direct path fails 203, the
+          # wrapped one starts clean.
+          ExecStart=/usr/bin/bash -c 'exec {{ ansible_user_dir }}/.local/bin/devcontainer up --workspace-folder {{ ansible_user_dir }}/igou-devenv --override-config {{ ansible_user_dir }}/.local/share/igou-devenv/devcontainer-release.json --update-remote-user-uid-default off'
           TimeoutStartSec=900
 
           [Install]


### PR DESCRIPTION
## What

Wrap `igou-devenv.service`'s ExecStart in `/usr/bin/bash -c 'exec ...'`.

## Why

First live start of the unit from #380 failed with `203/EXEC Unable to locate executable '/home/igou/.local/bin/devcontainer': Permission denied`. SELinux denies systemd (`init_t`) execve of a script under /home (the npm user-install labels devcontainer `gconf_home_t`). Exec'ing `/usr/bin/bash` (`shell_exec_t`) first transitions the service into an unconfined service domain, which may then exec the user-home script.

## Test

Live-verified on devenv-vlan9 via a systemd drop-in with exactly this ExecStart: direct path fails 203/EXEC, wrapped path starts clean (`systemctl restart igou-devenv` → active). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)