### PR TITLE
fix(hermes): stop podman image ops from taking down the state PVC

### DIFF
--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -318,10 +318,13 @@
           become_flags: "-i"
           environment: "{{ hermes_podman_environment }}"
 
+        # 20m (not 10m): the first keep-id run after a fresh pull cold-builds an
+        # ID-mapped copy of every layer of the multi-GB devenv image, which can
+        # exceed 10m under IO load (see the matching note in setup-os.yml).
         - name: Pre-warm Hermes terminal backend image with rootless Podman keep-id mapping
           ansible.builtin.command:
             cmd: >-
-              timeout --kill-after=30s 10m
+              timeout --kill-after=30s 20m
               podman run --rm
               --entrypoint {{ hermes_terminal_backend_container_shell }}
               --userns=keep-id:uid={{ hermes_terminal_backend_container_uid }},gid={{ hermes_terminal_backend_container_gid }}

--- a/playbooks/hermes/configure.yml
+++ b/playbooks/hermes/configure.yml
@@ -271,6 +271,42 @@
     - name: Manage Hermes terminal backend image lifecycle
       when: hermes_terminal_backend_image_pre_pull | default(false) | bool
       block:
+        # QUIESCE the live gateway BEFORE any image ops. The gateway
+        # (hermes-gateway.service, a rootless systemd --user unit) continuously
+        # spawns and removes ephemeral podman exec-sandbox containers on the SAME
+        # rootless-podman graphroot that the pull/prewarm/prune tasks below use.
+        # Two independent podman processes doing concurrent overlayfs
+        # copy-up/rename on the same XFS dirs previously tripped a kernel XFS bug
+        # and shut the filesystem down. Stop the gateway (and dashboard) and drain
+        # any still-running containers so nothing else touches podman while the
+        # image lifecycle runs. Nothing here restarts them: the gateway is brought
+        # back up unconditionally at play end ("Enable and restart the Hermes
+        # gateway user unit") and the dashboard by its auth-gated restart task.
+        - name: Stop the Hermes gateway and dashboard user units before image ops
+          ansible.builtin.systemd:
+            name: "{{ item }}"
+            state: stopped
+            scope: user
+          become: true
+          become_user: "{{ hermes_user }}"
+          environment:
+            XDG_RUNTIME_DIR: "/run/user/{{ hermes_uid }}"
+          loop:
+            - hermes-gateway.service
+            - hermes-dashboard.service
+
+        - name: Drain any running rootless Podman containers before image ops
+          ansible.builtin.command:
+            cmd: "{{ item }}"
+          become: true
+          become_user: "{{ hermes_user }}"
+          become_flags: "-i"
+          environment: "{{ hermes_podman_environment }}"
+          loop:
+            - podman stop --all --time 30
+            - podman rm --all --force
+          changed_when: false
+
         - name: Pre-pull Hermes terminal backend image
           containers.podman.podman_image:
             name: "{{ hermes_terminal_backend_image_ref }}"
@@ -685,6 +721,89 @@
         mode: "0644"
       become: true
       notify: Restart journald
