### PR TITLE
fix(netboot): serve snponly UEFI flavor, pin iPXE ref, build on builder host

### DIFF
--- a/docs/netboot-operations.md
+++ b/docs/netboot-operations.md
@@ -292,8 +292,20 @@ ansible-playbook playbooks/openshift/add_node_iso.yml \
 
 The binaries' embedded autoexec ALSO has a hardcoded `:tftpmenu` per-host MAC/HOSTNAME chain against `${tftp-server}` (= rb5009) — this is what makes pinned-host routing work without a custom menu.ipxe.
 
+### UEFI x64 serves the `snponly` flavor
+
+For UEFI x64 the build emits and serves `netboot.xyz-snponly.efi` (renamed to the public `netboot.xyz.efi` on rb5009 — the DHCP boot-file-name and `/ip tftp` request name are unchanged), **not** the full-driver `ipxe.efi`. Since iPXE commit [`2161e976`](https://github.com/ipxe/ipxe/commit/2161e976cdf78d0b26687e14f2cdc14008a99c83) ("[build] Include USB drivers in the all-drivers build by default", 2026-02-13) the full-driver `.efi` attaches native USB host-controller drivers, which disconnect the less-compliant USB keyboard drivers of AMI/HP UEFI firmware — the keyboard goes dead in the iPXE menu. `snponly` carries no native drivers at all (it uses the firmware's SNP, always present on a PXE chainload), so the keyboard keeps working. See the netboot.xyz KB: <https://netboot.xyz/docs/kb/hardware/usb-keyboard>. The map that selects the local flavor per arch lives in `tasks/netboot_build.yml` (and is mirrored in `netboot_upload.yml` / `netboot_verify.yml` for standalone `--tags` runs).
+
+### iPXE revision is pinned
+
+Upstream netboot.xyz defaults `ipxe_branch: master`, so without a pin every rebuild floats on iPXE master-of-the-day regardless of the `netboot_xyz_ref` tag. The build pins iPXE via `netboot_ipxe_ref` in `igou-inventory/group_vars/routeros.yml` (a full commit SHA; rendered into `ipxe_branch` in `user_overrides.yml.j2`, which upstream checks out with `ansible.builtin.git version:`). To bump it, change `netboot_ipxe_ref` in inventory and re-run `--tags build,upload,verify` — the rendered override feeds the build-input hash, so a changed SHA automatically triggers a rebuild.
+
+### The build runs on a docker-capable builder host
+
+The build stage runs the netbootxyz builder container, so it needs a real container runtime. The AAP execution environment only ships podman-remote and cannot run a builder container on its own localhost, so the build runs over SSH on the `armbian_builders` host (docker required; `ansible_user` in the docker group, no become) — mirroring `playbooks/armbian/build_and_publish.yaml`. The built binaries are fetched back to the controller's `.cache/netboot-build/` and the upload/DHCP/verify stages run against rb5009 as before. This makes the playbook AAP-runnable via the `netboot_deploy_binaries` job template (added in igou-inventory).
+
 ```bash
-# Build, upload, wire DHCP, verify — full pipeline:
+# Build, upload, wire DHCP, verify — full pipeline (local fallback):
 ansible-playbook playbooks/routeros/deploy_netboot_binaries.yml \
   -i 'localhost ansible_connection=local,' \
   -i igou-inventory/inventory.yaml
@@ -305,7 +317,10 @@ ansible-playbook playbooks/routeros/deploy_netboot_binaries.yml \
   --tags build,upload,verify
 ```
 
+The build no longer runs on localhost: play 1 targets `armbian_builders` (override with `netboot_builders_group`) and the local `-i 'localhost ...'` entry only serves the rb5009 play's `delegate_to: localhost` tasks. Prefer the `netboot_deploy_binaries` AAP job template for routine runs; the local invocation above is the fallback.
+
 Rebuild when:
+- `netboot_ipxe_ref` is bumped (pinning iPXE to a newer/older revision).
 - `netboot_chainload_host` or `netboot_chainload_proto` changes (rare).
 - Upstream netboot.xyz publishes a security fix to the iPXE bundle.
 - A new arch is added.

--- a/docs/netboot-operations.md
+++ b/docs/netboot-operations.md
@@ -298,7 +298,7 @@ For UEFI x64 the build emits and serves `netboot.xyz-snponly.efi` (renamed to th
 
 ### iPXE revision is pinned
 
-Upstream netboot.xyz defaults `ipxe_branch: master`, so without a pin every rebuild floats on iPXE master-of-the-day regardless of the `netboot_xyz_ref` tag. The build pins iPXE via `netboot_ipxe_ref` in `igou-inventory/group_vars/routeros.yml` (a full commit SHA; rendered into `ipxe_branch` in `user_overrides.yml.j2`, which upstream checks out with `ansible.builtin.git version:`). To bump it, change `netboot_ipxe_ref` in inventory and re-run `--tags build,upload,verify` — the rendered override feeds the build-input hash, so a changed SHA automatically triggers a rebuild.
+Upstream netboot.xyz defaults `ipxe_branch: master`, so without a pin every rebuild floats on iPXE master-of-the-day regardless of the `netboot_xyz_ref` tag. The build pins iPXE via `netboot_ipxe_ref` in `igou-inventory/group_vars/all/netboot.yml` — the `netboot_*` build vars live at the `all` scope (not `group_vars/routeros.yml`) because the build play runs on the `armbian_builders` host, which is outside the routeros group. It's a full commit SHA, rendered into `ipxe_branch` in `user_overrides.yml.j2`, which upstream checks out with `ansible.builtin.git version:`. To bump it, change `netboot_ipxe_ref` in inventory and re-run `--tags build,upload,verify` — the rendered override feeds the build-input hash, so a changed SHA automatically triggers a rebuild.
 
 ### The build runs on a docker-capable builder host
 

--- a/playbooks/routeros/deploy_netboot_binaries.yml
+++ b/playbooks/routeros/deploy_netboot_binaries.yml
@@ -28,6 +28,9 @@
 # mirroring playbooks/armbian/build_and_publish.yaml. The last task in
 # netboot_build.yml fetches the artifacts back to the controller so the
 # rb5009 play (below) can upload them.
+# The netboot_* build vars come from igou-inventory group_vars/all/netboot.yml:
+# the builder host is outside the routeros group, so group_vars/routeros.yml
+# would be invisible here.
 - name: Build custom netboot.xyz iPXE binaries on the builder host
   hosts: "{{ netboot_builders_group | default('armbian_builders') }}"
   # gather_facts required: netboot_build.yml resolves the build dir from

--- a/playbooks/routeros/deploy_netboot_binaries.yml
+++ b/playbooks/routeros/deploy_netboot_binaries.yml
@@ -1,11 +1,13 @@
 ---
-# Build custom netboot.xyz iPXE binaries on the control node, ship them
-# to the rb5009 for TFTP serving, and wire RouterOS DHCP so PXE clients
-# land on the binaries (which then chainload to the existing TrueNAS
-# netbootxyz container at tftp://10.10.45.242/menu.ipxe).
+# Build custom netboot.xyz iPXE binaries on a docker-capable builder
+# host, ship them to the rb5009 for TFTP serving, and wire RouterOS DHCP
+# so PXE clients land on the binaries (which then chainload to the
+# public nginx netboot.xyz menu at https://public.igou.systems/boot-files/menu.ipxe).
 #
 # Stages (each backed by a tag):
-#   build   -- podman run nbxyz/builder against our user_overrides.yml
+#   build   -- run the nbxyz builder container ON a builder host against
+#              our user_overrides.yml, then fetch the artifacts back to
+#              the controller's build cache
 #   upload  -- net_put binaries to flash:/netboot/, register /ip tftp
 #   dhcp    -- /ip dhcp-server network/option/option-set/matcher
 #   verify  -- TFTP fetch checks + DHCP state assertion
@@ -18,21 +20,43 @@
 # follow the manual cleanup steps in:
 #   playbooks/routeros/files/netboot/cleanup-old-container.md
 
-- name: Build and deploy custom netboot.xyz iPXE binaries
-  hosts: "{{ host | default('rb5009.igou.systems') }}"
-  gather_facts: false
-  serial: 1
-  # Play-level connection: local serves as the fallback for delegate_to
-  # localhost tasks (stat, render). rb5009 has its own ansible_connection
-  # in group_vars/routeros.yml so its tasks still use network_cli.
-  # Inventory's localhost entry has no explicit connection so it would
-  # otherwise default to ssh, which fails in the claude-run container.
-  connection: local
+# --- Play 1: build on a docker-capable builder host -------------------------
+# The build stage runs a builder container, so it needs a real container
+# runtime. The AAP execution environment only has podman-remote, so the
+# build cannot run on the EE localhost; it runs on the armbian_builders
+# host (docker-capable, ansible_user in the docker group, no become),
+# mirroring playbooks/armbian/build_and_publish.yaml. The last task in
+# netboot_build.yml fetches the artifacts back to the controller so the
+# rb5009 play (below) can upload them.
+- name: Build custom netboot.xyz iPXE binaries on the builder host
+  hosts: "{{ netboot_builders_group | default('armbian_builders') }}"
+  # gather_facts required: netboot_build.yml resolves the build dir from
+  # ansible_env.HOME and stamps the MANIFEST with ansible_date_time.
+  gather_facts: true
   tasks:
 
     - name: Build stage
       ansible.builtin.import_tasks: tasks/netboot_build.yml
       tags: [build]
+
+# --- Play 2: upload / DHCP / verify against rb5009 --------------------------
+# netboot_arches_resolved is a per-host fact set on the builder in play 1;
+# it is NOT visible here (different host), so the upload and verify stages
+# recompute it from the static arches map via their
+# `when: netboot_arches_resolved is not defined` guards. This is also what
+# makes `--tags upload` (or `--tags verify`) work as a standalone run.
+- name: Deploy custom netboot.xyz iPXE binaries to rb5009
+  hosts: "{{ host | default('rb5009.igou.systems') }}"
+  gather_facts: false
+  serial: 1
+  # Play-level connection: local serves as the fallback for delegate_to
+  # localhost tasks (stat, render, TFTP fetch). rb5009 has its own
+  # ansible_connection in group_vars/routeros.yml so its tasks still use
+  # network_cli. Inventory's localhost entry has no explicit connection
+  # so it would otherwise default to ssh, which fails in the claude-run
+  # container.
+  connection: local
+  tasks:
 
     - name: Upload stage
       ansible.builtin.import_tasks: tasks/netboot_upload.yml

--- a/playbooks/routeros/tasks/netboot_build.yml
+++ b/playbooks/routeros/tasks/netboot_build.yml
@@ -1,15 +1,34 @@
 ---
-# Build the custom netboot.xyz iPXE binaries on the control node by
-# invoking the upstream Ansible build inside the official netbootxyz
-# builder container.
+# Build the custom netboot.xyz iPXE binaries by invoking the upstream
+# Ansible build inside the official netbootxyz builder container.
 #
-# Sets fact netboot_arches_resolved -- used by upload, dhcp, and verify
-# stages.
+# These tasks run ON the builder host (the armbian_builders group, a
+# docker-capable machine) — NOT on the controller. The AAP execution
+# environment only ships podman-remote, so it cannot run a builder
+# container on its own localhost; delegating the heavy lifting to a
+# real docker host over SSH is what makes this playbook AAP-runnable
+# (mirrors playbooks/armbian/build_and_publish.yaml).
+#
+# Sets fact netboot_arches_resolved -- consumed by the fetch at the end
+# of this file (to pull artifacts back to the controller). The upload,
+# dhcp, and verify stages run in the second play against rb5009, where
+# this fact is not visible; those stages recompute it from the static
+# arches map (see their `when: netboot_arches_resolved is not defined`
+# guards).
 #
 # Idempotency: a SHA256 of the rendered user_overrides plus the resolved
 # git SHA of the cloned netboot.xyz repo is recorded in MANIFEST.lastbuild
 # after each successful run. On re-run, if the hash matches AND every
-# expected output binary exists, the podman build is skipped.
+# expected output binary exists, the container build is skipped. The
+# MANIFEST lives on the builder host and persists across runs.
+
+- name: Resolve the builder-side build directory
+  # All build inputs/outputs live under the builder host's home by
+  # default (no become, no one-time sudo). Override with
+  # netboot_builder_build_dir to relocate.
+  ansible.builtin.set_fact:
+    _netboot_build_dir: >-
+      {{ netboot_builder_build_dir | default(ansible_env.HOME ~ '/netboot_build') }}
 
 - name: Define arches map (local -> public file names)
   ansible.builtin.set_fact:
@@ -18,7 +37,19 @@
         local_name: netboot.xyz.kpxe
         public_name: netboot.xyz.kpxe
       uefi-x64:
-        local_name: netboot.xyz.efi
+        # Serve the snponly flavor for UEFI x64, NOT the full-driver
+        # ipxe.efi. Since iPXE commit 2161e976 ("[build] Include USB
+        # drivers in the all-drivers build by default", 2026-02-13) the
+        # full-driver .efi attaches native USB host-controller drivers,
+        # which disconnect less-compliant AMI/HP UEFI firmware USB
+        # keyboard drivers -> a dead keyboard in the iPXE menu. snponly
+        # carries no native drivers (uses firmware SNP, always present
+        # on a PXE chainload), so the keyboard keeps working.
+        # See https://netboot.xyz/docs/kb/hardware/usb-keyboard
+        local_name: netboot.xyz-snponly.efi
+        # public_name stays netboot.xyz.efi: the DHCP boot-file-name,
+        # /ip tftp rows, and UEFI matchers are all keyed on this name
+        # and must not change.
         public_name: netboot.xyz.efi
       uefi-arm64:
         local_name: netboot.xyz-arm64.efi
@@ -32,64 +63,64 @@
                        | list
       }}
 
