### PR TITLE
feat(devenv): codify T3 Code firewalld port + Tailscale Serve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Built with `ansible-builder`, defined in `execution-environments/`. Each has `ex
 
 ### Roles
 
-Mix of community galaxy roles (pinned versions in `requirements.yml`) and custom roles in `roles/`: `alloy`, `kubevirt_vm_provision`, `kubevirt_vm_snapshot`, `rpi_boot_render`, `rpi_eeprom`, `rpi_rootfs`, `windows_computer_use`, `windows_debloat`, `windows_desktop_apps`, `windows_power`, `zfs_pool`.
+Mix of community galaxy roles (pinned versions in `requirements.yml`) and custom roles in `roles/`: `alloy`, `kubevirt_vm_provision`, `kubevirt_vm_snapshot`, `rpi_boot_render`, `rpi_eeprom`, `rpi_rootfs`, `tailscale_serve`, `windows_computer_use`, `windows_debloat`, `windows_desktop_apps`, `windows_power`, `zfs_pool`.
 
 **Roles are pure functions.** A role is pure over its declared inputs, with
 `meta/argument_specs.yml` as its signature. Do **not** put secret lookups

--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -153,7 +153,10 @@
     - name: Open the devenv service ports in firewalld
       # 8080: code-server (post-start in the devcontainer, host network,
       #       password auth + self-signed TLS). 9100: node_exporter (role
-      #       below), scraped by UWM/Prometheus.
+      #       below), scraped by UWM/Prometheus. 3773: T3 Code (t3 serve in
+      #       the devcontainer post-start, host network, plain HTTP on the
+      #       LAN — pairing-token auth; tailnet clients use the Tailscale
+      #       Serve HTTPS proxy configured at the end of this playbook).
       become: true
       ansible.posix.firewalld:
         port: "{{ item }}"
@@ -161,6 +164,7 @@
         immediate: true
         state: enabled
       loop:
+        - 3773/tcp
         - 8080/tcp
         - 9100/tcp
       when:

--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -626,3 +626,36 @@
   ansible.builtin.import_playbook: ../tailscale/tailscale.yml
   vars:
     tailscale_authkey: "{{ lookup('community.general.onepassword', 'tailscale-oauth-pettingzoo', field='token', vault='lab_external_api_keys') }}"
+
+# ---------------------------------------------------------------------------
+# Tailscale Serve: terminate tailnet HTTPS for T3 Code. The t3 desktop app
+# requires TLS and `t3 serve` has no native cert support, so tailscaled
+# proxies https://<magicdns-name>/ (tailnet only, auto-provisioned cert) to
+# the plain-HTTP t3 listener on 127.0.0.1:{{ tailscale_serve_port }}.
+# Gated on tailscale_serve_port (group_vars/devenv/tailscale.yml); skips
+# hosts without it. Adoptive: re-running against an already-configured host
+# reports ok. Requires the tailnet HTTPS-certificates feature (enabled
+# 2026-08-02). Manual rollback: `tailscale serve --https=443 off`.
+# ---------------------------------------------------------------------------
+- name: Configure Tailscale Serve for devenv services
+  hosts: "{{ ansible_limit | default('devenv') }}"
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Read current tailscale serve config
+      ansible.builtin.command: tailscale serve status --json
+      register: devenv_tailscale_serve_status
+      changed_when: false
+      failed_when: false
+      when: tailscale_serve_port is defined
+
+    - name: Serve tailnet HTTPS 443 to the local T3 Code port
+      ansible.builtin.command: >-
+        tailscale serve --bg {{ tailscale_serve_port }}
+      when:
+        - tailscale_serve_port is defined
+        - devenv_tailscale_serve_status.rc == 0
+        - ('127.0.0.1:' ~ tailscale_serve_port) not in
+          (devenv_tailscale_serve_status.stdout | default(''))
+      changed_when: true

--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -632,10 +632,17 @@
 # requires TLS and `t3 serve` has no native cert support, so tailscaled
 # proxies https://<magicdns-name>/ (tailnet only, auto-provisioned cert) to
 # the plain-HTTP t3 listener on 127.0.0.1:{{ tailscale_serve_port }}.
-# Gated on tailscale_serve_port (group_vars/devenv/tailscale.yml); skips
-# hosts without it. Adoptive: re-running against an already-configured host
-# reports ok. Requires the tailnet HTTPS-certificates feature (enabled
-# 2026-08-02). Manual rollback: `tailscale serve --https=443 off`.
+#
+# The work lives in the local roles/tailscale_serve role, NOT in the
+# artis3n.tailscale collection that owns the join above: that collection has no
+# serve capability at all (checked v1.2.1, latest, 2026-08-02). Ordering
+# matters — serve needs the tailscaled the play above joined.
+#
+# Gated on tailscale_serve_port (group_vars/devenv/tailscale.yml); the role is
+# a clean no-op on hosts without it, which is why it has no default. Adoptive:
+# re-running against an already-configured host reports ok. Requires the
+# tailnet HTTPS-certificates feature (enabled 2026-08-02). Manual rollback:
+# `tailscale serve --https=443 off`.
 # ---------------------------------------------------------------------------
 - name: Configure Tailscale Serve for devenv services
   hosts: "{{ ansible_limit | default('devenv') }}"
@@ -643,19 +650,6 @@
   gather_facts: false
 
   tasks:
-    - name: Read current tailscale serve config
-      ansible.builtin.command: tailscale serve status --json
-      register: devenv_tailscale_serve_status
-      changed_when: false
-      failed_when: false
-      when: tailscale_serve_port is defined
-
-    - name: Serve tailnet HTTPS 443 to the local T3 Code port
-      ansible.builtin.command: >-
-        tailscale serve --bg {{ tailscale_serve_port }}
-      when:
-        - tailscale_serve_port is defined
-        - devenv_tailscale_serve_status.rc == 0
-        - ('127.0.0.1:' ~ tailscale_serve_port) not in
-          (devenv_tailscale_serve_status.stdout | default(''))
-      changed_when: true
+    - name: Configure Tailscale Serve
+      ansible.builtin.include_role:
+        name: tailscale_serve

--- a/roles/tailscale_serve/README.md
+++ b/roles/tailscale_serve/README.md
@@ -1,0 +1,58 @@
+# tailscale_serve
+
+Configure [Tailscale Serve](https://tailscale.com/kb/1242/tailscale-serve) on a
+host that is **already joined to the tailnet**, so `tailscaled` terminates
+tailnet HTTPS on `:443` (auto-provisioned cert, reachable only from the tailnet)
+and proxies to a plain-HTTP listener on `127.0.0.1:<port>`.
+
+Written for T3 Code on the devenv host: the t3 desktop app requires TLS and
+`t3 serve` has no native cert support, so tailscaled does the termination.
+
+Exists as a local role because `artis3n.tailscale` — the collection that owns
+the tailnet join in `playbooks/tailscale/tailscale.yml` — has no serve
+capability at v1.2.1 (checked 2026-08-02, latest release).
+
+## Requirements
+
+- The host is already joined to the tailnet and `tailscaled` is running (run
+  this **after** `playbooks/tailscale/tailscale.yml`).
+- The tailnet has the HTTPS-certificates feature enabled.
+- Root on the target (the caller supplies `become`).
+
+## Role variables
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `tailscale_serve_port` | *(none — intentionally undefined)* | Local plain-HTTP port to proxy `https://<magicdns-name>/` to. **When undefined the role does nothing at all.** |
+
+`tailscale_serve_port` is deliberately **not** defaulted in
+`defaults/main.yml`. The undefined-variable no-op is the role's contract: hosts
+that do not set it (molecule containers, any devenv host without a served
+service) skip both tasks. It is supplied from inventory, in igou-inventory
+`group_vars/devenv/tailscale.yml`.
+
+## Behavior
+
+| Situation | Result |
+|---|---|
+| `tailscale_serve_port` undefined | both tasks skip, no failure |
+| defined, but tailscaled down/absent | status read reports ok (`failed_when: false`), apply skips — no failure |
+| defined, no existing proxy to that port | `tailscale serve --bg <port>` runs, reports **changed** |
+| defined, proxy to that port already present | apply skips, reports ok — **adoptive/idempotent** |
+
+Manual rollback on the host: `tailscale serve --https=443 off`.
+
+## Example
+
+```yaml
+- name: Configure Tailscale Serve for devenv services
+  hosts: "{{ ansible_limit | default('devenv') }}"
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Configure Tailscale Serve
+      ansible.builtin.include_role:
+        name: tailscale_serve
+```
+
+Used by `playbooks/devenv/bootstrap.yml` (final play, after the tailnet join).