+
+    # END-OF-PLAY HEALTH GATES. This play once SUCCEEDED over a dead filesystem:
+    # the state XFS shut itself down mid-converge (concurrent rootless-podman
+    # activity tripped a kernel XFS bug), every access to the state disk returned
+    # Input/output error, yet the systemd units stayed "active" so the AAP job
+    # went green and nobody noticed for days. These pure, side-effect-free checks
+    # FAIL LOUD at play end so a future mid-run fault turns the job RED instead.
+    #
+    # flush_handlers FIRST: the gateway/dashboard restart handlers run at play
+    # end, AFTER all tasks — so a plain "gateway active" assertion here would race
+    # a not-yet-fired restart handler and false-pass (or false-fail) on a stale
+    # unit state. Flushing forces any pending restarts to happen NOW, so the
+    # checks below observe the post-restart reality.
+    - name: Flush pending restart handlers before asserting health
+      ansible.builtin.meta: flush_handlers
+
+    - name: Assert Hermes end-of-play health
+      block:
+        # State mount writable: a shut-down XFS returns EIO on EVERY operation,
+        # so a real read-write-delete probe as the hermes user fails loudly here
+        # instead of the play silently passing over a dead disk. Plain file IO —
+        # no XDG_RUNTIME_DIR/podman env needed. changed_when: false + the probe
+        # file is removed in the same command, so this leaves no side effect.
+        - name: Probe the Hermes state mount is writable (catches an EIO / shut-down fs)
+          ansible.builtin.command:
+            cmd: >-
+              bash -lc 'f={{ hermes_state_mount }}/.configure_health_probe;
+              echo ok > "$f" && cat "$f" && rm -f "$f"'
+          become: true
+          become_user: "{{ hermes_user }}"
+          register: hermes_state_probe
+          changed_when: false
+          failed_when: >-
+            hermes_state_probe.rc != 0
+            or 'ok' not in hermes_state_probe.stdout
+
+        # Gateway unit active: the durable agent gateway must be up at play end.
+        # It may have JUST been restarted by the flushed handler above, so a brief
+        # activating->active transition is normal — retry/until absorbs it rather
+        # than false-failing on a momentary "activating". scope: user + become_user
+        # hermes + XDG_RUNTIME_DIR matches the systemd --user idiom used above.
+        - name: Verify the Hermes gateway user unit is active
+          ansible.builtin.systemd:
+            name: hermes-gateway.service
+            scope: user
+          become: true
+          become_user: "{{ hermes_user }}"
+          environment:
+            XDG_RUNTIME_DIR: "/run/user/{{ hermes_uid }}"
+          register: hermes_gateway_state
+          until: hermes_gateway_state.status.ActiveState == "active"
+          retries: 5
+          delay: 3
+
+        # No XFS shutdown / state-disk EIO during this run: scan the kernel log
+        # for the state-device (vdb, the XFS state disk) failure signature. The
+        # units can stay "active" over a dead fs, so unit state alone is not
+        # enough — the kernel is the source of truth. Match the vd[b-z] XFS
+        # shutdown/corruption strings SPECIFICALLY to avoid false positives from
+        # unrelated benign log lines; grep rc is ignored (no match = rc 1 = fine),
+        # and the assert fails only if the signature actually appears.
+        - name: Scan the kernel log for a state-disk XFS shutdown / corruption signature
+          ansible.builtin.shell:
+            cmd: >-
+              set -o pipefail;
+              journalctl -k --since "-15min" --no-pager
+              | grep -E 'XFS \(vd[b-z]\): .*(Shutting down|Corruption of in-memory data)'
+              || true
+          become: true
+          register: hermes_xfs_shutdown_scan
+          changed_when: false
+          failed_when: false
+
+        - name: Assert no state-disk XFS shutdown occurred during this run
+          ansible.builtin.assert:
+            that:
+              - hermes_xfs_shutdown_scan.stdout | trim | length == 0
+            fail_msg: >-
+              Kernel log shows an XFS shutdown / in-memory corruption on the
+              Hermes state disk (vdb) during this run. The state filesystem at
+              {{ hermes_state_mount }} is compromised — the units may still read
+              "active" but every state-disk access returns EIO. Investigate the
+              vdb XFS filesystem (dmesg / xfs_repair) before trusting this host.
   handlers:
     - name: Restart journald
       ansible.builtin.systemd:

--- a/playbooks/hermes/setup-os.yml
+++ b/playbooks/hermes/setup-os.yml
@@ -29,7 +29,16 @@
     hermes_podman_subid_start: 100000
     hermes_podman_subid_count: 65536
     hermes_podman_subid_end: "{{ (hermes_podman_subid_start | int) + (hermes_podman_subid_count | int) - 1 }}"
-    hermes_podman_graphroot: "{{ hermes_state_mount }}/containers/storage"
+    # Rootless Podman graphroot lives on the ROOT disk (the rootless-podman default
+    # location), deliberately SEPARATED from the durable state PVC mounted at
+    # {{ hermes_state_mount }}. Container storage is high-churn overlayfs: a
+    # container-store/overlay fault must never be able to take down the agent's
+    # irreplaceable state (config.yaml, memory, skills, .env, the hermes-agent
+    # venv) that shares that PVC — this actually happened. Images are re-pullable
+    # (backup.yml already excludes the graphroot and treats images as re-pullable),
+    # so nothing durable is lost by keeping the store here. The one-time migration
+    # block below relocates any pre-existing on-PVC graphroot to this path.
+    hermes_podman_graphroot: "{{ hermes_home }}/.local/share/containers/storage"
     centos_stream_major: "10"
     centos_stream_repo_base: "https://mirror.stream.centos.org/{{ centos_stream_major }}-stream"
     centos_stream_repo_backup_suffix: ansible-pre-mirror-pin
@@ -437,11 +446,88 @@
       loop:
         - "{{ hermes_home }}/.config"
         - "{{ hermes_home }}/.config/containers"
-        - "{{ hermes_state_mount }}/containers"
+        # Parents for the root-disk graphroot (~/.local/share/containers/storage).
+        # The old on-PVC "{{ hermes_state_mount }}/containers" dir is intentionally
+        # no longer created here — the graphroot now lives on the root disk.
+        - "{{ hermes_home }}/.local"
+        - "{{ hermes_home }}/.local/share"
+        - "{{ hermes_home }}/.local/share/containers"
         - "{{ hermes_podman_graphroot }}"
       become: true
 