-- name: Ensure local build cache directory exists
+- name: Ensure builder build cache directory exists
   ansible.builtin.file:
-    path: "{{ netboot_local_build_dir }}"
+    path: "{{ _netboot_build_dir }}"
     state: directory
     mode: "0755"
-  delegate_to: localhost
 
-- name: Ensure local build output directory exists
+- name: Ensure builder build output directory exists
   ansible.builtin.file:
-    path: "{{ netboot_local_build_dir }}/output"
+    path: "{{ _netboot_build_dir }}/output"
     state: directory
     mode: "0755"
-  delegate_to: localhost
 
 - name: Clone or update netboot.xyz source at the pinned ref
   ansible.builtin.git:
     repo: "{{ netboot_xyz_repo }}"
-    dest: "{{ netboot_local_build_dir }}/src"
+    dest: "{{ _netboot_build_dir }}/src"
     version: "{{ netboot_xyz_ref }}"
     force: true
-  delegate_to: localhost
   environment:
-    # Bypass any host-level url rewrites in ~/.gitconfig (e.g.,
-    # `insteadOf = https://github.com/`). The clone is anonymous HTTPS
-    # against a public repo, so no creds are needed.
+    # Bypass any host-level url rewrites in the builder's ~/.gitconfig
+    # (e.g., `insteadOf = https://github.com/`). The clone is anonymous
+    # HTTPS against a public repo, so no creds are needed.
     GIT_CONFIG_GLOBAL: /dev/null
   register: _netboot_git
 
 - name: Render user_overrides.yml into the source clone
   ansible.builtin.template:
     src: "{{ playbook_dir }}/templates/netboot/user_overrides.yml.j2"