--- a/roles/tailscale_serve/defaults/main.yml
+++ b/roles/tailscale_serve/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# defaults file for tailscale_serve
+
+# Required from caller — DELIBERATELY NOT DEFAULTED HERE:
+#   tailscale_serve_port
+#
+# The whole no-op contract of this role is "undefined means do nothing".
+# Defining a default (even a falsy one) would break that: the role's tasks
+# gate on `tailscale_serve_port is defined`, so a default would make every
+# devenv host — including molecule containers with no tailscaled — attempt a
+# serve configuration. The variable comes from inventory
+# (igou-inventory group_vars/devenv/tailscale.yml); hosts that do not set it
+# skip both tasks cleanly.

--- a/roles/tailscale_serve/meta/argument_specs.yml
+++ b/roles/tailscale_serve/meta/argument_specs.yml
@@ -1,0 +1,26 @@
+---
+argument_specs:
+  main:
+    short_description: "Configure Tailscale Serve on an already-joined tailnet node."
+    description:
+      - >-
+        Points tailnet HTTPS :443 at a plain-HTTP listener on 127.0.0.1, so
+        tailscaled terminates TLS with an auto-provisioned cert for services
+        (T3 Code) that cannot do it themselves. Must run AFTER the tailnet
+        join (playbooks/tailscale/tailscale.yml) — it needs a live tailscaled.
+      - >-
+        Adoptive and idempotent: the applied state is detected by matching
+        127.0.0.1:<port> in `tailscale serve status --json`, so re-running
+        against an already-configured host reports ok. If tailscaled is down
+        or absent the status read fails soft and the apply skips, so the role
+        never fails a host without a live tailnet.
+    options:
+      tailscale_serve_port:
+        type: int
+        required: false
+        description: >-
+          Local plain-HTTP port to proxy https://<magicdns-name>/ to.
+          DELIBERATELY has no default — when it is undefined the role does
+          nothing at all, which is the contract that lets it run against every
+          devenv host (and molecule containers) unconditionally. Supplied from
+          inventory, igou-inventory group_vars/devenv/tailscale.yml.

