### PR TITLE
fix(netboot): verify stage TFTP fetch via bundled python client (EE curl-minimal has no tftp)

### DIFF
--- a/playbooks/routeros/files/tftp_get.py
+++ b/playbooks/routeros/files/tftp_get.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Minimal RFC 1350 TFTP read client (octet mode, 512-byte blocks).
+
+Replaces ``curl tftp://...`` in the netboot verify stage: the igou-awx-ee
+execution environment and this repo's devcontainer both ship curl-minimal,
+which is built without TFTP protocol support (curl exits 1 instantly with
+CURLE_UNSUPPORTED_PROTOCOL), so the e2e TFTP check could never pass from
+AAP. stdlib only; no options negotiation (blksize etc.) -- servers fall
+back to plain 512-byte blocks per the RFC.
+
+Usage: tftp_get.py <host>[/<path-prefix>] <filename> <dest>
+
+The optional /<path-prefix> on the host argument mirrors how the verify
+tasks derive the server from vars like netboot_chainload_host
+("host/prefix"): the prefix is prepended to the requested filename.
+"""
+
+import socket
+import struct
+import sys
+
+RRQ_RETRIES = 3
+TIMEOUT_S = 5.0
+BLOCK_SIZE = 512
+
+
+def die(msg):
+    print("tftp_get: " + msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) != 4:
+        die("usage: tftp_get.py <host>[/<prefix>] <filename> <dest>")
+    host, _, prefix = sys.argv[1].partition("/")
+    filename = prefix + "/" + sys.argv[2] if prefix else sys.argv[2]
+    dest = sys.argv[3]
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(TIMEOUT_S)
+    rrq = struct.pack("!H", 1) + filename.encode() + b"\0octet\0"
+
+    # UDP can drop the first packet; retry the initial RRQ a few times.
+    data = addr = None
+    for _ in range(RRQ_RETRIES):
+        sock.sendto(rrq, (host, 69))
+        try:
+            data, addr = sock.recvfrom(4 + BLOCK_SIZE)
+            break
+        except socket.timeout:
+            continue
+    if data is None:
+        die("no response from %s:69 for %s after %d RRQ attempts"
+            % (host, filename, RRQ_RETRIES))
+
+    expected = 1
+    with open(dest, "wb") as out:
+        while True:
+            opcode, block = struct.unpack("!HH", data[:4])
+            if opcode == 5:  # ERROR
+                detail = data[4:].rstrip(b"\0").decode(errors="replace")
+                die("server error %d fetching %s: %s" % (block, filename, detail))
+            if opcode != 3:  # not DATA
+                die("unexpected opcode %d fetching %s" % (opcode, filename))
+            if block == expected:
+                out.write(data[4:])
+                expected += 1
+            # ACK every DATA (including duplicates, whose ACK may have
+            # been lost); transfer ends on a short final block.
+            sock.sendto(struct.pack("!HH", 4, block), addr)
+            if block == expected - 1 and len(data) - 4 < BLOCK_SIZE:
+                break
+            try:
+                data, addr = sock.recvfrom(4 + BLOCK_SIZE)
+            except socket.timeout:
+                die("timed out mid-transfer fetching %s (waiting for block %d)"
+                    % (filename, expected))
+
+
+if __name__ == "__main__":
+    main()

--- a/playbooks/routeros/tasks/netboot_verify.yml
+++ b/playbooks/routeros/tasks/netboot_verify.yml
@@ -51,12 +51,20 @@
     mode: "0755"
   delegate_to: localhost
 
-- name: Fetch each binary from rb5009 over TFTP  # noqa: command-instead-of-module
+# TFTP fetches use the bundled files/tftp_get.py, not curl: the
+# igou-awx-ee execution environment and the devcontainer both ship
+# curl-minimal, which is built without TFTP protocol support (curl
+# exits 1 instantly with CURLE_UNSUPPORTED_PROTOCOL), so a curl-based
+# check can never pass from AAP. The script is a self-contained
+# stdlib RFC 1350 client (octet mode, 512-byte blocks).
+
+- name: Fetch each binary from rb5009 over TFTP
   ansible.builtin.command:
     cmd: >-
-      curl -sf
-      -o {{ netboot_local_build_dir }}/verify/{{ item.public_name }}
-      tftp://{{ netboot_subnets[0].rb5009_ip }}/{{ item.public_name }}
+      python3 {{ playbook_dir }}/files/tftp_get.py
+      {{ netboot_subnets[0].rb5009_ip }}
+      {{ item.public_name }}
+      {{ netboot_local_build_dir }}/verify/{{ item.public_name }}
   delegate_to: localhost
   changed_when: false
   loop: "{{ netboot_arches_resolved }}"
@@ -85,12 +93,13 @@
   loop_control:
     label: "{{ item.0.item.public_name }}"
 
-- name: Fetch menu.ipxe redirect from rb5009 over TFTP  # noqa: command-instead-of-module
+- name: Fetch menu.ipxe redirect from rb5009 over TFTP
   ansible.builtin.command:
     cmd: >-
-      curl -sf
-      -o {{ netboot_local_build_dir }}/verify/menu-redirect.ipxe
-      tftp://{{ netboot_subnets[0].rb5009_ip }}/menu.ipxe
+      python3 {{ playbook_dir }}/files/tftp_get.py
+      {{ netboot_subnets[0].rb5009_ip }}
+      menu.ipxe
+      {{ netboot_local_build_dir }}/verify/menu-redirect.ipxe
   delegate_to: localhost
   changed_when: false
 
@@ -110,12 +119,16 @@
       doesn't chain to tftp://{{ netboot_chainload_host }}/menu.ipxe.
       Re-run --tags upload to refresh the redirect file.
 
-- name: Fetch menu.ipxe from TrueNAS netbootxyz over TFTP  # noqa: command-instead-of-module
+- name: Fetch menu.ipxe from TrueNAS netbootxyz over TFTP
+  # netboot_chainload_host may carry a path prefix ("host/prefix");
+  # tftp_get.py splits it and prepends the prefix to the filename,
+  # matching curl's tftp://host/prefix/menu.ipxe semantics.
   ansible.builtin.command:
     cmd: >-
-      curl -sf
-      -o {{ netboot_local_build_dir }}/verify/menu.ipxe
-      tftp://{{ netboot_chainload_host }}/menu.ipxe
+      python3 {{ playbook_dir }}/files/tftp_get.py
+      {{ netboot_chainload_host }}
+      menu.ipxe
+      {{ netboot_local_build_dir }}/verify/menu.ipxe
   delegate_to: localhost
   changed_when: false
 


### PR DESCRIPTION
## Summary

Follow-up to #393. The AAP rollout (job 458) succeeded through the **build**, **upload**, and **dhcp** stages — the snponly binary is live on rb5009, verified out-of-band — but the **verify** stage failed on its very first TFTP check.

**Root cause:** `playbooks/routeros/tasks/netboot_verify.yml` shelled out to `curl -sf -o ... tftp://<router>/<name>` for the e2e TFTP fetches. The igou-awx-ee execution environment (and this repo's devcontainer) ship **curl-minimal**, which is built without TFTP protocol support: curl exits 1 in ~5 ms with an empty stderr (`CURLE_UNSUPPORTED_PROTOCOL`). The e2e TFTP check can therefore never pass from AAP, regardless of network reachability.

**Fix:** replace the curl dependency with a small self-contained TFTP client shipped with the playbook.

## Changes

- **`playbooks/routeros/files/tftp_get.py`** (new) — minimal RFC 1350 read client: octet mode, 512-byte blocks, stdlib only (`socket`/`struct`/`sys`), 5 s socket timeout with a retried initial RRQ (UDP can drop the first packet), exit 0 on success and non-zero with a clear stderr message on a TFTP ERROR packet or timeout. No options negotiation (blksize etc.) — servers fall back to plain 512-byte blocks per the RFC. The host argument accepts an optional `/path-prefix` (`host/prefix`), mirroring curl's `tftp://host/prefix/file` semantics for `netboot_chainload_host`.
- **`playbooks/routeros/tasks/netboot_verify.yml`** — all three TFTP fetch tasks (per-arch binaries loop, rb5009 `menu.ipxe` redirect, chainload-host `menu.ipxe`) now invoke `python3 {{ playbook_dir }}/files/tftp_get.py ...` instead of curl. The server-address derivation (`netboot_subnets[0].rb5009_ip`, `netboot_chainload_host`) is unchanged — only the transport tool is swapped. Download-dir layout and the subsequent size/sha256 compare and assert tasks are untouched. Task comment explains why curl is unusable.

No docs change needed: `docs/netboot-operations.md` has no curl-tftp invocations (its curl examples are all HTTPS probes).

## Validation

- **Live TFTP test against the router (from the devcontainer):** `python3 playbooks/routeros/files/tftp_get.py 10.10.9.1 netboot.xyz.efi ...` → 305152 bytes, sha256 `c9532d9a1ac54544213ab58f3d49586b114a67ac05c01a6162516bdbd00dac63` — exactly the deployed snponly binary, fetched in ~0.2 s.
- `ansible-lint --profile=production playbooks/routeros/` — clean (0 failures/warnings).
- `yamllint playbooks/routeros/` — clean.
- `ansible-playbook playbooks/routeros/deploy_netboot_binaries.yml ... --syntax-check` — passes.

After merge, re-running the `netboot_deploy_binaries` job template with `--tags verify` (or a full run) should complete the previously failing stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129BBzeQt3MKZLdxGfxnnJD