-    dest: "{{ netboot_local_build_dir }}/src/user_overrides.yml"
+    dest: "{{ _netboot_build_dir }}/src/user_overrides.yml"
     mode: "0644"
-  delegate_to: localhost
   register: _netboot_template
+
+- name: Read the rendered user_overrides back for hashing
+  # The build-input hash covers the rendered overrides + git SHA. The
+  # rendered file lives on the builder, so slurp it back rather than
+  # using lookup('file') (which only reads the controller filesystem).
+  ansible.builtin.slurp:
+    src: "{{ _netboot_build_dir }}/src/user_overrides.yml"
+  register: _netboot_overrides_slurp
 
 - name: Compute a build-input hash (rendered overrides + git SHA)
   ansible.builtin.set_fact:
     _netboot_build_hash: >-
       {{
-        (lookup('ansible.builtin.file',
-                netboot_local_build_dir ~ '/src/user_overrides.yml')
+        ((_netboot_overrides_slurp.content | b64decode)
          ~ _netboot_git.after) | hash('sha256')
       }}
-  delegate_to: localhost
 
 - name: Read prior build hash if present
   ansible.builtin.slurp:
-    src: "{{ netboot_local_build_dir }}/MANIFEST.lastbuild"
+    src: "{{ _netboot_build_dir }}/MANIFEST.lastbuild"
   register: _netboot_lastbuild
-  delegate_to: localhost
   failed_when: false
   changed_when: false
 
 - name: Stat each expected output binary
   ansible.builtin.stat:
-    path: "{{ netboot_local_build_dir }}/output/ipxe/{{ item.local_name }}"
-  delegate_to: localhost
+    path: "{{ _netboot_build_dir }}/output/ipxe/{{ item.local_name }}"
   loop: "{{ netboot_arches_resolved }}"
   loop_control:
     label: "{{ item.public_name }}"
@@ -107,24 +138,26 @@
       }}
 
 - name: Run the netboot.xyz builder container  # noqa: command-instead-of-module
