### PR TITLE
fix(devenv): reset connection after docker group grant

### DIFF
--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -168,6 +168,15 @@
         node_exporter_web_listen_address: "{{ node_exporter_listen_address | default('0.0.0.0:9100') }}"
 
   post_tasks:
+    - name: Reset the connection so the docker group grant takes effect
+      # Group membership is evaluated at login; the ControlPersist session was
+      # opened before the docker role added the user to the docker group, so
+      # the unprivileged `devcontainer up` below would hit docker.sock EACCES
+      # on a fresh host's first bootstrap (AAP job 482). meta doesn't support
+      # `when`, so this runs unconditionally — a harmless reconnect on
+      # already-bootstrapped hosts.
+      ansible.builtin.meta: reset_connection
+
     # ------------------------------------------------------------------
     # Set the operator's global git identity on the host user's ~/.gitconfig.
     # The david_igou.devhost.host_prep role is intentionally NOT in this play's


### PR DESCRIPTION
## Problem

AAP job 482 (first bootstrap of the fresh `vscode` host) failed at the unprivileged post_task **"Launch the devcontainer from the pinned release image"** with an opaque devcontainer CLI error:

```
Command failed: docker ps -q -a --filter ...
```

The underlying cause is docker.sock EACCES:

- The `david_igou.devhost.docker` role adds the `igou` user to the `docker` group **mid-play**.
- Unix group membership is evaluated at login, and the SSH ControlPersist session was opened **before** the grant.
- Every subsequent unprivileged task therefore still runs without the `docker` group, so `devcontainer up` (which shells out to `docker ps`) gets permission denied on `/var/run/docker.sock`.

Already-bootstrapped hosts mask the bug: the membership predates the connection, so re-runs (and a plain re-run of job 482's template) succeed. This makes the fix durable rather than "just re-run it".

## Fix

Add an unconditional `ansible.builtin.meta: reset_connection` at the very top of `post_tasks` in `playbooks/devenv/bootstrap.yml` — right after the play-level `roles:` (where the docker role runs) and before any unprivileged docker use. The re-opened SSH session picks up the new group membership.

`meta: reset_connection` doesn't support `when`/loops, so it runs unconditionally; on already-bootstrapped hosts it's just a harmless reconnect.

## Validation

- `ansible-lint playbooks/devenv/bootstrap.yml` — passed (production profile, 0 failures/warnings)
- `ansible-playbook --syntax-check` fails only on the missing `david_igou.devhost` collection in the local checkout (environment-only; no galaxy install in the worktree) — YAML parse verified clean separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129BBzeQt3MKZLdxGfxnnJD