### PR TITLE
fix(netboot): make netboot deploy job templates runnable green from AAP

### DIFF
--- a/playbooks/netboot/tasks/preflight.yml
+++ b/playbooks/netboot/tasks/preflight.yml
@@ -10,6 +10,11 @@
     timeout: 10
     validate_certs: true
   delegate_to: localhost
+  # become: false on every localhost-delegated task in this playbook: the
+  # play-level become: true is only for the truenas-owned 950 tree, and
+  # the AAP EE has no sudo (job 467) — controller-side tasks never need
+  # privilege.
+  become: false
   changed_when: false
   run_once: true
 
@@ -20,6 +25,7 @@
       - netboot_entries is not string
     fail_msg: "netboot_entries must be a list (got {{ netboot_entries | type_debug }})."
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Preflight — validate each entry
@@ -45,12 +51,14 @@
   loop_control:
     label: "{{ item.id | default('<missing-id>') }}"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Preflight — collect entry ids for cross-reference
   ansible.builtin.set_fact:
     _netboot_entry_ids: "{{ netboot_entries | map(attribute='id') | list }}"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Preflight — validate each host pin (Form 3 fragment only)
@@ -74,6 +82,7 @@
   loop_control:
     label: "{{ item.mac | default('<missing-mac>') }}"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Preflight — verify referenced kickstart files exist locally
@@ -84,6 +93,7 @@
   loop_control:
     label: "{{ item.id }} -> {{ item.kickstart }}"
   delegate_to: localhost
+  become: false
   run_once: true
   failed_when:
     - _ks_check.stat is defined
@@ -96,12 +106,14 @@
     file_type: file
   register: _fragments_find
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Preflight — register fragment filename list
   ansible.builtin.set_fact:
     _netboot_fragments: "{{ _fragments_find.files | map(attribute='path') | map('basename') | sort | list }}"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Preflight — summary
@@ -111,4 +123,5 @@
       - "host pins:  {{ netboot_host_pins | length }}"
       - "fragments:  {{ _netboot_fragments | length }} ({{ _netboot_fragments | join(', ') }})"
   delegate_to: localhost
+  become: false
   run_once: true

--- a/playbooks/netboot/tasks/push_pins_rb5009.yml
+++ b/playbooks/netboot/tasks/push_pins_rb5009.yml
@@ -28,6 +28,10 @@
          | list)
       }}
   delegate_to: localhost
+  # become: false on all localhost-delegated tasks — the AAP EE has no
+  # sudo; controller-side tasks never need privilege. (rb5009-delegated
+  # network_cli tasks are untouched: become works differently there.)
+  become: false
   run_once: true
 
 - name: Push pins — ensure flash subdirectory exists on rb5009
@@ -56,6 +60,7 @@
     label: "{{ item }}"
   register: _pin_local_stat
   delegate_to: localhost
+  become: false
 
 - name: Push pins — assert each expected pin exists locally
   ansible.builtin.assert:
@@ -153,6 +158,7 @@
         | difference(_pin_expected_files)
       }}
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Push pins — remove stale pin files from rb5009 flash
@@ -189,6 +195,7 @@
         | difference(_pin_expected_files)
       }}
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Push pins — remove stale /ip tftp rows

--- a/playbooks/netboot/tasks/push_text.yml
+++ b/playbooks/netboot/tasks/push_text.yml
@@ -33,6 +33,9 @@
     path: "{{ _netboot_cache_dir }}/menu.ipxe"
   register: _netboot_cache_check
   delegate_to: localhost
+  # become: false on all localhost-delegated tasks — the AAP EE has no
+  # sudo; controller-side tasks never need privilege.
+  become: false
   run_once: true
 
 - name: Push — assert render cache is populated
@@ -44,6 +47,7 @@
       with --tags render,push (or no tag filter) so render produces the
       cache before push reads it.
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Push — ensure destination subdirs exist on public host

--- a/playbooks/netboot/tasks/render_menu.yml
+++ b/playbooks/netboot/tasks/render_menu.yml
@@ -7,6 +7,9 @@
   ansible.builtin.set_fact:
     _netboot_cache_dir: "{{ playbook_dir }}/../../.cache/netboot-menus"
   delegate_to: localhost
+  # become: false on all localhost-delegated tasks — the AAP EE has no
+  # sudo; controller-side render work never needs privilege.
+  become: false
   run_once: true
 
 - name: Render — wipe cache to avoid stale outputs
@@ -14,6 +17,7 @@
     path: "{{ _netboot_cache_dir }}"
     state: absent
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Render — recreate cache subdirs
@@ -26,6 +30,7 @@
     - entries
     - per_host
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Render — top-level menu.ipxe
@@ -34,6 +39,7 @@
     dest: "{{ _netboot_cache_dir }}/menu.ipxe"
     mode: "0644"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Render — entries (kernel/local)