+  # netboot_container_runtime defaults to docker (the builder host is a
+  # real docker host). docker accepts --pull=always and ignores the :Z
+  # SELinux relabel suffix on non-SELinux hosts, so the same command
+  # works whether the runtime is docker or podman.
   ansible.builtin.command:
     cmd: >-
-      podman run --rm
+      {{ netboot_container_runtime | default('docker') }} run --rm
       --pull=always
-      -v {{ netboot_local_build_dir }}/src:/ansible:Z
-      -v {{ netboot_local_build_dir }}/output:/var/www/html:Z
+      -v {{ _netboot_build_dir }}/src:/ansible:Z
+      -v {{ _netboot_build_dir }}/output:/var/www/html:Z
       --workdir /ansible
       {{ netboot_builder_image }}
       ansible-playbook site.yml
   when: _netboot_need_build
-  delegate_to: localhost
   changed_when: true
   register: _netboot_build_run
 
 - name: Re-stat each expected output binary after build
   ansible.builtin.stat:
-    path: "{{ netboot_local_build_dir }}/output/ipxe/{{ item.local_name }}"
-  delegate_to: localhost
+    path: "{{ _netboot_build_dir }}/output/ipxe/{{ item.local_name }}"
   loop: "{{ netboot_arches_resolved }}"
   loop_control:
     label: "{{ item.public_name }}"