-    - name: Configure rootless Podman storage on Hermes state disk
+    # One-time migration: earlier revisions pinned the rootless Podman graphroot
+    # ONTO the durable state PVC ({{ hermes_state_mount }}/containers/storage). A
+    # container-store/overlay fault there could (and did) take the whole state
+    # filesystem — and thus the agent's brain — offline. Detect that legacy layout
+    # by stat-ing the old graphroot; the migration below only fires during the
+    # one-time transition and is skipped on fresh VMs (old dir never existed) and
+    # on already-migrated VMs (old dir removed).
+    - name: Check for a legacy rootless Podman graphroot on the state PVC
+      ansible.builtin.stat:
+        path: "{{ hermes_state_mount }}/containers/storage"
+      register: hermes_old_graphroot_stat
+      become: true
+
+    # Quiesce rootless Podman and reclaim the old on-PVC store BEFORE the template
+    # rewrites storage.conf to the new root-disk graphroot. Order matters: the
+    # running units and containers are still bound to the OLD storage.conf here, so
+    # they must be drained while it still points at the state PVC. Runs only for the
+    # one-time legacy->root-disk transition (guarded on the old dir existing).
+    - name: Migrate the legacy state-PVC graphroot off the durable state disk
+      when: hermes_old_graphroot_stat.stat.exists
+      block:
+        # Stop the rootless systemd --user units so nothing re-opens the old store
+        # mid-migration. failed_when:false because a legacy VM predating these units
+        # may lack them; the drain below still cleans up any stray podman process.
+        - name: Stop the Hermes gateway and dashboard user units before graphroot migration
+          ansible.builtin.systemd:
+            name: "{{ item }}"
+            state: stopped
+            scope: user
+          become: true
+          become_user: "{{ hermes_user }}"
+          environment:
+            XDG_RUNTIME_DIR: "/run/user/{{ hermes_uid }}"
+          loop:
+            - hermes-gateway.service
+            - hermes-dashboard.service
+          failed_when: false
+
+        # Drain any remaining rootless containers via the OLD storage.conf (still in
+        # place). The terminal backend uses host bind mounts, not podman NAMED
+        # volumes, so removing containers loses no durable data.
+        - name: Drain running rootless Podman containers from the legacy store
+          ansible.builtin.command:
+            cmd: "{{ item }}"
+          become: true
+          become_user: "{{ hermes_user }}"
+          become_flags: "-i"
+          environment: "{{ hermes_podman_environment }}"
+          loop:
+            - podman stop --all --time 30
+            - podman rm --all --force
+          changed_when: false
+          failed_when: false
+
+        # Reclaim ~15G on the state PVC. Safe: no podman named volumes exist and
+        # images are re-pullable — the image-pull step later in this play repopulates
+        # the new root-disk graphroot.
+        - name: Remove the orphaned legacy graphroot from the state PVC
+          ansible.builtin.file:
+            path: "{{ hermes_state_mount }}/containers/storage"
+            state: absent
+          become: true
+
+        # Drop the now-dead SELinux file-context rule for the old on-PVC graphroot so
+        # policy carries no stale entry. Guard on SELinux being enabled.
+        - name: Remove the stale SELinux context rule for the legacy graphroot
+          community.general.sefcontext:
+            target: "{{ hermes_state_mount }}/containers/storage(/.*)?"
+            state: absent
+          become: true
+          when: ansible_facts.selinux.status == "enabled"
+
+    - name: Configure rootless Podman storage on the root disk
       ansible.builtin.template:
         src: hermes-containers-storage.conf.j2
         dest: "{{ hermes_home }}/.config/containers/storage.conf"
@@ -450,12 +536,13 @@
         mode: "0600"
       become: true
 
-    # Rootless Podman graphroot is moved from the default per-user location to the
-    # persistent Hermes state disk. On SELinux systems, relocated Podman graphroot
-    # paths need persistent file-context rules and restorecon, otherwise Podman can
-    # fail later with SELinux denials when reading/writing image and container
-    # storage. Match the distro Podman policy shape: container_var_lib_t for the
-    # graphroot and more specific labels for image storage and named volumes.
+    # The rootless Podman graphroot lives under the per-user root-disk location
+    # (~/.local/share/containers/storage). Persist the distro Podman file-context
+    # rules and restorecon so the store keeps correct labels across relabels,
+    # otherwise Podman can fail later with SELinux denials when reading/writing
+    # image and container storage. Match the distro Podman policy shape:
+    # container_var_lib_t for the graphroot and more specific labels for image
+    # storage and named volumes.
     - name: Persist SELinux context for Hermes rootless Podman graphroot
       community.general.sefcontext:
         target: "{{ hermes_podman_graphroot }}(/.*)?"