@@ -47,6 +53,7 @@
   loop_control:
     label: "{{ item.id }}"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Render — entries (iso)
@@ -60,6 +67,7 @@
   loop_control:
     label: "{{ item.id }}"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Render — entries (chainload)
@@ -73,6 +81,7 @@
   loop_control:
     label: "{{ item.id }}"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Render — host pins (MAC file)
@@ -86,6 +95,7 @@
   loop_control:
     label: "{{ item.mac }}"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Render — host pins (HOSTNAME alias chains to MAC file)
@@ -106,6 +116,7 @@
   loop_control:
     label: "{{ item.hostname }}"
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Render — summary
@@ -115,10 +126,12 @@
     recurse: true
   register: _render_summary
   delegate_to: localhost
+  become: false
   run_once: true
 
 - name: Render — list rendered files
   ansible.builtin.debug:
     msg: "{{ _render_summary.files | map(attribute='path') | map('regex_replace', '^.*/.cache/netboot-menus/', '') | sort | list }}"
   delegate_to: localhost
+  become: false
   run_once: true

--- a/playbooks/netboot/tasks/verify.yml
+++ b/playbooks/netboot/tasks/verify.yml
@@ -12,6 +12,9 @@
     timeout: 10
     validate_certs: true
   delegate_to: localhost
+  # become: false on all localhost-delegated tasks — the AAP EE has no
+  # sudo; controller-side HTTPS probes never need privilege.
+  become: false
   run_once: true
   changed_when: false
 
@@ -22,6 +25,7 @@
     timeout: 10
     validate_certs: true
   delegate_to: localhost
+  become: false
   loop: "{{ netboot_entries | default([]) }}"
   loop_control:
     label: "{{ item.id }}"
@@ -106,6 +110,7 @@
     status_code: [200, 206, 302]
     timeout: 15
   delegate_to: localhost
+  become: false
   loop: "{{ netboot_entries | default([]) | selectattr('kind', 'equalto', 'iso') | list }}"
   loop_control:
     label: "{{ item.id }}"

--- a/playbooks/routeros/tasks/netboot_verify.yml
+++ b/playbooks/routeros/tasks/netboot_verify.yml
@@ -3,8 +3,9 @@
 #   1. Fetch each binary from rb5009 over TFTP (sha256 compare against
 #      the controller build cache). Runs from the builder host — see
 #      the comment block above the fetch tasks for why.
-#   2. Fetch menu.ipxe from the TrueNAS netbootxyz container over TFTP
-#      and assert it begins with #!ipxe (chainload target alive).
+#   2. Fetch menu.ipxe from the chainload host over HTTPS — the
+#      binaries' actual fallback transport — and assert it begins with
+#      #!ipxe (chainload target alive).
 #   3. Read /ip dhcp-server network and matcher rows, assert that
 #      next-server, boot-file-name, and the expected matchers exist.
 
@@ -160,40 +161,38 @@
       doesn't chain to tftp://{{ netboot_chainload_host }}/menu.ipxe.
       Re-run --tags upload to refresh the redirect file.
 
-- name: Fetch menu.ipxe from TrueNAS netbootxyz over TFTP (from the builder)
-  # netboot_chainload_host may carry a path prefix ("host/prefix");
-  # tftp_get.py splits it and prepends the prefix to the filename,
-  # matching curl's tftp://host/prefix/menu.ipxe semantics.
-  ansible.builtin.script:
-    cmd: >-
-      {{ playbook_dir }}/files/tftp_get.py
-      {{ netboot_chainload_host }}
-      menu.ipxe
-      {{ _netboot_verify_dir }}/menu.ipxe
-  delegate_to: "{{ _netboot_verify_host }}"
-  vars:
-    ansible_connection: ssh
-  changed_when: false
+# Probe the chainload menu the way the binaries actually fetch it:
+# over HTTPS from the public nginx. The old check here TFTP-fetched
+# menu.ipxe from the TrueNAS netbootxyz container, but that container
+# was retired 2026-05-11 (assets moved to public.igou.systems, which
+# serves HTTP/HTTPS only — no TFTP listener), so the check probed a
+# dead service the boot chain no longer touches. The embedded autoexec
+# falls back to ${conn_type}://${boot_domain}/menu.ipxe, so an HTTPS
+# probe from the controller is the faithful e2e check (and works from
+# the AAP EE, unlike TFTP).
 