@@ -136,7 +169,7 @@
       - item.stat.exists
     fail_msg: >-
       Expected output binary
-      {{ netboot_local_build_dir }}/output/ipxe/{{ item.item.local_name }}
+      {{ _netboot_build_dir }}/output/ipxe/{{ item.item.local_name }}
       is missing after the build step. Check the builder container's
       ansible-playbook output (the prior task) for errors.
   loop: "{{ _netboot_output_stat_post.results }}"
@@ -145,15 +178,14 @@
 
 - name: Persist build hash for next run
   ansible.builtin.copy:
-    dest: "{{ netboot_local_build_dir }}/MANIFEST.lastbuild"
+    dest: "{{ _netboot_build_dir }}/MANIFEST.lastbuild"
     content: "{{ _netboot_build_hash }}"
     mode: "0644"
-  delegate_to: localhost
   when: _netboot_need_build
 
 - name: Write human-readable MANIFEST
   ansible.builtin.copy:
-    dest: "{{ netboot_local_build_dir }}/MANIFEST"
+    dest: "{{ _netboot_build_dir }}/MANIFEST"
     mode: "0644"
     content: |
       ref: {{ netboot_xyz_ref }}
@@ -163,5 +195,18 @@
       {% for item in netboot_arches_resolved %}
         - ipxe/{{ item.local_name }}
       {% endfor %}
-  delegate_to: localhost
   when: _netboot_need_build
+
+# Pull the freshly built binaries from the builder back to the
+# controller's build cache, where the upload/verify stages (second play,
+# against rb5009) expect them. Always fetch: it is cheap (~3 MB total)
+# and keeps the controller cache in lockstep with the builder even when
+# the container build itself was skipped by the hash gate.
+- name: Fetch built binaries from the builder to the controller cache
+  ansible.builtin.fetch:
+    src: "{{ _netboot_build_dir }}/output/ipxe/{{ item.local_name }}"
+    dest: "{{ netboot_local_build_dir }}/output/ipxe/{{ item.local_name }}"
+    flat: true
+  loop: "{{ netboot_arches_resolved }}"
+  loop_control:
+    label: "{{ item.public_name }}"

