### PR TITLE
feat(devenv): write ~/.ssh/config in bootstrap post_tasks

### DIFF
--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -181,6 +181,29 @@
       when: host_prep_git_user_email | default('') | length > 0
 
     # ------------------------------------------------------------------
+    # Write the operator's ~/.ssh/config on the host user. Like the git identity
+    # above, this mirrors a david_igou.devhost.host_prep task (its "Write SSH
+    # config" step) that this play deliberately does not run, reading the same
+    # host_prep_ssh_config var from group_vars/devenv/ssh.yml. host_prep normally
+    # also creates ~/.ssh via host_prep_directories, so the dir is ensured here
+    # first (cloud-init may not have created it). Skipped when the var is empty.
+    # Bind-mounted into the devcontainer, so the container inherits it too.
+    # ------------------------------------------------------------------
+    - name: Ensure the host ~/.ssh directory exists
+      ansible.builtin.file:
+        path: "{{ ansible_user_dir }}/.ssh"
+        state: directory
+        mode: "0700"
+      when: host_prep_ssh_config | default('') | length > 0
+
+    - name: Write the host SSH config
+      ansible.builtin.copy:
+        content: "{{ host_prep_ssh_config }}"
+        dest: "{{ ansible_user_dir }}/.ssh/config"
+        mode: "0600"
+      when: host_prep_ssh_config | default('') | length > 0
+
+    # ------------------------------------------------------------------
     # Seed ~/workspace so the devcontainer's /workspace mirrors the operator's
     # physical devhost — a directory of ALL the working repos — instead of just
     # the igou-devenv clone. The canonical devcontainer.json ALREADY bind-mounts


### PR DESCRIPTION
## Summary

Adds an SSH-config step to `playbooks/devenv/bootstrap.yml` post_tasks so devenv VMs get `~/.ssh/config`.

The play deliberately does **not** run `david_igou.devhost.host_prep` (its repo-clone defaults fight the post_tasks workspace seeding), so host_prep's "Write SSH config" task never ran on devenv VMs and `~/.ssh/config` was left unconfigured. This mirrors it the same way the git identity is already mirrored:

- **Ensure the host `~/.ssh` directory exists** (`0700`) — host_prep normally creates it via `host_prep_directories`; this play doesn't, and cloud-init may not have.
- **Write the host SSH config** — `copy` of `host_prep_ssh_config` to `~/.ssh/config` (`0600`), skipped when the var is empty.

Bind-mounted into the devcontainer, so the container inherits it too.

## Validation

- `ansible-lint --profile=production playbooks/devenv/bootstrap.yml` → 0 failures.

## Companion PR

Content ships in https://github.com/igou-io/igou-inventory/pull/170 (adds `group_vars/devenv/ssh.yml` with `host_prep_ssh_config`). Merge together — this PR is a no-op until that var is set.

## Follow-up

Collection issue david-igou/ansible-collection-devhost#39 tracks removing the HTTPS→SSH rewrite from `host_prep`; once the collection is re-added to this play, this mirrored step can be dropped in favor of the role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyCgu5Tc64ytBZLeXpxA5g