### PR TITLE
fix(netboot): menu.ipxe passes through when a pin requested local boot

### DIFF
--- a/docs/netboot-operations.md
+++ b/docs/netboot-operations.md
@@ -173,6 +173,10 @@ Pin fragments may use Jinja `{{ '{{' }} netboot_public_url {{ '}}' }}` because A
 
 After any change: `--tags render,push,verify`. Push writes the pin file to `flash:/netboot/per-host/MAC-<hex>.ipxe` on rb5009 and creates a `/ip tftp` row mapping `MAC-<hex>.ipxe` → that flash path. Stale pins (entries removed from inventory) are pruned from both `flash:/netboot/per-host/` and `/ip tftp`.
 
+### Pins that boot from local disk: the `pin_local_exit` sentinel
+
+A pin cannot exit straight to firmware: the binary's embedded `:tftpmenu` autoexec chains the fallback `menu.ipxe` **unconditionally** after the MAC pin returns — a pin's `exit 1` returns to the autoexec ladder, not to the firmware. Without countermeasures, a pinned host choosing local boot therefore transits the generic fallback menu (and its 30-second default timeout) before the firmware finally boots the disk. The fix is a sentinel: iPXE variables persist across chains within a boot session, so a pin's local-boot path sets `set pin_local_exit 1` before its `exit`, and the rendered `menu.ipxe` checks `isset ${pin_local_exit}` at the top of `:start` and exits immediately — each retry in the autoexec's `:menu` ladder hits the same check (sub-second on LAN) until the binary's `:localboot` exit hands control to firmware. The generic menu never appears. Pin fragments that want a clean local boot must set the sentinel (see `netboot_host_pins` in igou-inventory); rollout is `deploy_assets.yml --tags render,push,verify` (the `netboot_deploy_assets` job template) — no binary rebuild needed.
+
 ---
 
 ## Adding a hand-written `.ipxe` fragment

--- a/playbooks/netboot/templates/menu.ipxe.j2
+++ b/playbooks/netboot/templates/menu.ipxe.j2
@@ -8,8 +8,19 @@
 ### Choices are deliberately minimal -- pinned hosts should be the norm;
 ### this menu is for one-off interactive selection on the rare host
 ### that boots without a pin.
+###
+### pin_local_exit sentinel contract (with netboot_host_pins in
+### igou-inventory): the binary's autoexec chains this menu
+### UNCONDITIONALLY after a pin returns -- a pin's `exit 1` returns to
+### the autoexec's :tftpmenu ladder, never straight to firmware. iPXE
+### variables persist across chains within a boot session, so a pin's
+### :local path sets `set pin_local_exit 1` before exiting; the check
+### below then exits this menu instantly (and every retry of it in the
+### autoexec's :menu ladder) so the host lands on the binary's
+### :localboot exit to firmware without showing the generic 30s menu.
 
 :start
+isset ${pin_local_exit} && echo Pin requested local boot -- passing through to firmware ... && exit 0 ||
 menu netboot.igou.systems - default Boot from local disk in 30s
 item local       Boot from local disk
 item ocp-add     Boot OCP add-node ISO (installs an OCP worker)


### PR DESCRIPTION
## Summary

Live testing on a pinned host showed that choosing "Boot from local disk" from a per-host pin bounces through the **generic fallback menu.ipxe** — with its 30-second default-timeout menu — before the firmware finally boots the disk.

**Root cause** (verified against the deployed binary's embedded autoexec): the `:tftpmenu` block chains `tftp://${tftp-server}/menu.ipxe` **unconditionally** after the MAC pin returns. A pin's `exit 1` returns control to the autoexec ladder, never straight to firmware — so the fallback menu is always visited on the way out.

**Fix — `pin_local_exit` sentinel pass-through:** iPXE variables persist across chains within a boot session. The paired igou-inventory PR adds `set pin_local_exit 1` before the `exit` in every pin's `:local` label; this PR makes the rendered fallback menu check the sentinel at the very top of `:start`:

```
isset ${pin_local_exit} && echo Pin requested local boot -- passing through to firmware ... && exit 0 ||
```

iPXE flat-evaluation semantics: for unpinned hosts `isset` is false, the `echo`/`exit` are skipped, and the trailing `||` swallows the failure so the script continues to the menu — no behavior change. For a pin that requested local boot, the `echo` runs and `exit 0` terminates this chained script successfully; the binary's autoexec then cascades through its `:menu` retry ladder — each subsequent menu.ipxe fetch hits the same sentinel and exits instantly (sub-second on LAN) — and lands on its `:localboot` exit to firmware. The generic menu never appears.

## Changes

- `playbooks/netboot/templates/menu.ipxe.j2` — sentinel check added as the first line of `:start` (before the `menu` command); header comment block documents the sentinel contract with `netboot_host_pins` in igou-inventory.
- `docs/netboot-operations.md` — new subsection under "Adding a per-host pin" explaining why a pin's local boot transits menu.ipxe at all, and how the sentinel makes it invisible.

## Rollout

Pairs with an igou-inventory PR updating `netboot_host_pins` (the `set pin_local_exit 1` side of the contract). Deploys via `deploy_assets.yml --tags render,push,verify` (the `netboot_deploy_assets` job template) — **no binary rebuild needed**. Merge order does not matter: the sentinel check is a no-op until a pin sets the variable, and a pin setting it before this menu deploys only means the old menu shows once more.

## Validation

- `ansible-lint --profile=production playbooks/netboot/` — clean (0 failures/warnings).
- Template render-tested via `ansible.builtin.template` with both populated and empty `netboot_entries`/`_netboot_fragments`, asserting the sentinel line renders exactly between `:start` and the `menu` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129BBzeQt3MKZLdxGfxnnJD