### PR TITLE
chore(devenv): adopt igou-devenv release v2026.08.02-2

### DIFF
--- a/playbooks/devenv/bootstrap.yml
+++ b/playbooks/devenv/bootstrap.yml
@@ -51,12 +51,13 @@
     # Pinned to the igou-devenv release cut for this rebuild (git tag +
     # container image promoted by digest from the tested :latest). Bump both
     # together when adopting a newer release.
-    # v2026.08.02 carries the always-on T3 Code service (t3 serve on
+    # v2026.08.02-2 carries the always-on T3 Code service (t3 serve on
     # 0.0.0.0:3773 with persistent ~/.t3 pairing state, fronted on the
-    # tailnet by the tailscale_serve role below) plus the ghapp post-create
-    # guard from v2026.07.12-2.
-    devenv_repo_version: v2026.08.02
-    devenv_image: ghcr.io/igou-io/igou-devenv:2026.08.02
+    # tailnet by the tailscale_serve role below), with post-start hardened
+    # against the postStart exec teardown race that reaped freshly-forked
+    # services, plus the ghapp post-create guard from v2026.07.12-2.
+    devenv_repo_version: v2026.08.02-2
+    devenv_image: ghcr.io/igou-io/igou-devenv:2026.08.02-2
     devenv_launch_devcontainer: true
 
     # GitHub App runtime tokens (ghapp, local-mint mode). ON by default so the


### PR DESCRIPTION
v2026.08.02-2 = v2026.08.02 + the postStart teardown-race fix (igou-io/igou-devenv#183): t3 serve was reaped ~8ms after fork on every unattended bootstrap. With this pin, the AAP-deployed container brings T3 Code up reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)