--- a/playbooks/routeros/tasks/netboot_upload.yml
+++ b/playbooks/routeros/tasks/netboot_upload.yml
@@ -14,7 +14,13 @@
         local_name: netboot.xyz.kpxe
         public_name: netboot.xyz.kpxe
       uefi-x64:
-        local_name: netboot.xyz.efi
+        # snponly flavor: the full-driver ipxe.efi attaches native USB
+        # host-controller drivers (iPXE 2161e976) that kill USB keyboards
+        # on AMI-based UEFI firmware; snponly carries no native drivers.
+        # public_name stays netboot.xyz.efi (DHCP boot-file-name, /ip
+        # tftp rows, and matchers are keyed on it). Must match the map in
+        # tasks/netboot_build.yml.
+        local_name: netboot.xyz-snponly.efi
         public_name: netboot.xyz.efi
       uefi-arm64:
         local_name: netboot.xyz-arm64.efi

--- a/playbooks/routeros/tasks/netboot_verify.yml
+++ b/playbooks/routeros/tasks/netboot_verify.yml
@@ -13,7 +13,14 @@
         local_name: netboot.xyz.kpxe
         public_name: netboot.xyz.kpxe
       uefi-x64:
-        local_name: netboot.xyz.efi
+        # snponly flavor: the full-driver ipxe.efi attaches native USB
+        # host-controller drivers (iPXE 2161e976) that kill USB keyboards
+        # on AMI-based UEFI firmware; snponly carries no native drivers.
+        # local_name drives the controller-side size compare below, so it
+        # must match the fetched artifact name. public_name (the TFTP
+        # request name) stays netboot.xyz.efi. Must match the map in
+        # tasks/netboot_build.yml.
+        local_name: netboot.xyz-snponly.efi
         public_name: netboot.xyz.efi
       uefi-arm64:
         local_name: netboot.xyz-arm64.efi

--- a/playbooks/routeros/templates/netboot/user_overrides.yml.j2
+++ b/playbooks/routeros/templates/netboot/user_overrides.yml.j2
@@ -13,6 +13,15 @@
 # Documentation of every key:
 #   https://github.com/netbootxyz/netboot.xyz/blob/master/user_overrides.yml
 
+# Pin the iPXE source revision. Upstream defaults ipxe_branch to
+# `master` (floating), so every rebuild silently tracks iPXE
+# master-of-the-day regardless of the netboot_xyz_ref tag pinned above.
+# We pin a full commit SHA; upstream checks it out with ansible.builtin.git
+# `version:`, which accepts a SHA. Bumping netboot_ipxe_ref changes this
+# rendered file, which feeds the build-input hash in netboot_build.yml,
+# so a bump automatically triggers a rebuild.
+ipxe_branch: "{{ netboot_ipxe_ref }}"
+
 boot_domain: "{{ netboot_chainload_host }}"
 bootloader_default: "{{ netboot_chainload_proto }}"
 site_name: "igou homelab"

--- a/playbooks/routeros/templates/netboot/user_overrides.yml.j2
+++ b/playbooks/routeros/templates/netboot/user_overrides.yml.j2
@@ -1,6 +1,8 @@
 ---
 # Rendered by playbooks/routeros/tasks/netboot_build.yml from
-# group_vars/routeros.yml at build time. This file is mounted into the
+# group_vars/all/netboot.yml (the `all` scope: the build play runs on the
+# armbian_builders host, outside the routeros group) at build time. This
+# file is mounted into the
 # netboot.xyz builder container at /ansible/user_overrides.yml and
 # consumed by the upstream site.yml -> netbootxyz role.
 #


### PR DESCRIPTION
## Summary

Three related fixes to the custom netboot.xyz iPXE binary pipeline (`playbooks/routeros/deploy_netboot_binaries.yml`), which builds the iPXE binaries served over TFTP from rb5009.

### 1. UEFI x64 serves the `snponly` flavor (dead USB keyboard fix)