--- a/roles/tailscale_serve/meta/main.yml
+++ b/roles/tailscale_serve/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  role_name: tailscale_serve
+  author: david-igou
+  description: >-
+    Configure Tailscale Serve on an already-joined tailnet node so tailscaled
+    terminates tailnet HTTPS on :443 and proxies to a plain-HTTP listener on
+    127.0.0.1. Exists because artis3n.tailscale (v1.2.1, the collection that
+    owns the tailnet join) has no serve capability at all. Tiny single-concern
+    role; adoptive and a clean no-op when tailscale_serve_port is undefined.
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: EL
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - tailscale
+    - serve
+    - https
+dependencies: []

--- a/roles/tailscale_serve/tasks/main.yml
+++ b/roles/tailscale_serve/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# tasks file for tailscale_serve
+
+# `failed_when: false` on the read: if tailscaled is down or absent (e.g. a
+# molecule container), rc != 0 and the apply task's `rc == 0` guard skips it —
+# the role never fails on hosts without a live tailnet.
+- name: Read current tailscale serve config
+  ansible.builtin.command: tailscale serve status --json
+  register: tailscale_serve_status
+  changed_when: false
+  failed_when: false
+  when: tailscale_serve_port is defined
+
+# Idempotency/adoption check: a substring match on the JSON serve config. An
+# existing proxy to 127.0.0.1:<port> appears verbatim in
+# `tailscale serve status --json` output, so a re-run against an
+# already-configured host reports ok instead of changed.
+- name: Serve tailnet HTTPS 443 to the local T3 Code port
+  ansible.builtin.command: >-
+    tailscale serve --bg {{ tailscale_serve_port }}
+  when:
+    - tailscale_serve_port is defined
+    - tailscale_serve_status.rc == 0
+    - ('127.0.0.1:' ~ tailscale_serve_port) not in
+      (tailscale_serve_status.stdout | default(''))
+  changed_when: true


### PR DESCRIPTION
Codifies the 2026-08-02 manual host changes on vscode.igou.systems: 3773/tcp in the devenv firewalld loop, and an adoptive Tailscale Serve play (443 -> 127.0.0.1:{{ tailscale_serve_port }}) appended after the tailnet join. Pairs with the igou-inventory PR adding tailscale_serve_port. Refs igou-io/igou-inventory#276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)