@@ -581,6 +668,37 @@
         or hermes_devenv_smoke_test.stdout_lines[0] != "igou"
         or hermes_devenv_smoke_test.stdout_lines[1] != "1000"
         or hermes_devenv_smoke_test.stdout_lines[2] != "1000"
+
+    # Bring the units we stopped for the one-time graphroot migration back up so a
+    # STANDALONE setup-os run leaves a healthy VM. Placed at play end so the new
+    # root-disk graphroot is already SELinux-labelled and the runtime image pulled.
+    # Skipped entirely on fresh/already-migrated VMs (old dir absent). The later
+    # configure play also restarts these idempotently in the full workflow.
+    - name: Restart the Hermes gateway user unit after graphroot migration
+      ansible.builtin.systemd:
+        name: hermes-gateway.service
+        state: restarted
+        scope: user
+      become: true
+      become_user: "{{ hermes_user }}"
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ hermes_uid }}"
+      when: hermes_old_graphroot_stat.stat.exists
+      failed_when: false
+
+    # Dashboard is auth-gated (fail-closed without creds), so it may legitimately be
+    # absent/inactive; failed_when:false keeps migration success independent of it.
+    - name: Restart the Hermes dashboard user unit after graphroot migration
+      ansible.builtin.systemd:
+        name: hermes-dashboard.service
+        state: restarted
+        scope: user
+      become: true
+      become_user: "{{ hermes_user }}"
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ hermes_uid }}"
+      when: hermes_old_graphroot_stat.stat.exists
+      failed_when: false
 
   handlers:
     - name: Clean DNF metadata

--- a/playbooks/hermes/setup-os.yml
+++ b/playbooks/hermes/setup-os.yml
@@ -644,10 +644,14 @@
     # clearly enough to assert the future runtime identity. Keep podman run here
     # so the smoke test proves whoami=igou under the planned keep-id mapping.
     # timeout keeps first-run ID-mapped layer preparation from hanging forever.
+    # 20m (not 10m): the first keep-id run cold-builds an ID-mapped copy of every
+    # layer of the multi-GB devenv image, and here it runs right after the graphroot
+    # migration's ~15G delete + fresh image pull — that IO contention pushed a cold
+    # map past 10m (measured ~4.5m unloaded). 20m gives margin for the loaded case.
     - name: Smoke test igou-devenv image with rootless Podman keep-id mapping
       ansible.builtin.command:
         cmd: >-
-          timeout --kill-after=30s 10m
+          timeout --kill-after=30s 20m
           podman run --rm
           --entrypoint /usr/bin/bash
           --userns=keep-id:uid=1000,gid=1000


### PR DESCRIPTION
## Why
An operator ran `configure.yml` with `hermes_terminal_backend_image_pre_pull=true` to update the terminal-backend image. The image-lifecycle block (`podman pull` → `podman run --rm` prewarm → `podman rmi -f` prune) runs as the `hermes` user on the **same rootless-podman graphroot** the live `hermes-gateway.service` is concurrently churning exec-sandbox containers on. Two independent podman processes doing concurrent overlayfs copy-up/rename on the same XFS dirs tripped a kernel `xfs_trans_cancel` in-memory-corruption shutdown of the **hermes-state PVC** (vdb). Every `~/.hermes` access then returned `EIO` while the systemd units still read `active`, so the job went green over a dead filesystem and it went unnoticed for days.

## Changes
1. **`configure.yml` — quiesce before image ops.** Stop the gateway + dashboard user units and drain running containers at the top of the image-lifecycle block, so image updates never race the live agent on the shared graphroot. Existing end-of-play restarts bring them back.

2. **`setup-os.yml` — relocate the graphroot off the state PVC.** Move the rootless-podman graphroot from `~/.hermes/containers/storage` (durable state PVC) to `~/.local/share/containers/storage` (root disk). Volatile container storage no longer shares a filesystem with the agent's irreplaceable state (config/memory/skills/venv), so a container-store fault can't take the agent's brain offline. Idempotent one-time migration (quiesce → reclaim the ~15G on-PVC store → re-pull) gated on the legacy layout; images are re-pullable (`backup.yml` already excludes the graphroot). Fresh and already-migrated VMs skip it.

3. **`configure.yml` — fail-loud health gates.** `meta: flush_handlers`, then assert: state mount is writable (rw probe), gateway is `active` (retry/until), and the kernel log has no `XFS (vdb): Shutting down` / `Corruption of in-memory data` signature during the run. Turns a future mid-run fault into a RED AAP job instead of a silent green.

## Validation
- `yamllint` + `ansible-lint --profile=production` + `--syntax-check` all clean on both playbooks.
- Idempotency reasoned through: migration fires only on the one-time old→new transition; health gates are `changed_when: false`.
- To be deployed + verified via AAP (`hermes_setup_os` JT 33 → `hermes_configure` JT 66) on the live `hermes` VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)