**Root cause:** the deployed uefi-x64 binary was the full-driver `ipxe.efi`. Since iPXE commit [`2161e976`](https://github.com/ipxe/ipxe/commit/2161e976cdf78d0b26687e14f2cdc14008a99c83) ("[build] Include USB drivers in the all-drivers build by default", 2026-02-13) that flavor attaches native USB host-controller drivers, which disconnect the less-compliant USB keyboard drivers of AMI/HP UEFI firmware — the keyboard goes dead in the iPXE menu (netboot.xyz KB: <https://netboot.xyz/docs/kb/hardware/usb-keyboard>).

**Fix:** serve `netboot.xyz-snponly.efi` (already emitted by the 2.0.84 build). snponly carries no native drivers at all — it uses the firmware SNP, always present on a PXE chainload — so the keyboard keeps working. `public_name` stays `netboot.xyz.efi`, so the DHCP boot-file-name, `/ip tftp` rows, and UEFI option-93 matchers are all unchanged. The arches map was updated in all three copies (`netboot_build.yml`, `netboot_upload.yml`, `netboot_verify.yml`) so standalone `--tags upload` / `--tags verify` stay consistent.

### 2. Pin the iPXE source revision (reproducible builds)

**Root cause:** upstream netboot.xyz defaults `ipxe_branch: master`, so every rebuild floated on iPXE master-of-the-day regardless of the pinned `netboot_xyz_ref` tag.

**Fix:** render `ipxe_branch: "{{ netboot_ipxe_ref }}"` into `user_overrides.yml` (upstream checks it out with `ansible.builtin.git version:`, which accepts a full commit SHA). Because the rendered override feeds the build-input hash, bumping `netboot_ipxe_ref` automatically triggers a rebuild. The inventory var is added in the paired igou-inventory PR with the iPXE master HEAD of the currently-deployed, network-proven 2026-05-11 binaries.

### 3. Build on a docker-capable builder host (AAP-runnable)

**Root cause:** the AAP EE (`igou-awx-ee`) ships only podman-remote, so the build stage (which runs a builder container) cannot run on the EE localhost.

**Fix:** split the playbook into two plays. Play 1 runs the build over SSH on the `armbian_builders` host (docker required, `ansible_user` in the docker group, no become — mirroring `playbooks/armbian/build_and_publish.yaml`) and fetches the ~3 MB of artifacts back to the controller's `.cache/netboot-build/`. Play 2 uploads / wires DHCP / verifies against rb5009 as before. All stage tags (`build`, `upload`, `dhcp`, `verify`) are preserved, so `--tags build,upload,verify` etc. keep working. `netboot_arches_resolved` is a per-host fact set on the builder in play 1 and is not visible to the rb5009 play, so the existing `when: netboot_arches_resolved is not defined` recompute guards in the upload/verify stages fire — which is also what makes standalone `--tags upload` work.

## Files changed

- `playbooks/routeros/deploy_netboot_binaries.yml` — split into build (armbian_builders) + rb5009 plays.
- `playbooks/routeros/tasks/netboot_build.yml` — runs on the builder host; builder-side build dir, container runtime var (`docker` default), slurp-based build-input hash (`lookup('file')` can't read the builder), fetch artifacts back to controller; snponly in the arches map.
- `playbooks/routeros/tasks/netboot_upload.yml` — snponly `local_name` in the recompute map.
- `playbooks/routeros/tasks/netboot_verify.yml` — snponly `local_name` in the recompute map (drives the controller-side size compare).
- `playbooks/routeros/templates/netboot/user_overrides.yml.j2` — `ipxe_branch: "{{ netboot_ipxe_ref }}"` pin.
- `docs/netboot-operations.md` — "rb5009: refresh iPXE binaries" section rewritten (snponly rationale, iPXE pin/bump, builder-host / AAP job template, local fallback).

## Validation

- `ansible-lint --profile=production playbooks/routeros/` — clean (0 failures/warnings, 20 files).
- `yamllint playbooks/routeros/` — clean.
- `ansible-playbook ... --syntax-check` — passes.
- grep confirms no stale `local_name: netboot.xyz.efi` for uefi-x64 remains.

## Pairing

Pairs with an igou-inventory PR adding `netboot_ipxe_ref` (the iPXE commit SHA) and the `netboot_deploy_binaries` AAP job template. **Merge the inventory PR first** — `netboot_ipxe_ref` is required to render `user_overrides.yml` at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129BBzeQt3MKZLdxGfxnnJD