-- name: Read fetched menu.ipxe
-  # slurp instead of `head -c 32` via command: the command module does
-  # not shell-expand the ~ in the default scratch dir; slurp's path
-  # argument does. menu.ipxe is a few KB, so whole-file slurp is fine.
-  ansible.builtin.slurp:
-    src: "{{ _netboot_verify_dir }}/menu.ipxe"
-  delegate_to: "{{ _netboot_verify_host }}"
-  vars:
-    ansible_connection: ssh
-  register: _netboot_menu_slurp
+- name: Fetch menu.ipxe from the chainload host over HTTPS
+  ansible.builtin.uri:
+    url: "{{ netboot_chainload_proto }}://{{ netboot_chainload_host }}/menu.ipxe"
+    status_code: 200
+    timeout: 10
+    validate_certs: true
+    return_content: true
+  delegate_to: localhost
+  become: false
+  changed_when: false
+  register: _netboot_menu_probe
 
 - name: Assert menu.ipxe begins with the iPXE shebang
   ansible.builtin.assert:
     that:
-      - "'#!ipxe' in (_netboot_menu_slurp.content | b64decode)[:32]"
+      - "'#!ipxe' in (_netboot_menu_probe.content | default(''))[:32]"
     fail_msg: >-
-      Fetched {{ netboot_chainload_host }}/menu.ipxe but it does not
-      begin with #!ipxe. The TrueNAS netbootxyz container is likely
-      down or its dnsmasq is not serving menu.ipxe.
+      Fetched
+      {{ netboot_chainload_proto }}://{{ netboot_chainload_host }}/menu.ipxe
+      but it does not begin with #!ipxe. The public nginx is likely
+      serving the wrong file at /boot-files/menu.ipxe — re-run
+      playbooks/netboot/deploy_assets.yml --tags render,push.
 
 - name: Read DHCP network rows for assertion
   community.routeros.command:


### PR DESCRIPTION
## Summary

Two independent AAP-blocker fixes for the netboot playbooks, batched into one merge. Both are the last known failures of their respective job templates.

## Commit 1 — `deploy_assets` localhost-delegated tasks must not become (EE has no sudo)

**Evidence:** first-ever AAP execution of the pre-existing `netboot_deploy_assets` JT (job 467) failed at the very first task: `/bin/sh: line 1: sudo: command not found` at `preflight.yml:6`.

**Root cause:** `playbooks/netboot/deploy_assets.yml` sets play-level `become: true` — legitimately needed for the truenas-host file tasks that chown to uid 950 — and `delegate_to: localhost` tasks inherit it. The igou-awx-ee container has no sudo. Latent until now because this playbook had only ever run from the devcontainer, where sudo exists.

**Fix:** explicit `become: false` on every localhost-delegated task under `playbooks/netboot/tasks/` — 29 tasks total (preflight 9, render_menu 11, push_text 2, push_pins_rb5009 4, verify 3), with an explanatory comment at the first occurrence per file. Deliberately untouched:
- tasks running on the truenas host (no `delegate_to`) keep inherited become — they need root for the 950-owned tree;
- rb5009-delegated `community.routeros.command` / `net_put` tasks — become is not applied the same way over network_cli and they demonstrably work;
- `fetch_binaries.yml` / `push_local_artifacts.yml` contain no localhost delegations; `deploy_assets.yml` has no inline localhost tasks.

Grep-verified: every `delegate_to: localhost` in `playbooks/netboot/` is now paired with `become: false`.

## Commit 2 — verify chainload menu over HTTPS, drop retired TrueNAS TFTP check

**Evidence:** JT 83 (`netboot_deploy_binaries`, post-#395): the builder-host TFTP verify works — all three binaries fetched in ~2 s and sha256-asserted green, rb5009 menu.ipxe redirect check green. The sole remaining failure was the final task in `playbooks/routeros/tasks/netboot_verify.yml`, which TFTP-fetched menu.ipxe from the TrueNAS netbootxyz container.

**Root cause:** that container was retired 2026-05-11 (assets moved to the public nginx, which serves HTTP/HTTPS only — no TFTP listener). The check probed a dead service that nothing in the current boot chain touches: the binaries' embedded autoexec falls back to `${conn_type}://${boot_domain}/menu.ipxe` over HTTPS.

**Fix:** replace the TFTP fetch + builder-side slurp/assert with a controller-side `ansible.builtin.uri` probe of `{{ netboot_chainload_proto }}://{{ netboot_chainload_host }}/menu.ipxe` (status 200, `return_content: true`, assert body begins with `#!ipxe`) — the faithful e2e check of the real fallback transport, and one that works from the AAP EE.

## Validation

- `ansible-lint --profile=production playbooks/routeros/ playbooks/netboot/` — clean (0 failures/warnings, 43 files).
- `yamllint` both trees — clean.
- `--syntax-check` on both `deploy_assets.yml` and `deploy_netboot_binaries.yml` — passes.
- Grep audit: all 29 `delegate_to: localhost` tasks paired with `become: false`.
- Live probe of the replacement check: `https://public.igou.systems/boot-files/menu.ipxe` returns 200 with a `#!ipxe` body.

After merge, both `netboot_deploy_assets` and `netboot_deploy_binaries` job templates should run green end-to-end from AAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129BBzeQt3MKZLdxGfxnnJD