### PR TITLE
chore(devenv): adopt igou-devenv release v2026.08.02

### DIFF
--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -51,10 +51,12 @@
     # Pinned to the igou-devenv release cut for this rebuild (git tag +
     # container image promoted by digest from the tested :latest). Bump both
     # together when adopting a newer release.
-    # v2026.07.12-2 carries the post-create guard that lets the VM's
-    # read-only file-based ghapp config mount win over the op-based seed.
-    devenv_repo_version: v2026.07.12-2
-    devenv_image: ghcr.io/igou-io/igou-devenv:2026.07.12-2
+    # v2026.08.02 carries the always-on T3 Code service (t3 serve on
+    # 0.0.0.0:3773 with persistent ~/.t3 pairing state, fronted on the
+    # tailnet by the tailscale_serve role below) plus the ghapp post-create
+    # guard from v2026.07.12-2.
+    devenv_repo_version: v2026.08.02
+    devenv_image: ghcr.io/igou-io/igou-devenv:2026.08.02
     devenv_launch_devcontainer: true
 
     # GitHub App runtime tokens (ghapp, local-mint mode). ON by default so the


### PR DESCRIPTION
Bumps devenv_repo_version + devenv_image from v2026.07.12-2 to v2026.08.02 (T3 Code always-on service, gws CLI, node 26.4.0, opencode 1.18.10, tkn-pac 0.49.0, argocd 3.4.5). Pairs with the tailscale_serve role + 3773/tcp firewalld rule from #486 so the AAP-deployed container actually runs the service those rules front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)